### PR TITLE
Use LinkedHashSet when deserializing Set to preserve order

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
@@ -17,6 +17,8 @@
 package org.jsonschema2pojo;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.codehaus.jackson.annotate.JsonAnyGetter;
 import org.codehaus.jackson.annotate.JsonAnySetter;
@@ -25,6 +27,7 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.annotate.JsonValue;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -57,6 +60,9 @@ public class Jackson1Annotator implements Annotator {
     @Override
     public void propertyField(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
         field.annotate(JsonProperty.class).param("value", propertyName);
+        if (field.type().erasure().equals(field.type().owner().ref(Set.class))) {
+            field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
+        }
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -17,6 +17,8 @@
 package org.jsonschema2pojo;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -27,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sun.codemodel.JAnnotationArrayMember;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
@@ -57,6 +60,9 @@ public class Jackson2Annotator implements Annotator {
     @Override
     public void propertyField(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
         field.annotate(JsonProperty.class).param("value", propertyName);
+        if (field.type().erasure().equals(field.type().owner().ref(Set.class))) {
+            field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
+        }
     }
 
     @Override

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/array/typeWithArrayProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/array/typeWithArrayProperties.json
@@ -15,6 +15,13 @@
                 "type" : "boolean"
             }
         },
+        "uniqueIntegerArray" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+                "type" : "integer"
+            }
+        },
         "nonUniqueArrayByDefault" : {
             "type" : "array",
             "items" : {


### PR DESCRIPTION
Issue #160 corrected ordering problems when building POJOs in code, but order is still being lost during deserialization.  This change configures Jackson 1 and Jackson 2 to use `java.util.LinkedHashSet` when deserializing to `java.util.Set`.
