### PR TITLE
Corrected path separators in default include pattern.

### DIFF
--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/MatchPatternsFileFilter.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/MatchPatternsFileFilter.java
@@ -91,7 +91,7 @@ public class MatchPatternsFileFilter implements FileFilter {
 
         public MatchPatternsFileFilter build() {
             if (includes.isEmpty()) {
-                includes.add("**/*");
+                includes.add(processPattern("**/*"));
             }
             return new MatchPatternsFileFilter(
                     MatchPatterns.from(includes.toArray(new String[] {})),
@@ -133,13 +133,17 @@ public class MatchPatternsFileFilter implements FileFilter {
             return null;
         List<String> processed = new ArrayList<String>();
         for (String pattern : patterns) {
-            processed.add(pattern
-                    .trim()
-                    .replace('/', File.separatorChar)
-                    .replace('\\', File.separatorChar)
-                    .replaceAll(quote(File.separator) + "$", File.separator + "**"));
+            processed.add(processPattern(pattern));
         }
         return processed;
+    }
+    
+    static String processPattern(String pattern) {
+        return pattern
+                .trim()
+                .replace('/', File.separatorChar)
+                .replace('\\', File.separatorChar)
+                .replaceAll(quote(File.separator) + "$", File.separator + "**");
     }
 
 }


### PR DESCRIPTION
Fixes #226

Note: This change allows the build to complete for the maven-plugin module, but it still fails on the EnumIT integration test.  I will open an issue with details.
