### PR TITLE
Corrected default annotationStyle to be jackson2

### DIFF
--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -196,7 +196,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      *            default-value="jackson2"
      * @since 0.3.1
      */
-    private String annotationStyle = "jackson";
+    private String annotationStyle = "jackson2";
 
     /**
      * A fully qualified class name, referring to a custom annotator class that


### PR DESCRIPTION
The documentation had default-value="jackson2", but the actual value of annotationStyle was "jackson".
