### PR TITLE
Support for @JsonTypeInfo in generated classes using deserializationClassProperty

### DIFF
--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PolymorphicIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PolymorphicIT.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ *
+ * @author JAshe
+ */
+public class PolymorphicIT {
+    
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void extendsWithPolymorphicDeserialization() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = generateAndCompile("/schema/polymorphic/extendsSchema.json", "com.example");
+
+        Class subtype = resultsClassLoader.loadClass("com.example.ExtendsSchema");
+        Class supertype = subtype.getSuperclass();
+
+        assertNotNull(supertype.getAnnotation(JsonTypeInfo.class));
+
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/polymorphic/extendsSchema.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/polymorphic/extendsSchema.json
@@ -1,0 +1,11 @@
+{
+    "type" : "object",
+    "properties" : {
+        "propertyOfChild" : {
+            "type" : "string"
+        }
+    },
+    "extends" : {
+        "$ref" : "parentWithPolymorphism.json"
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/polymorphic/parentWithPolymorphism.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/polymorphic/parentWithPolymorphism.json
@@ -1,0 +1,9 @@
+{
+    "type" : "object",
+    "deserializationClassProperty" : "deserializationClassName",
+    "properties" : {
+        "propertyOfParent" : {
+            "type" : "string"
+        }
+    }
+}


### PR DESCRIPTION
Jackson 2 has a `@JsonTypeInfo` annotation available so that (de)serialization of classes that extend abstract classes works correctly. 

Adding this annotation to an abstract POJO will (during serialization) add a top-level property to the schema that specifies a fully qualified class name that specifies the type that a particular json object should be deserialized to. 

This PR allows for an "abstractJavaTypeProperty" that specifies the name of the property that will contain the fully qualified name in the serialized object. 

For example, if your schema contains node with:

```
"abstractJavaTypeProperty" : "className"
```

The generated POJO will be an abstract class, and will have this annotation:

```
@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "className")
```
