### PR TITLE
Added support for 'sources' construct, so multiple target packages generated.

### DIFF
--- a/jsonschema2pojo-maven-plugin/pom.xml
+++ b/jsonschema2pojo-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.3</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -87,6 +88,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.1.0
      */
     private String targetPackage = "";
+
+    /**
+     * List of sources (targetPackage + sourcePaths) to support generating
+     * source in multiple packages.
+     * 
+     * @parameter
+     * @since 0.4.0
+     */
+    private List<Source> sources;
 
     /**
      * Whether to generate builder-style methods of the form
@@ -321,8 +331,8 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
             return;
         }
 
-        if (null == sourceDirectory && null == sourcePaths) {
-            throw new MojoExecutionException("One of sourceDirectory or sourcePaths must be provided");
+        if (null == sourceDirectory && null == sourcePaths && (null == sources || sources.isEmpty())) {
+            throw new MojoExecutionException("One of sourceDirectory, sourcePaths, or sources must be provided");
         }
 
         if (addCompileSourceRoot) {
@@ -332,7 +342,14 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         addProjectDependenciesToClasspath();
 
         try {
-            Jsonschema2Pojo.generate(this);
+            if (null != sources && !sources.isEmpty()) {
+                for (Source source : sources) {
+                    source.setParentConfig(this);
+                    Jsonschema2Pojo.generate(source);
+                }
+            } else {
+                Jsonschema2Pojo.generate(this);
+            }
         } catch (IOException e) {
             throw new MojoExecutionException(
                     "Error generating classes from JSON Schema file(s) " + sourceDirectory.getPath(), e);

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Source.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Source.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright © 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.maven;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jsonschema2pojo.AnnotationStyle;
+import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.SourceType;
+
+public class Source implements GenerationConfig {
+    /**
+     * Most configuration happens on the Mojo.  This allows the object to be used by itself without managing all attributes.
+     */
+    private GenerationConfig parentConfig;
+
+    /**
+     * The target package for the given source paths.
+     */
+    private String targetPackage;
+
+    /**
+     * List of source paths to generate source for.
+     */
+    private List<File> sourcePaths;
+
+    /**
+     * Implemented as an "add" because Mojo will call it for each sourcePath element in the plugin configuration.
+     * @param sourcePath
+     */
+    public void setSourcePath(File sourcePath) {
+        if (sourcePaths == null) {
+            sourcePaths = new LinkedList<File>();
+        }
+        sourcePaths.add(sourcePath);
+    }
+
+    public List<File> getSourcePaths() {
+        return sourcePaths;
+    }
+
+    public void setSourcePaths(List<File> sourcePaths) {
+        this.sourcePaths = sourcePaths;
+    }
+
+    public void setTargetPackage(String targetPackage) {
+        this.targetPackage = targetPackage;
+    }
+
+    /**
+     * Before using this object as GenerationConfig, another "parent" object (Jsonschema2PojoMojo) needs to be set.
+     * @param parentConfig
+     */
+    public void setParentConfig(GenerationConfig parentConfig) {
+        this.parentConfig = parentConfig;
+    }
+
+    public GenerationConfig getParentConfig() {
+        return parentConfig;
+    }
+
+    @Override
+    public AnnotationStyle getAnnotationStyle() {
+        return parentConfig.getAnnotationStyle();
+    }
+
+    @Override
+    public Class<? extends Annotator> getCustomAnnotator() {
+        return parentConfig.getCustomAnnotator();
+    }
+
+    @Override
+    public String getOutputEncoding() {
+        return parentConfig.getOutputEncoding();
+    }
+
+    @Override
+    public char[] getPropertyWordDelimiters() {
+        return parentConfig.getPropertyWordDelimiters();
+    }
+
+    @Override
+    public Iterator<File> getSource() {
+        return this.sourcePaths.iterator();
+    }
+
+    @Override
+    public SourceType getSourceType() {
+        return parentConfig.getSourceType();
+    }
+
+    @Override
+    public File getTargetDirectory() {
+        return parentConfig.getTargetDirectory();
+    }
+
+    /**
+     * If target package is not set locally, use the value from the parent config.
+     */
+    @Override
+    public String getTargetPackage() {
+        if (this.targetPackage != null) {
+            return this.targetPackage;
+        } else {
+            return parentConfig.getTargetPackage();
+        }
+    }
+
+    @Override
+    public boolean isGenerateBuilders() {
+        return parentConfig.isGenerateBuilders();
+    }
+
+    @Override
+    public boolean isIncludeHashcodeAndEquals() {
+        return parentConfig.isIncludeHashcodeAndEquals();
+    }
+
+    @Override
+    public boolean isIncludeJsr303Annotations() {
+        return parentConfig.isIncludeJsr303Annotations();
+    }
+
+    @Override
+    public boolean isIncludeToString() {
+        return parentConfig.isIncludeToString();
+    }
+
+    @Override
+    public boolean isRemoveOldOutput() {
+        return parentConfig.isRemoveOldOutput();
+    }
+
+    @Override
+    public boolean isUseJodaDates() {
+        return parentConfig.isUseJodaDates();
+    }
+
+    @Override
+    public boolean isUseLongIntegers() {
+        return parentConfig.isUseLongIntegers();
+    }
+
+    @Override
+    public boolean isUsePrimitives() {
+        return parentConfig.isUsePrimitives();
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/test/resources/example/pom.xml
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/example/pom.xml
@@ -24,6 +24,12 @@
                     <targetPackage>com.example.types</targetPackage>
                     <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
                     <includeToString>false</includeToString>
+                    <sources>
+                        <source>
+                            <targetPackage>com.exmaple.types</targetPackage>
+                            <sourcePath>${basedir}/schema</sourcePath>
+                        </source>
+                    </sources>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
The project I am working on has lots of json schemas and I wanted the generated source to land in many packages to help organize things.  This change adds support for a configuration construct called "sources" to support this.  Example configuration has been added to the test pom.xml.