### PR TITLE
Add suppression of equals symmetric check

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -299,7 +299,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         body._return(equalsBuilderInvocation.invoke("isEquals"));
 
-        JAnnotationUse suppress = equals.annotate(edu.umd.cs.findbugs.annotations.SuppressWarnings.class);
+        JAnnotationUse suppress = equals.annotate(edu.umd.cs.findbugs.annotations.SuppressFBWarnings.class);
         suppress.param("value", "EQ_OVERRIDING_EQUALS_NOT_SYMMETRIC");
         suppress.param("justification", "jsonschema2pojo appears to know what it's doing");
 

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
             <!-- Allows Findbugs annotations in submodules to suppress inaccurate warnings.-->
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>1.3.9</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Because we like to use findbugs in our projects and findbugs makes it a PIA to exclude/supress warnings using maven when I want to use a shared parent pom.xml file with findbugs rules across the company I think it makes most sense to add a suppression using the annotations for this use case.

I didn't see a better way of implementing equals() without just doing full reflection.

http://findbugs.sourceforge.net/bugDescriptions.html#EQ_OVERRIDING_EQUALS_NOT_SYMMETRIC
