### PR TITLE
Schema Discovery

### DIFF
--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/PackageMapper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/PackageMapper.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright © 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import static org.apache.commons.io.FilenameUtils.*;
+import static org.apache.commons.io.FileUtils.*;
+
+/**
+ * Maps files to package names.
+ * 
+ * @author Christian Trimble
+ *
+ */
+public class PackageMapper {
+    private SortedSet<PackageMapping> packageMappings = new TreeSet<PackageMapping>();
+    
+    public PackageMapper withPackageMapping( File source, String packageName ) throws IOException {
+        packageMappings.add(
+          (source.isDirectory()?new DirectoryPackageMapping():new FilePackageMapping())
+          .withSource(source)
+          .withPackageName(packageName));
+        
+        return this;
+    }
+    
+    public String map( URI systemId ) throws IOException {
+        return map(systemId.normalize().toString());
+    }
+    
+  public String map( File file ) throws IOException {
+      if( !file.exists() ) { return ""; }
+      
+      return map(file.getCanonicalFile().toURI().toString());
+  }
+  
+  public String map( String systemId ) throws IOException {
+      for( PackageMapping packageMapping : packageMappings ) {
+          if( packageMapping.appliesTo(systemId) ) {
+              return packageMapping.map(systemId);
+          }
+      }
+      return "";      
+  }
+  
+  public String packageNameForSchemaPath( String basePackage, String path ) {
+      String[] segments = getFullPathNoEndSeparator(normalize(path))
+        .split(Pattern.quote(File.separator));
+      
+      StringBuilder sb = new StringBuilder();
+      if( basePackage != null && !"".equals(basePackage) ) {
+          sb.append(basePackage);
+      }
+      for( String segment : segments ) {
+          if( !segment.equals("") ) {
+            sb.append(".").append(replaceIllegalCharacters(segment));
+          }
+      }
+      return sb.toString();
+  }
+  
+  public static String relativePath( String parentPath, String childPath ) {
+      return childPath.substring(parentPath.length());
+  }
+  
+  private static final String ILLEGAL_CHARACTER_REGEX = "[^0-9a-zA-Z_$]";
+
+  public static String replaceIllegalCharacters(String name) {
+      return name.replaceAll(ILLEGAL_CHARACTER_REGEX, "_");
+  }
+    
+    public abstract class PackageMapping implements Comparable<PackageMapping> {
+        String source;
+        String packageName;
+        
+        public PackageMapping withSource( File source ) throws IOException {
+            this.source = source.getCanonicalFile().toURI().toString().replaceAll("/$", "");
+            if( source.isDirectory() ) {
+                this.source = this.source+"/";
+            }
+            return this;
+        }
+        
+        public PackageMapping withSource( URI source ) throws IOException {
+            URI normalized = source.normalize();
+            try {
+                normalized = new URI(normalized.getScheme(), normalized.getSchemeSpecificPart(), null);
+            } catch (URISyntaxException e) {
+                throw new IOException("could not remove fragment from "+source.toString());
+            }
+            this.source = normalized.toString();
+            return this;
+        }
+        
+        public PackageMapping withPackageName( String packageName ) {
+            this.packageName = packageName;
+            return this;
+        }
+        
+        public boolean appliesTo( String path ) throws IOException {
+            return directoryContains(source, path);
+        }
+        
+        public String map( String path ) {
+            return packageNameForSchemaPath( packageName, relativePath(source, path));
+        }
+        
+        @Override
+        public int compareTo(PackageMapping pm) {
+            int dirCompare = source.compareTo(pm.source);
+            int packageCompare = packageName.compareTo(pm.packageName);
+            
+            return dirCompare != 0 ? -dirCompare : packageCompare;
+        }
+        
+        @Override
+        public String toString() {
+            return "{source:"+source+", packageName:"+packageName+"}";
+        }
+    }
+    
+    public class DirectoryPackageMapping extends PackageMapping {
+        public boolean appliesTo( String path ) throws IOException {
+            return path.startsWith(source);
+        }
+        
+        public String map( String path ) {
+            return packageNameForSchemaPath( packageName, relativePath(source, path));
+        }        
+    }
+    
+    public class FilePackageMapping extends PackageMapping {
+
+        @Override
+        public boolean appliesTo(String path) throws IOException {
+           return source.equals(path);
+        }
+
+        @Override
+        public String map(String path) {
+            return packageName;
+        }
+    }
+    
+    public class UriPackageMapping extends PackageMapping {
+
+        @Override
+        public boolean appliesTo(String path) throws IOException {
+            return source.equals(path);
+        }
+
+        @Override
+        public String map(String path) {
+            return packageName;
+        }
+        
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
@@ -17,11 +17,14 @@
 package org.jsonschema2pojo;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.jsonschema2pojo.rules.RuleFactory;
+
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
@@ -69,17 +72,20 @@ public class SchemaMapper {
      *            generated new types
      * @param className
      *            the name of the parent class the represented by this schema
-     * @param packageName
-     *            the target package that should be used for generated types
      * @param schemaUrl
      *            location of the schema to be used as input
      * @return The top-most type generated from the given file
      * @throws IOException
      *             if the schema content cannot be read
      */
-    public JType generate(JCodeModel codeModel, String className, String packageName, URL schemaUrl) throws IOException {
+    public JType generate(JCodeModel codeModel, String className, URL schemaUrl) throws IOException {
 
-        JPackage jpackage = codeModel._package(packageName);
+        JPackage jpackage;
+        try {
+            jpackage = codeModel._package(ruleFactory.getPackageMapper().map(schemaUrl.toURI()));
+        } catch (URISyntaxException e) {
+            throw new IOException("Cannot convert shema URI to URL", e);
+        }
 
         ObjectNode schemaNode = readSchema(schemaUrl);
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
@@ -20,6 +20,7 @@ import static java.lang.Character.*;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import java.io.File;
+import java.net.URI;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
@@ -86,5 +87,9 @@ public class NameHelper {
             }
         }
         return sb.toString();
+    }
+
+    public String nodeNameForUri(URI id) {
+        return substringBeforeLast(id.getPath().replaceAll(".*?([^/]*)$", "$1"), ".");
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
@@ -19,8 +19,11 @@ package org.jsonschema2pojo.rules;
 import static java.lang.Character.*;
 import static org.apache.commons.lang3.StringUtils.*;
 
-import org.apache.commons.lang3.text.WordUtils;
+import java.io.File;
+import java.util.regex.Pattern;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
 
 public class NameHelper {
@@ -66,5 +69,22 @@ public class NameHelper {
         }
 
         return name;
+    }
+    
+    public String packageNameForSchemaPath( String basePackage, String path ) {
+        String[] segments = FilenameUtils
+          .getFullPathNoEndSeparator(FilenameUtils.normalize(path))
+          .split(Pattern.quote(File.separator));
+        
+        StringBuilder sb = new StringBuilder();
+        if( basePackage != null && !"".equals(basePackage) ) {
+            sb.append(basePackage);
+        }
+        for( String segment : segments ) {
+            if( !segment.equals("") ) {
+              sb.append(".").append(replaceIllegalCharacters(segment));
+            }
+        }
+        return sb.toString();
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -71,6 +71,8 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
         String propertyName = getPropertyName(nodeName);
 
+        // if we had a rule for refs here, then two phase would not be
+        // required.
         JType propertyType = ruleFactory.getSchemaRule().apply(nodeName, node, jclass, schema);
 
         node = resolveRefs(node, schema);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -20,6 +20,7 @@ import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Jackson2Annotator;
+import org.jsonschema2pojo.PackageMapper;
 import org.jsonschema2pojo.SchemaStore;
 
 import com.sun.codemodel.JClass;
@@ -40,6 +41,7 @@ public class RuleFactory {
     private final Annotator annotator;
     private final SchemaStore schemaStore;
     private final NameHelper nameHelper;
+    private final PackageMapper packageMapper;
 
     /**
      * Create a new rule factory with the given generation config options.
@@ -54,10 +56,11 @@ public class RuleFactory {
      * @param schemaStore
      *            the object used by this factory to get and store schemas
      */
-    public RuleFactory(GenerationConfig generationConfig, Annotator annotator, SchemaStore schemaStore) {
+    public RuleFactory(GenerationConfig generationConfig, Annotator annotator, SchemaStore schemaStore, PackageMapper packageMapper) {
         this.generationConfig = generationConfig;
         this.annotator = annotator;
         this.schemaStore = schemaStore;
+        this.packageMapper = packageMapper;
         this.nameHelper = new NameHelper(generationConfig);
     }
 
@@ -67,7 +70,7 @@ public class RuleFactory {
      * @see DefaultGenerationConfig
      */
     public RuleFactory() {
-        this(new DefaultGenerationConfig(), new Jackson2Annotator(), new SchemaStore());
+        this(new DefaultGenerationConfig(), new Jackson2Annotator(), new SchemaStore(), new PackageMapper());
     }
 
     /**
@@ -313,4 +316,7 @@ public class RuleFactory {
         return new MediaRule(this);
     }
 
+    public PackageMapper getPackageMapper() {
+        return this.packageMapper;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -16,8 +16,14 @@
 
 package org.jsonschema2pojo.rules;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import com.fasterxml.jackson.databind.JsonNode;
+
 import org.jsonschema2pojo.Schema;
+
 import com.sun.codemodel.JClassContainer;
 import com.sun.codemodel.JType;
 
@@ -51,6 +57,7 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
      * 
      * @param schema
      *            the schema within which this schema rule is being applied
+     * @throws MalformedURLException 
      */
     @Override
     public JType apply(String nodeName, JsonNode schemaNode, JClassContainer generatableType, Schema schema) {
@@ -62,8 +69,17 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
             if (schema.isGenerated()) {
                 return schema.getJavaType();
             }
+            
+            try {
+              String packageName = ruleFactory.getPackageMapper().map(schema.getId());
+              
+              JClassContainer schemaPackage = generatableType.owner().rootPackage().subPackage(packageName);
 
-            return apply(nodeName, schemaNode, generatableType, schema);
+              return apply(nodeName, schemaNode, schemaPackage, schema);
+            }
+            catch( IOException ioe ) {
+                throw new RuntimeException("Could not map package.", ioe);
+            }
         }
 
         JType javaType;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -72,6 +72,7 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
             
             try {
               String packageName = ruleFactory.getPackageMapper().map(schema.getId());
+              nodeName = ruleFactory.getNameHelper().nodeNameForUri(schema.getId());
               
               JClassContainer schemaPackage = generatableType.owner().rootPackage().subPackage(packageName);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/PackageMapperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/PackageMapperTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright ¬© 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class PackageMapperTest {
+
+    PackageMapper mapper = new PackageMapper();
+    
+    File namingDir = new File("./src/test/resources/schema/naming");
+    File commonDir = new File(namingDir, "common");
+    File common2Dir = new File(namingDir, "common2");
+    File dir1 = new File(namingDir, "dir1");
+    File dir2 = new File(namingDir, "dir2");
+    File topLevelSchema = new File(namingDir, "top-level.json");
+    File commonSchema = new File(commonDir, "common-type.json");
+    File newCommonSchema = new File(common2Dir, "new-common-type.json");
+    File singleRefSchema = new File(dir1, "single-ref.json");
+    File multipleRefSchema = new File(dir2, "multiple-refs.json");
+    
+    @Test
+    public void shouldReturnEmptyForNoMappings() throws IOException {
+        String packageName = mapper.map(topLevelSchema);
+        
+        assertThat("an empty mapper produces empty packages", packageName, equalTo(""));
+    
+    }
+
+    @Test
+    public void shouldReturnPackageNameWhenMapped() throws IOException {
+        mapper.withPackageMapping(namingDir, "com.example");
+        
+        String packageName = mapper.map(topLevelSchema);
+        
+        assertThat("the no mapping cause empty package", packageName, equalTo("com.example"));
+    
+    }
+    
+    @Test
+    public void shouldAddPackageNames() throws IOException {
+        mapper.withPackageMapping(namingDir, "com.example");
+        
+        String packageName = mapper.map(commonSchema);
+        
+        assertThat("nested packages are added", packageName, equalTo("com.example.common"));
+        
+    }
+    
+    @Test
+    public void shouldAllowDifferentNestedPackageNames() throws IOException {
+        mapper
+          .withPackageMapping(namingDir, "com.example")
+          .withPackageMapping(commonDir, "com.sample")
+          .withPackageMapping(dir1, "com.archetype");
+        
+        String commonPackage = mapper.map(commonSchema);
+        String dir1Package = mapper.map(singleRefSchema);
+        String dir2Package = mapper.map(multipleRefSchema);
+        
+        assertThat("the common package was mapped", commonPackage, equalTo("com.sample"));
+        assertThat("dir1 was mapped", dir1Package, equalTo("com.archetype"));
+        assertThat("dir2 was mapped", dir2Package, equalTo("com.example.dir2"));
+        
+    }
+    
+    @Test
+    public void shouldAllowSimilarSiblingNames() throws IOException {
+        mapper
+          .withPackageMapping(commonDir, "com.sample");
+        
+        String commonPackage = mapper.map(commonSchema);
+        String newCommonPackage = mapper.map(newCommonSchema);
+        
+        assertThat("the common package was mapped", commonPackage, equalTo("com.sample"));
+        assertThat("the common2 package was mapped", newCommonPackage, equalTo(""));
+        
+    }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaMapperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaMapperTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -31,8 +32,10 @@ import org.mockito.Mockito;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.jsonschema2pojo.rules.RuleFactory;
 import org.jsonschema2pojo.rules.SchemaRule;
+
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JPackage;
 
@@ -41,15 +44,16 @@ public class SchemaMapperTest {
     @Test
     public void generateReadsSchemaAsObject() throws IOException {
 
+        URL schemaContent = this.getClass().getResource("/schema/address.json");
+
         final SchemaRule mockSchemaRule = mock(SchemaRule.class);
 
         final RuleFactory mockRuleFactory = mock(RuleFactory.class);
         when(mockRuleFactory.getSchemaRule()).thenReturn(mockSchemaRule);
         when(mockRuleFactory.getGenerationConfig()).thenReturn(new DefaultGenerationConfig());
+        when(mockRuleFactory.getPackageMapper()).thenReturn(new PackageMapper().withPackageMapping(FileUtils.toFile(schemaContent).getParentFile(), "com.example.package"));
 
-        URL schemaContent = this.getClass().getResource("/schema/address.json");
-
-        new SchemaMapper(mockRuleFactory, new SchemaGenerator()).generate(new JCodeModel(), "Address", "com.example.package", schemaContent);
+        new SchemaMapper(mockRuleFactory, new SchemaGenerator()).generate(new JCodeModel(), "Address", schemaContent);
 
         ArgumentCaptor<JPackage> capturePackage = ArgumentCaptor.forClass(JPackage.class);
         ArgumentCaptor<JsonNode> captureNode = ArgumentCaptor.forClass(JsonNode.class);
@@ -79,8 +83,9 @@ public class SchemaMapperTest {
         final RuleFactory mockRuleFactory = mock(RuleFactory.class);
         when(mockRuleFactory.getSchemaRule()).thenReturn(mockSchemaRule);
         when(mockRuleFactory.getGenerationConfig()).thenReturn(mockGenerationConfig);
+        when(mockRuleFactory.getPackageMapper()).thenReturn(new PackageMapper().withPackageMapping(FileUtils.toFile(schemaContent).getParentFile(), "com.example.package"));
 
-        new SchemaMapper(mockRuleFactory, mockSchemaGenerator).generate(new JCodeModel(), "Address", "com.example.package", schemaContent);
+        new SchemaMapper(mockRuleFactory, mockSchemaGenerator).generate(new JCodeModel(), "Address", schemaContent);
 
         ArgumentCaptor<JPackage> capturePackage = ArgumentCaptor.forClass(JPackage.class);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/example/Example.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/example/Example.java
@@ -16,11 +16,15 @@
 
 package org.jsonschema2pojo.example;
 
+import org.jsonschema2pojo.SchemaGenerator;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.commons.io.FileUtils;
 import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.rules.RuleFactory;
+
 import com.sun.codemodel.JCodeModel;
 
 public class Example {
@@ -33,7 +37,10 @@ public class Example {
         
         URL source = new URL("file:///path/to/my/schema.json");
         
-        new SchemaMapper().generate(codeModel, "ClassName", "com.example", source);
+        RuleFactory factory = new RuleFactory();
+        factory.getPackageMapper().withPackageMapping(FileUtils.toFile(source),  "com.example");
+        
+        new SchemaMapper(factory, new SchemaGenerator()).generate(codeModel, "ClassName", source);
         
         codeModel.build(new File("output"));
         

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.PackageMapper;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
 import com.sun.codemodel.JClass;
@@ -39,7 +40,7 @@ import com.sun.codemodel.JPackage;
 public class ArrayRuleTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
-    private final ArrayRule rule = new ArrayRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private final ArrayRule rule = new ArrayRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore(), new PackageMapper()));
 
     @Test
     public void arrayWithUniqueItemsProducesSet() {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
@@ -32,9 +32,12 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import com.fasterxml.jackson.databind.node.TextNode;
+
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.PackageMapper;
 import org.jsonschema2pojo.SchemaStore;
+
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JType;
 
@@ -42,7 +45,7 @@ import com.sun.codemodel.JType;
 public class FormatRuleTest {
 
     private GenerationConfig config = mock(GenerationConfig.class);
-    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore(), new PackageMapper()));
 
     private final String formatValue;
     private final Class<?> expectedType;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/NameHelperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/NameHelperTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright ¬© 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.io.File;
+
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+import org.jsonschema2pojo.GenerationConfig;
+
+public class NameHelperTest {
+    
+    GenerationConfig config = mock(GenerationConfig.class);
+    NameHelper helper;
+    
+    @Before
+    public void setUp() {
+        when(config.getPropertyWordDelimiters())
+          .thenReturn(new char[]{ '-', ' ', '_' });
+        
+        helper = new NameHelper(config);
+    }
+    
+    @Test
+    public void shouldBuildPackageForTopLevelFile() {
+        String packageName = helper.packageNameForSchemaPath("com.example", systemSeperator("./context.json"));
+        
+        assertThat("the package name for path is correct", packageName, equalTo("com.example"));
+        
+    }
+
+    @Test
+    public void shouldBuildRelativePathPackage() {
+        String packageName = helper.packageNameForSchemaPath("com.example", systemSeperator("./context/context.json"));
+        
+        assertThat("the package name for path is correct", packageName, equalTo("com.example.context"));
+    }
+
+    @Test
+    public void shouldBuildRelativePathPackageWithIllegalChars() {
+        String packageName = helper.packageNameForSchemaPath("com.example", systemSeperator("./context-package/context.json"));
+        
+        assertThat("the package name for path is correct", packageName, equalTo("com.example.context_package"));
+    }
+
+    @Test
+    public void shouldBuildRelativePathPackageWithSpaces() {
+        String packageName = helper.packageNameForSchemaPath("com.example", systemSeperator("./context package/context.json"));
+        
+        assertThat("the package name for path is correct", packageName, equalTo("com.example.context_package"));
+    }
+    
+    private static String systemSeperator( String path ) {
+        return path.replaceAll("/", File.separator);
+    }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
@@ -21,10 +21,10 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
-
 import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.PackageMapper;
 import org.jsonschema2pojo.SchemaStore;
 
 public class RuleFactoryImplTest {
@@ -75,7 +75,7 @@ public class RuleFactoryImplTest {
 
         GenerationConfig mockGenerationConfig = mock(GenerationConfig.class);
 
-        RuleFactory ruleFactory = new RuleFactory(mockGenerationConfig, new NoopAnnotator(), new SchemaStore());
+        RuleFactory ruleFactory = new RuleFactory(mockGenerationConfig, new NoopAnnotator(), new SchemaStore(), new PackageMapper());
 
         assertThat(ruleFactory.getGenerationConfig(), is(sameInstance(mockGenerationConfig)));
 
@@ -86,7 +86,7 @@ public class RuleFactoryImplTest {
 
         SchemaStore mockSchemaStore = mock(SchemaStore.class);
 
-        RuleFactory ruleFactory = new RuleFactory(new DefaultGenerationConfig(), new NoopAnnotator(), mockSchemaStore);
+        RuleFactory ruleFactory = new RuleFactory(new DefaultGenerationConfig(), new NoopAnnotator(), mockSchemaStore, new PackageMapper());
 
         assertThat(ruleFactory.getSchemaStore(), is(sameInstance(mockSchemaStore)));
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -30,8 +30,11 @@ import org.mockito.ArgumentCaptor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.jsonschema2pojo.PackageMapper;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
+
 import com.sun.codemodel.JClassAlreadyExistsException;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
@@ -58,13 +61,14 @@ public class SchemaRuleTest {
         TypeRule mockTypeRule = mock(TypeRule.class);
         when(mockRuleFactory.getTypeRule()).thenReturn(mockTypeRule);
         when(mockRuleFactory.getSchemaStore()).thenReturn(new SchemaStore());
+        when(mockRuleFactory.getPackageMapper()).thenReturn(new PackageMapper());
 
         ArgumentCaptor<JsonNode> captureJsonNode = ArgumentCaptor.forClass(JsonNode.class);
         ArgumentCaptor<Schema> captureSchema = ArgumentCaptor.forClass(Schema.class);
 
         rule.apply(NODE_NAME, schemaWithRef, jclass, null);
 
-        verify(mockTypeRule).apply(eq(NODE_NAME), captureJsonNode.capture(), eq(jclass.getPackage()), captureSchema.capture());
+        verify(mockTypeRule).apply(eq(NODE_NAME), captureJsonNode.capture(), eq(jclass.owner().rootPackage()), captureSchema.capture());
 
         assertThat(captureSchema.getValue().getId(), is(equalTo(schemaUri)));
         assertThat(captureSchema.getValue().getContent(), is(equalTo(captureJsonNode.getValue())));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.PackageMapper;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
@@ -62,13 +64,14 @@ public class SchemaRuleTest {
         when(mockRuleFactory.getTypeRule()).thenReturn(mockTypeRule);
         when(mockRuleFactory.getSchemaStore()).thenReturn(new SchemaStore());
         when(mockRuleFactory.getPackageMapper()).thenReturn(new PackageMapper());
+        when(mockRuleFactory.getNameHelper()).thenReturn(new NameHelper(new DefaultGenerationConfig()));
 
         ArgumentCaptor<JsonNode> captureJsonNode = ArgumentCaptor.forClass(JsonNode.class);
         ArgumentCaptor<Schema> captureSchema = ArgumentCaptor.forClass(Schema.class);
 
         rule.apply(NODE_NAME, schemaWithRef, jclass, null);
 
-        verify(mockTypeRule).apply(eq(NODE_NAME), captureJsonNode.capture(), eq(jclass.owner().rootPackage()), captureSchema.capture());
+        verify(mockTypeRule).apply(eq("address"), captureJsonNode.capture(), eq(jclass.owner().rootPackage()), captureSchema.capture());
 
         assertThat(captureSchema.getValue().getId(), is(equalTo(schemaUri)));
         assertThat(captureSchema.getValue().getContent(), is(equalTo(captureJsonNode.getValue())));

--- a/jsonschema2pojo-core/src/test/resources/schema/naming/common/common-type.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/naming/common/common-type.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "value" : {
+            "type" : "string"
+        } 
+    }
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/naming/common2/new-common-type.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/naming/common2/new-common-type.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "value" : {
+            "type" : "string"
+        } 
+    }
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/naming/dir1/single-ref.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/naming/dir1/single-ref.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "refToDir2" : {
+            "$ref" : "../dir2/multiple-refs.json"
+        } 
+    }
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/naming/dir2/multiple-refs.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/naming/dir2/multiple-refs.json
@@ -1,0 +1,14 @@
+{
+    "type" : "object",
+    "properties" : {
+        "refToSingle" : {
+            "$ref" : "../dir1/single-ref.json"
+        },
+        "refToShared" : {
+            "$ref" : "../common/common-type.json"
+        },
+        "refToTopLevel" : {
+            "$ref" : "../top-level.json"
+        } 
+    }
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/naming/top-level.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/naming/top-level.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "refToSub" : {
+            "$ref" : "common/common-type.json"
+        } 
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/NamingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/NamingIT.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright ¬© 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static java.util.Arrays.asList;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class NamingIT {
+    
+    @Parameters
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][] {
+                { "com.example.TopLevel" }, 
+                { "com.example.dir1.SingleRef" }, 
+                { "com.example.dir2.MultipleRefs" }, 
+                { "com.example.common.CommonType" }
+        });
+    }
+    
+    static ClassLoader resultsClassLoader;
+    
+    @BeforeClass
+    public static void generateClasses() {
+        try {
+          resultsClassLoader = generateAndCompile(new File("src/test/resources/schema/naming"), "com.example");
+        }
+        catch( Exception e ) {
+            throw new RuntimeException("could not generate and compile naming test", e);
+        }
+    }
+
+    private String className;
+    
+    public NamingIT( String className ) {
+        this.className = className;
+    }
+
+    @Test
+    public void shouldGenerateClass() throws ClassNotFoundException {
+        resultsClassLoader.loadClass(className);
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
@@ -80,12 +80,34 @@ public class CodeGenerationHelper {
     }
 
     public static void generate(final URL schema, final String targetPackage, final Map<String, Object> configValues, final File outputDirectory) {
+        try {
+            generate(new File(schema.toURI()), targetPackage, configValues, outputDirectory);
+          } catch (URISyntaxException e) {
+              throw new RuntimeException(e);
+          }
+      }
+      
+      public static File generate(final File sourceDirectory, final String targetPackage) {
+          Map<String, Object> configValues = Collections.emptyMap();
+
+          return generate(sourceDirectory, targetPackage, configValues);
+      }
+      
+      public static File generate(final File sourceDirectory, final String targetPackage, final Map<String, Object> configValues) {
+          final File outputDirectory = createTemporaryOutputFolder();
+
+          generate(sourceDirectory, targetPackage, configValues, outputDirectory);
+
+          return outputDirectory;
+      }
+      
+      public static void generate(final File sourceDirectory, final String targetPackage, final Map<String, Object> configValues, final File outputDirectory) {
 
         try {
             @SuppressWarnings("serial")
         Jsonschema2PojoMojo pluginMojo = new TestableJsonschema2PojoMojo().configure(new HashMap<String, Object>() {
                 {
-                    put("sourceDirectory", new File(schema.toURI()));
+                    put("sourceDirectory", sourceDirectory);
                     put("outputDirectory", outputDirectory);
                     put("project", getMockProject());
                     put("targetPackage", targetPackage);
@@ -94,8 +116,6 @@ public class CodeGenerationHelper {
             });
 
             pluginMojo.execute();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
         } catch (MojoExecutionException e) {
             throw new RuntimeException(e);
         } catch (DependencyResolutionRequiredException e) {
@@ -166,6 +186,22 @@ public class CodeGenerationHelper {
     public static ClassLoader generateAndCompile(String schema, String targetPackage) {
 
         File outputDirectory = generate(schema, targetPackage);
+
+        return compile(outputDirectory);
+
+    }
+
+    public static ClassLoader generateAndCompile(File sourceDirectory, String targetPackage) {
+
+        File outputDirectory = generate(sourceDirectory, targetPackage);
+
+        return compile(outputDirectory);
+
+    }
+    
+    public static ClassLoader generateAndCompile(File sourceDirectory, String targetPackage, Map<String, Object> configValues) {
+
+        File outputDirectory = generate(sourceDirectory, targetPackage, configValues);
 
         return compile(outputDirectory);
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/common/common-type.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/common/common-type.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "value" : {
+            "type" : "string"
+        } 
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/common2/new-common-type.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/common2/new-common-type.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "value" : {
+            "type" : "string"
+        } 
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/dir1/single-ref.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/dir1/single-ref.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "refToDir2" : {
+            "$ref" : "../dir2/multiple-refs.json"
+        } 
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/dir2/multiple-refs.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/dir2/multiple-refs.json
@@ -1,0 +1,14 @@
+{
+    "type" : "object",
+    "properties" : {
+        "refToSingle" : {
+            "$ref" : "../dir1/single-ref.json"
+        },
+        "refToShared" : {
+            "$ref" : "../common/common-type.json"
+        },
+        "refToTopLevel" : {
+            "$ref" : "../top-level.json"
+        } 
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/top-level.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/naming/top-level.json
@@ -1,0 +1,8 @@
+{
+    "type" : "object",
+    "properties" : {
+        "refToSub" : {
+            "$ref" : "common/common-type.json"
+        } 
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,6 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.4</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>


### PR DESCRIPTION
The purpose of this PR is to rework the schema discovery process, so that:

1. schema names are more predictable, especially when "$ref" entries are present in the schemas.  #164
2. nested schemas can be inner classes or use the current naming structure. #125
3. the POJO generation process can be configured in a way native to the tool being used.

This PR is a work in progress.  Currently, the following changes are included:

1. Some m2e lifecycle mappings have been added, to clean up eclipse warnings.  This could be moved into another PR or removed.
2. The current schema discovery code has been moved from the CLI module to PojoGenerator in the core module.  This is a verbatim move at this point.
3. The Maven, Ant, and Gradle modules have been updated to depend on the core module.

Planned next steps:

1. Convert PojoGenerator into an instance based class with fluid api.
2. Allow clients of the generator to specify the schema discovery process.
3. Update the rules, so that generation can happen in 2 phases.