### PR TITLE
Added ')' to jdk unbounded range for Maven 2.X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
-                <jdk>[1.8,</jdk>
+                <jdk>[1.8,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
I was trying to use the maven plugin in my project, and was getting the the following error:

```
[ERROR] BUILD ERROR
[INFO] ------------------------------------------------------------------------
[INFO] Error building POM (may not be this project's POM).


Project ID: org.jsonschema2pojo:jsonschema2pojo

Reason: Invalid JDK version in profile 'doclint-java8-disable': Unbounded range: [1.8, for project org.jsonschema2pojo:jsonschema2pojo
```

Investigating, I found that Maven 2.x has a problem parsing unbound versions without ')'. This pull request adds the same to the jdk version range.
