### PR TITLE
Allow SchemaMapper to generate from String and not only URL

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
@@ -1,15 +1,19 @@
 /**
  * Copyright © 2010-2014 Nokia
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.jsonschema2pojo;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,11 +28,10 @@ import java.net.URL;
 import org.jsonschema2pojo.rules.RuleFactory;
 
 /**
- * Generates Java types from a JSON schema. Can accept a factory which will be used to create type generation rules for
- * this mapper.
+ * Generates Java types from a JSON schema. Can accept a factory which will be
+ * used to create type generation rules for this mapper.
  */
 public class SchemaMapper {
-
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
 
     private final RuleFactory ruleFactory;
@@ -36,10 +39,13 @@ public class SchemaMapper {
 
     /**
      * Create a schema mapper with the given {@link RuleFactory}.
-     *
-     * @param ruleFactory A factory used by this mapper to create Java type generation rules.
-     * @param schemaGenerator the generator that this mapper will use if the config dictates that the input documents
-     * are plain json (not json schema)
+     * 
+     * @param ruleFactory
+     *            A factory used by this mapper to create Java type generation
+     *            rules.
+     * @param schemaGenerator
+     *            the generator that this mapper will use if the config dictates
+     *            that the input documents are plain json (not json schema)
      */
     public SchemaMapper(RuleFactory ruleFactory, SchemaGenerator schemaGenerator) {
         this.ruleFactory = ruleFactory;
@@ -47,8 +53,9 @@ public class SchemaMapper {
     }
 
     /**
-     * Create a schema mapper with the default {@link RuleFactory} implementation.
-     *
+     * Create a schema mapper with the default {@link RuleFactory}
+     * implementation.
+     * 
      * @see RuleFactory
      */
     public SchemaMapper() {
@@ -57,13 +64,19 @@ public class SchemaMapper {
 
     /**
      * Reads a schema and adds generated types to the given code model.
-     *
-     * @param codeModel the java code-generation context that should be used to generated new types
-     * @param className the name of the parent class the represented by this schema
-     * @param packageName the target package that should be used for generated types
-     * @param schemaUrl location of the schema to be used as input
+     * 
+     * @param codeModel
+     *            the java code-generation context that should be used to
+     *            generated new types
+     * @param className
+     *            the name of the parent class the represented by this schema
+     * @param packageName
+     *            the target package that should be used for generated types
+     * @param schemaUrl
+     *            location of the schema to be used as input
      * @return The top-most type generated from the given file
-     * @throws IOException if the schema content cannot be read
+     * @throws IOException
+     *             if the schema content cannot be read
      */
     public JType generate(JCodeModel codeModel, String className, String packageName, URL schemaUrl) throws IOException {
 
@@ -95,9 +108,10 @@ public class SchemaMapper {
         JPackage jpackage = codeModel._package(packageName);
 
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode schemaNode = mapper.readTree(json);
-        ObjectNode schema = schemaGenerator.schemaFromExample(schemaNode);
+        JsonNode schemaJsonNode = mapper.readTree(json);
+        ObjectNode schemaNode = schemaGenerator.schemaFromExample(schemaJsonNode);
 
         return ruleFactory.getSchemaRule().apply(className, schemaNode, jpackage, new Schema(null, schemaNode));
     }
+
 }


### PR DESCRIPTION
Some use cases have a JSON schema in a string, instead of a file on disk or otherwise accessible via url. This allows for generating based on that, which eliminates the need for temp files in that use case.
