### PR TITLE
Add includes & excludes Maven config options for source file filtering

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -19,6 +19,7 @@ package org.jsonschema2pojo.ant;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -34,6 +35,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Reference;
+import org.jsonschema2pojo.AllFileFilter;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.GenerationConfig;
@@ -524,6 +526,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseCommonsLang3() {
         return useCommonsLang3;
+    }
+
+    @Override
+    public FileFilter getFileFilter() {
+        return new AllFileFilter();
     }
 
 }

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -19,9 +19,11 @@ package org.jsonschema2pojo.cli;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.util.Iterator;
 import java.util.List;
 
+import org.jsonschema2pojo.AllFileFilter;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.GenerationConfig;
@@ -225,6 +227,11 @@ public class Arguments implements GenerationConfig {
     
     protected void exit(int status) {
         System.exit(status);
+    }
+
+    @Override
+    public FileFilter getFileFilter() {
+        return new AllFileFilter();
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AllFileFilter.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AllFileFilter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jsonschema2pojo;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * A file filter that accepts all files.
+ * 
+ * @author Christian Trimble
+ *
+ */
+public class AllFileFilter implements FileFilter {
+
+    @Override
+    public boolean accept(File arg0) {
+        return true;
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -17,6 +17,7 @@
 package org.jsonschema2pojo;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.util.Iterator;
 
 /**
@@ -160,5 +161,10 @@ public class DefaultGenerationConfig implements GenerationConfig {
     @Override
     public boolean isUseCommonsLang3() {
         return false;
+    }
+
+    @Override
+    public FileFilter getFileFilter() {
+        return new AllFileFilter();
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -17,6 +17,7 @@
 package org.jsonschema2pojo;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.util.Iterator;
 
 /**
@@ -205,5 +206,12 @@ public interface GenerationConfig {
      *         2.x imports when adding equals, hashCode and toString methods.
      */
     boolean isUseCommonsLang3();
+    
+    /**
+     * Gets the file filter used to isolate the schema mapping files in the source directories.
+     * 
+     * @return the file filter use when scanning for schema files.
+     */
+    FileFilter getFileFilter();
     
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
@@ -61,7 +61,7 @@ public class Jsonschema2Pojo {
             File source = sources.next();
 
             if (source.isDirectory()) {
-                generateRecursive(config, mapper, codeModel, defaultString(config.getTargetPackage()), Arrays.asList(source.listFiles()));
+                generateRecursive(config, mapper, codeModel, defaultString(config.getTargetPackage()), Arrays.asList(source.listFiles(config.getFileFilter())));
             } else {
                 mapper.generate(codeModel, getNodeName(source), defaultString(config.getTargetPackage()), source.toURI().toURL());
             }
@@ -83,7 +83,7 @@ public class Jsonschema2Pojo {
             if (child.isFile()) {
                 mapper.generate(codeModel, getNodeName(child), defaultString(packageName), child.toURI().toURL());
             } else {
-                generateRecursive(config, mapper, codeModel, packageName + "." + child.getName(), Arrays.asList(child.listFiles()));
+                generateRecursive(config, mapper, codeModel, packageName + "." + child.getName(), Arrays.asList(child.listFiles(config.getFileFilter())));
             }
         }
     }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -18,6 +18,7 @@ package org.jsonschema2pojo.gradle
 import java.util.Map
 import org.jsonschema2pojo.AnnotationStyle
 import org.jsonschema2pojo.Annotator
+import org.jsonschema2pojo.AllFileFilter
 import org.jsonschema2pojo.GenerationConfig
 import org.jsonschema2pojo.NoopAnnotator
 import org.jsonschema2pojo.SourceType
@@ -47,6 +48,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   String outputEncoding
   boolean useJodaDates
   boolean useCommonsLang3
+  FileFilter fileFilter
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -66,6 +68,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     outputEncoding = 'UTF-8'
     useJodaDates = false
     useCommonsLang3 = false
+    fileFilter = new AllFileFilter()
   }
 
   @Override

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.filtering;
+
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
+
+import org.junit.Test;
+
+/**
+ * Tests the filtering of files in the source directory.
+ * 
+ * @author Christian Trimble
+ */
+public class FilteringIT {
+    @Test
+    public void shouldFilterFiles() throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile("/schema/filtering", "com.example",
+                config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
+
+        resultsClassLoader.loadClass("com.example.Included");
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/README.md
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/README.md
@@ -1,0 +1,1 @@
+a readme that should not be included.

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/excluded.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/excluded.json
@@ -1,0 +1,1 @@
+an invalid schema file that should not be included.

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/included.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/included.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "a location on s3",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/pom.xml
+++ b/jsonschema2pojo-maven-plugin/pom.xml
@@ -48,6 +48,10 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/MatchPatternsFileFilter.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/MatchPatternsFileFilter.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright © 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.maven;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.shared.utils.io.DirectoryScanner;
+import org.apache.maven.shared.utils.io.MatchPatterns;
+
+import static java.util.Arrays.*;
+import static java.lang.String.format;
+import static java.util.regex.Pattern.quote;
+
+/**
+ * <p>A file filter that supports include and exclude patterns.</p>
+ * 
+ * @author Christian Trimble
+ * @since 0.4.3
+ */
+public class MatchPatternsFileFilter implements FileFilter {
+    MatchPatterns includePatterns;
+    MatchPatterns excludePatterns;
+    String sourceDirectory;
+    boolean caseSensitive;
+
+    /**
+     * <p>Builder for MatchPatternFileFilter instances.</p>
+     */
+    public static class Builder {
+        List<String> includes = new ArrayList<String>();
+        List<String> excludes = new ArrayList<String>();
+        String sourceDirectory;
+        boolean caseSensitive;
+
+        public Builder addIncludes(List<String> includes) {
+            this.includes.addAll(processPatterns(includes));
+            return this;
+        }
+
+        public Builder addIncludes(String... includes) {
+            if (includes != null) {
+                addIncludes(asList(includes));
+            }
+            return this;
+        }
+
+        public Builder addExcludes(List<String> excludes) {
+            this.excludes.addAll(processPatterns(excludes));
+            return this;
+        }
+
+        public Builder addExcludes(String... excludes) {
+            if (excludes != null) {
+                addExcludes(asList(excludes));
+            }
+            return this;
+        }
+
+        public Builder addDefaultExcludes() {
+            excludes.addAll(processPatterns(asList(DirectoryScanner.DEFAULTEXCLUDES)));
+            return this;
+        }
+
+        public Builder withSourceDirectory(String canonicalSourceDirectory) {
+            this.sourceDirectory = canonicalSourceDirectory;
+            return this;
+        }
+
+        public Builder withCaseSensitive(boolean caseSensitive) {
+            this.caseSensitive = caseSensitive;
+            return this;
+        }
+
+        public MatchPatternsFileFilter build() {
+            if (includes.isEmpty()) {
+                includes.add("**/*");
+            }
+            return new MatchPatternsFileFilter(
+                    MatchPatterns.from(includes.toArray(new String[] {})),
+                    MatchPatterns.from(excludes.toArray(new String[] {})),
+                    sourceDirectory,
+                    caseSensitive);
+        }
+    }
+
+    MatchPatternsFileFilter(MatchPatterns includePatterns, MatchPatterns excludePatterns, String sourceDirectory, boolean caseSensitive) {
+        this.includePatterns = includePatterns;
+        this.excludePatterns = excludePatterns;
+        this.sourceDirectory = sourceDirectory;
+        this.caseSensitive = caseSensitive;
+    }
+
+    @Override
+    public boolean accept(File file) {
+        try {
+            String path = relativePath(file);
+            return file.isDirectory() ?
+                    includePatterns.matchesPatternStart(path, caseSensitive) && !excludePatterns.matchesPatternStart(path, caseSensitive) :
+                    includePatterns.matches(path, caseSensitive) && !excludePatterns.matches(path, caseSensitive);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    String relativePath(File file) throws IOException {
+        String canonicalPath = file.getCanonicalPath();
+        if (!canonicalPath.startsWith(sourceDirectory)) {
+            throw new IOException(format("the path %s is not a decendent of the basedir %s", canonicalPath, sourceDirectory));
+        }
+        return canonicalPath.substring(sourceDirectory.length()).replaceAll("^" + quote(File.separator), "");
+    }
+
+    static List<String> processPatterns(List<String> patterns) {
+        if (patterns == null)
+            return null;
+        List<String> processed = new ArrayList<String>();
+        for (String pattern : patterns) {
+            processed.add(pattern
+                    .trim()
+                    .replace('/', File.separatorChar)
+                    .replace('\\', File.separatorChar)
+                    .replaceAll(quote(File.separator) + "$", File.separator + "**"));
+        }
+        return processed;
+    }
+
+}

--- a/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
+++ b/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright © 2010-2013 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.maven;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+
+public class MatchPatternsFileFilterTest {
+
+    File basedir;
+    MatchPatternsFileFilter fileFilter;
+
+    @Before
+    public void setUp() {
+        basedir = new File("./src/test/resources/filtered/schema");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldIncludeAllIfEmpty() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("all of the files were found.", asList(files),
+                hasItems(
+                        equalTo(file("sub1")),
+                        equalTo(file("excluded")),
+                        equalTo(file("example.json")),
+                        equalTo(file("README.md"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldIncludeMatchesAndDirectoriesWhenIncluding() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addIncludes(asList("**/*.json"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("all of the files were found.", asList(files),
+                hasItems(
+                        equalTo(file("sub1")),
+                        equalTo(file("excluded")),
+                        equalTo(file("example.json"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNoIncludedUnmatchedFiles() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addIncludes(asList("**/*.json"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("the markdown file was not found.", asList(files), not(hasItem(file("README.md"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNoIncludedNestedUnmatchedFiles() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addIncludes(asList("**/*.json"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = new File(basedir, "sub1").listFiles(fileFilter);
+
+        assertThat("the markdown file was not found.", asList(files), not(hasItem(file("README.md"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldExcludeNested() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addExcludes(asList("**/*.md"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = new File(basedir, "sub1").listFiles(fileFilter);
+
+        assertThat("the markdown file was not found.", asList(files), not(hasItem(file("README.md"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldExcludeDirectories() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addExcludes(asList("**/excluded/**"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("the markdown file was not found.", asList(files), not(hasItem(file("excluded"))));
+    }
+
+    private File file(String relativePath) {
+        return new File(basedir, relativePath);
+    }
+
+}

--- a/jsonschema2pojo-maven-plugin/src/test/resources/example/schema/README.md
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/example/schema/README.md
@@ -1,0 +1,1 @@
+These are exmaple schemas.

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/pom.xml
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jsonschema2pojo</groupId>
+    <artifactId>jsonschema2pojo-mojo-filtering-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jsonschema2pojo</groupId>
+                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <version>0.4.3-SNAPSHOT</version>
+                <configuration>
+                    <sourceDirectory>${basedir}/schema</sourceDirectory>
+                    <targetPackage>com.example.types</targetPackage>
+                    <includes>
+                      <include>**/*.json</include>
+                    </includes>
+                    <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                    <includeToString>false</includeToString>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/README.md
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/README.md
@@ -1,0 +1,1 @@
+This is a readme that should be ignored.

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/example.json
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/example.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "subProp": {
+            "$ref": "sub1/example-sub.json"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/excluded/example-excluded.json
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/excluded/example-excluded.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/sub1/README.md
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/sub1/README.md
@@ -1,0 +1,1 @@
+This is another readme that should be ignored.

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/sub1/example-sub.json
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/sub1/example-sub.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "type": "string"
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,11 @@
                 <version>2.0</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-shared-utils</artifactId>
+                <version>0.6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>1.9.11</version>


### PR DESCRIPTION
This PR adds general support for file filtering when scanning for schemas and configuration for that feature in the Maven plugin.

Usage:

```
<plugin>
    <groupId>org.jsonschema2pojo</groupId>
    <artifactId>jsonschema2pojo-maven-plugin</artifactId>
    <version>0.4.3-SNAPSHOT</version>
    <configuration>
        <sourceDirectory>${basedir}/schema</sourceDirectory>
        <includes>
            <include>**/*.json</include>
        </includes>
        <excludes>
            <exclude>exclude.json</exclude>
        </excludes>
        ...
    </configuration>
    ...
</plugin>
```

This feature only works with the `sourceDirectory` option and not with `sourcePaths`.
