### PR TITLE
Fix name normalization (issue #126)

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -218,8 +218,8 @@ public class EnumRule implements Rule<JClassContainer, JType> {
     }
 
     private String getEnumName(String nodeName) {
-        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(capitalize(nodeName));
-        return ruleFactory.getNameHelper().normalizeName(className);
+        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(nodeName);
+        return ruleFactory.getNameHelper().normalizeName(className, true);
     }
 
     private String getConstantName(String nodeName) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
@@ -37,12 +37,18 @@ public class NameHelper {
         return name.replaceAll(ILLEGAL_CHARACTER_REGEX, "_");
     }
 
-    public String normalizeName(String name) {
+    public String normalizeName(String name, boolean isClass) {
         name = capitalizeTrailingWords(name);
 
         if (isDigit(name.charAt(0))) {
             name = "_" + name;
         }
+
+        // Class names should start with uppercase letters,
+        // while property names should start with lovercase (see issue #129)
+        name = 
+        		(isClass ? toUpperCase(name.charAt(0)) : toLowerCase(name.charAt(0))) 
+        		+ (name.length() > 1 ? name.substring(1) : "");
 
         return name;
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -238,8 +238,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
     }
 
     private String getClassName(String nodeName, JPackage _package) {
-        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(capitalize(nodeName));
-        String normalizedName = ruleFactory.getNameHelper().normalizeName(className);
+        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(nodeName);
+        String normalizedName = ruleFactory.getNameHelper().normalizeName(className, true);
         return makeUnique(normalizedName, _package);
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -177,7 +177,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
     private String getPropertyName(String nodeName) {
         nodeName = ruleFactory.getNameHelper().replaceIllegalCharacters(nodeName);
-        nodeName = ruleFactory.getNameHelper().normalizeName(nodeName);
+        nodeName = ruleFactory.getNameHelper().normalizeName(nodeName, false);
 
         if (isKeyword(nodeName)) {
             nodeName = "_" + nodeName;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -150,6 +150,15 @@ public class EnumIT {
     }
 
     @Test
+    public void enumWithUppercaseProperty() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumWithUppercaseProperty.json", "com.example");
+
+        resultsClassLoader.loadClass("com.example.EnumWithUppercaseProperty");
+        resultsClassLoader.loadClass("com.example.EnumWithUppercaseProperty$TimeFormat");
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void jacksonCanMarshalEnums() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException, IOException {
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumWithUppercaseProperty.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumWithUppercaseProperty.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "TimeFormat" : {
+            "enum" : ["12h", "24h"]
+        }
+    }
+}


### PR DESCRIPTION
Name normalization should differentiate between class names and property
names to avoid name collisions and resulted compilation errors
