### PR TITLE
Issue231/constructors

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -107,6 +107,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private String classNameSuffix = "";
 
+    private boolean constructorsRequiredPropertiesOnly = false;
+
     /**
      * Execute this task (it's expected that all relevant setters will have been
      * called by Ant to provide task configuration <em>before</em> this method
@@ -182,6 +184,14 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
      */
     public void setIncludeConstructors(boolean includeConstructors) {
         this.includeConstructors = includeConstructors;
+    }
+
+    /**
+     * Sets the 'constructorsRequiredPropertiesOnly' property of this class.
+     * @param constructorsRequiredPropertiesOnly Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    public void setConstructorsRequiredPropertiesOnly(boolean constructorsRequiredPropertiesOnly) {
+        this.constructorsRequiredPropertiesOnly = constructorsRequiredPropertiesOnly;
     }
 
     /**
@@ -598,6 +608,16 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isIncludeConstructors() {
         return includeConstructors;
+    }
+
+    /**
+     * Gets the 'constructorsRequiredPropertiesOnly' configuration option
+     *
+     * @return Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    @Override
+    public boolean isConstructorsRequiredPropertiesOnly() {
+        return constructorsRequiredPropertiesOnly;
     }
 
 }

--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -59,6 +59,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean generateBuilders;
 
+    private boolean includeConstructors = false;
+
     private boolean usePrimitives;
 
     private File source;
@@ -172,6 +174,14 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
                 return new URLClassLoader(classpathUrls.toArray(new URL[classpathUrls.size()]), parentClassloader);
             }
         });
+    }
+
+    /**
+     * Sets the 'includeConstructors' property of this class
+     * @param includeConstructors Whether to generate constructors or not.
+     */
+    public void setIncludeConstructors(boolean includeConstructors) {
+        this.includeConstructors = includeConstructors;
     }
 
     /**
@@ -583,6 +593,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public String getClassNameSuffix() {
         return classNameSuffix;
+    }
+
+    @Override
+    public boolean isIncludeConstructors() {
+        return includeConstructors;
     }
 
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -95,8 +95,14 @@
       <tr>
         <td valign="top">includeConstructors</td>
         <td valign="top">Whether to generate constructors for generated Java types</td>
-        <td align="center" valign="top">No (default <code>true</code>)</td>
-        </tr>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+      </tr>
+
+      <tr>
+        <td valign="top">constructorsRequiredPropertiesOnly</td>
+        <td valign="top">Whether generated constructors should have parameters for all properties, or only required ones.</td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+      </tr>
 
       <tr>
         <td valign="top">includeJsr303Annotations</td>

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -91,6 +91,13 @@
         <td valign="top">Whether to use include <code>hashCode</code> and <code>equals</code> methods in generated Java types.</td>
         <td align="center" valign="top">No (default <code>true</code>)</td>
       </tr>
+
+      <tr>
+        <td valign="top">includeConstructors</td>
+        <td valign="top">Whether to generate constructors for generated Java types</td>
+        <td align="center" valign="top">No (default <code>true</code>)</td>
+        </tr>
+
       <tr>
         <td valign="top">includeJsr303Annotations</td>
         <td valign="top">Whether to include <a href="http://jcp.org/en/jsr/detail?id=303">JSR-303/349</a> annotations (for schema rules like minimum, maximum, etc) in generated Java types.

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -57,6 +57,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-b", "--generate-builders" }, description = "Generate builder-style methods as well as setters")
     private boolean generateBuilderMethods = false;
 
+    @Parameter(names = {"-c", "--generate-constructors"}, description = "Generate constructors")
+    private boolean generateConstructors = false;
+
     @Parameter(names = { "-P", "--use-primitives" }, description = "Use primitives instead of wrapper types for bean properties")
     private boolean usePrimitives = false;
 
@@ -267,6 +270,16 @@ public class Arguments implements GenerationConfig {
     @Override
     public String getClassNameSuffix() {
         return classNameSuffix;
+    }
+
+    /**
+     * Gets the 'includeConstructors' configuration option
+     *
+     * @return Whether to generate constructors or not.
+     */
+    @Override
+    public boolean isIncludeConstructors() {
+        return generateConstructors;
     }
 
 }

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -60,6 +60,10 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = {"-c", "--generate-constructors"}, description = "Generate constructors")
     private boolean generateConstructors = false;
 
+    @Parameter(names = {"-r", "--constructors-required-only"}, description = "Generate constructors with only required fields")
+    private boolean constructorsRequiredPropertiesOnly = false;
+
+
     @Parameter(names = { "-P", "--use-primitives" }, description = "Use primitives instead of wrapper types for bean properties")
     private boolean usePrimitives = false;
 
@@ -280,6 +284,16 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isIncludeConstructors() {
         return generateConstructors;
+    }
+
+    /**
+     * Gets the 'constructorsRequiredPropertiesOnly' configuration option
+     *
+     * @return Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    @Override
+    public boolean isConstructorsRequiredPropertiesOnly() {
+        return constructorsRequiredPropertiesOnly;
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -192,4 +192,9 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public String getClassNameSuffix() {
         return "";
     }
+
+    @Override
+    public boolean isIncludeConstructors() {
+        return false;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -197,4 +197,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isIncludeConstructors() {
         return false;
     }
+
+    /**
+     * Gets the 'constructorsRequiredPropertiesOnly' configuration option
+     *
+     * @return Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    @Override
+    public boolean isConstructorsRequiredPropertiesOnly() {
+        return false;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -242,4 +242,11 @@ public interface GenerationConfig {
      * @return Whether to initialize collections with empty instance or null.
      */
     String getClassNameSuffix();
+
+    /**
+     * Gets the 'includeConstructors' configuration option
+     *
+     * @return Whether to generate constructors or not.
+     */
+    boolean isIncludeConstructors();
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -249,4 +249,11 @@ public interface GenerationConfig {
      * @return Whether to generate constructors or not.
      */
     boolean isIncludeConstructors();
+
+    /**
+     * Gets the 'constructorsRequiredPropertiesOnly' configuration option
+     *
+     * @return Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    boolean isConstructorsRequiredPropertiesOnly();
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
@@ -17,6 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import static java.lang.Character.*;
+import static javax.lang.model.SourceVersion.isKeyword;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import org.apache.commons.lang3.text.WordUtils;
@@ -60,5 +61,25 @@ public class NameHelper {
         }
 
         return name;
+    }
+
+    /**
+     * Convert jsonFieldName into the equivalent Java fieldname by replacing illegal characters and normalizing it.
+     * @param jsonFieldName
+     * @return
+     */
+    public String getPropertyName(String jsonFieldName) {
+        jsonFieldName = replaceIllegalCharacters(jsonFieldName);
+        jsonFieldName = normalizeName(jsonFieldName);
+
+        if (isKeyword(jsonFieldName)) {
+            jsonFieldName = "_" + jsonFieldName;
+        }
+
+        if (isKeyword(jsonFieldName)) {
+            jsonFieldName += "_";
+        }
+
+        return jsonFieldName;
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -310,7 +310,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         // add a no-args constructor for serialization purposes
-        jclass.constructor(JMod.PUBLIC);
+        JMethod noargsConstructor = jclass.constructor(JMod.PUBLIC);
+        noargsConstructor.javadoc().add("No args constructor for use in serialization");
 
         // add the public constructor with property parameters
         JMethod fieldsConstructor = jclass.constructor(JMod.PUBLIC);
@@ -323,8 +324,10 @@ public class ObjectRule implements Rule<JPackage, JType> {
             if (field == null) {
                 throw new IllegalStateException("Required property " + property + " hasn't been added to JDefinedClass before calling addConstructors");
             }
+
+            fieldsConstructor.javadoc().addParam(property);
             JVar param = fieldsConstructor.param(field.type(), field.name());
-            constructorBody.assign(field, param);
+            constructorBody.assign(JExpr._this().ref(field), param);
         }
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -20,6 +20,9 @@ import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
 
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.*;
@@ -114,8 +117,37 @@ public class ObjectRule implements Rule<JPackage, JType> {
             addEquals(jclass);
         }
 
+        if (ruleFactory.getGenerationConfig().isIncludeConstructors()) {
+            addConstructors(jclass, getRequiredProperties(node));
+        }
+
         return jclass;
 
+    }
+
+    /**
+     * Retrieve the list of required properties from node.
+     * @param node
+     * @return
+     */
+    private List<String> getRequiredProperties(JsonNode node) {
+
+        if (! node.has("properties")) {
+            return new ArrayList<String>();
+        }
+
+        List<String> rtn = new ArrayList<String>();
+
+        NameHelper nameHelper = ruleFactory.getNameHelper();
+        for (Iterator<Map.Entry<String, JsonNode>> properties = node.get("properties").fields(); properties.hasNext(); ) {
+            Map.Entry<String, JsonNode> property = properties.next();
+
+            JsonNode propertyObj = property.getValue();
+            if (propertyObj.has("required") && propertyObj.get("required").asBoolean()) {
+                rtn.add(nameHelper.getPropertyName(property.getKey()));
+            }
+        }
+        return rtn;
     }
 
     /**
@@ -268,6 +300,32 @@ public class ObjectRule implements Rule<JPackage, JType> {
         body._return(hashCodeBuilderInvocation.invoke("toHashCode"));
 
         hashCode.annotate(Override.class);
+    }
+
+    private void addConstructors(JDefinedClass jclass, List<String> requiredProperties) {
+
+        // no required properties => default constructor is good enough.
+        if (requiredProperties.isEmpty()) {
+            return;
+        }
+
+        // add a no-args constructor for serialization purposes
+        jclass.constructor(JMod.PUBLIC);
+
+        // add the public constructor with property parameters
+        JMethod fieldsConstructor = jclass.constructor(JMod.PUBLIC);
+        JBlock constructorBody = fieldsConstructor.body();
+        Map<String, JFieldVar> fields = jclass.fields();
+
+        for (String property : requiredProperties) {
+            JFieldVar field = fields.get(property);
+
+            if (field == null) {
+                throw new IllegalStateException("Required property " + property + " hasn't been added to JDefinedClass before calling addConstructors");
+            }
+            JVar param = fieldsConstructor.param(field.type(), field.name());
+            constructorBody.assign(field, param);
+        }
     }
 
     private void addEquals(JDefinedClass jclass) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -307,23 +307,6 @@ public class ObjectRule implements Rule<JPackage, JType> {
         hashCode.annotate(Override.class);
     }
 
-//    /**
-//     * Add a constructor which takes in values for the specified fields as parameters and assigns them.
-//     * @param jclass
-//     * @param fields
-//     */
-//    private void addConstructorWithFields(JDefinedClass jclass, List<JFieldVar> fields) {
-//
-//        JMethod fieldsConstructor = jclass.constructor(JMod.PUBLIC);
-//        JBlock constructorBody = fieldsConstructor.body();
-//
-//        for (JFieldVar field : fields) {
-//            fieldsConstructor.javadoc().addParam(field.name());
-//            JVar param = fieldsConstructor.param(field.type(), field.name());
-//            constructorBody.assign(JExpr._this().ref(field), param);
-//        }
-//    }
-
     private void addConstructors(JDefinedClass jclass, List<String> properties) {
 
         // no properties to put in the constructor => default constructor is good enough.

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -40,6 +40,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean useLongIntegers
   boolean useDoubleNumbers
   boolean includeConstructors
+  boolean constructorsRequiredPropertiesOnly
   boolean includeHashcodeAndEquals
   boolean includeToString
   AnnotationStyle annotationStyle
@@ -67,6 +68,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     useDoubleNumbers = true
     includeHashcodeAndEquals = true
     includeConstructors = false
+    constructorsRequiredPropertiesOnly = false
     includeToString = true
     annotationStyle = AnnotationStyle.JACKSON
     customAnnotator = NoopAnnotator.class
@@ -133,6 +135,16 @@ public class JsonSchemaExtension implements GenerationConfig {
     @Override
     boolean isIncludeConstructors() {
         includeConstructors;
+    }
+
+    /**
+     * Gets the 'constructorsRequiredPropertiesOnly' configuration option
+     *
+     * @return Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    @Override
+    boolean isConstructorsRequiredPropertiesOnly() {
+        constructorsRequiredPropertiesOnly
     }
 
     @Override

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -39,6 +39,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   char[] propertyWordDelimiters
   boolean useLongIntegers
   boolean useDoubleNumbers
+  boolean includeConstructors
   boolean includeHashcodeAndEquals
   boolean includeToString
   AnnotationStyle annotationStyle
@@ -65,6 +66,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     useLongIntegers = false
     useDoubleNumbers = true
     includeHashcodeAndEquals = true
+    includeConstructors = false
     includeToString = true
     annotationStyle = AnnotationStyle.JACKSON
     customAnnotator = NoopAnnotator.class
@@ -123,7 +125,17 @@ public class JsonSchemaExtension implements GenerationConfig {
     classNameSuffix
   }
 
-  @Override
+    /**
+     * Gets the 'includeConstructors' configuration option
+     *
+     * @return Whether to generate constructors or not.
+     */
+    @Override
+    boolean isIncludeConstructors() {
+        includeConstructors;
+    }
+
+    @Override
   public String toString() {
     """|generateBuilders = ${generateBuilders}
        |usePrimitives = ${usePrimitives}
@@ -134,6 +146,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |useLongIntegers = ${useLongIntegers}
        |useDoubleNumbers = ${useDoubleNumbers}
        |includeHashcodeAndEquals = ${includeHashcodeAndEquals}
+       |includeConstructors = ${includeConstructors}
        |includeToString = ${includeToString}
        |annotationStyle = ${annotationStyle.toString().toLowerCase()}
        |customAnnotator = ${customAnnotator.getName()}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
@@ -1,57 +1,36 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jsonschema2pojo.integration;
 
 import com.sun.codemodel.JMod;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(Enclosed.class)
 public class ConstructorsIT {
-
-    private static Class typeWithRequired;
-    private static Class typeWithoutRequired;
-
-    private static Map<String, Object> config;
-
-    @BeforeClass
-    @SuppressWarnings("unchecked")
-    public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
-
-        config = config("propertyWordDelimiters", "_",
-                "includeConstructors", true
-        );
-        typeWithRequired = generateAndLoadClass(
-                "/schema/constructors/requiredPropertyConstructors.json",
-                "com.example",
-                "com.example.RequiredPropertyConstructors",
-                config);
-
-        typeWithoutRequired = generateAndLoadClass(
-                "/schema/constructors/noRequiredPropertiesConstructor.json",
-                "com.example",
-                "com.example.NoRequiredPropertiesConstructor",
-                config);
-    }
-
-    private static Class generateAndLoadClass(String schemaPath, String packageName, String className, Map<String, Object> config) throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile(schemaPath, packageName,
-                config);
-
-        return resultsClassLoader.loadClass(className);
-    }
-
-    @Test
-    public void testCreatesPublicNoArgsConstructor() throws Exception {
-        Constructor constructor = typeWithRequired.getConstructor();
-
-        assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
-    }
 
     public static void assertHasModifier(int modifier, int modifiers, String modifierName) {
         assertEquals(
@@ -59,54 +38,138 @@ public class ConstructorsIT {
                 modifier, modifier & modifiers);
     }
 
-    @Test
-    public void testCreatesConstructorWithRequiredParams() throws Exception {
-        Constructor constructor = getArgsConstructor();
-
-        assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
-    }
-
-    public Constructor getArgsConstructor() throws NoSuchMethodException {
-        return typeWithRequired.getConstructor(String.class, Integer.class, Boolean.class);
-    }
-
-    @Test
-    public void testConstructorAssignsFields() throws Exception {
-        Object instance = getArgsConstructor().newInstance("type", 5, true);
-
-        assertEquals("type", invokeGeneratedMethod("getType", instance));
-        assertEquals(5, invokeGeneratedMethod("getId", instance));
-        assertEquals(true, invokeGeneratedMethod("getHasTickets", instance));
-    }
-
-    private Object invokeGeneratedMethod(String method, Object instance) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-        return typeWithRequired.getMethod(method).invoke(instance);
-    }
-
-    @Test
-    public void testNoConstructorWithoutRequiredParams() throws Exception {
-        assertHasOnlyDefaultConstructor(typeWithoutRequired);
-    }
-
-    private static void assertHasOnlyDefaultConstructor(Class cls) {
+    public static void assertHasOnlyDefaultConstructor(Class cls) {
         Constructor[] constructors = cls.getConstructors();
 
         assertEquals(constructors.length, 1);
 
-        assertEquals("Expected " + typeWithoutRequired + " to only have the default, no-args constructor",
+        assertEquals("Expected " + cls + " to only have the default, no-args constructor",
                 0, constructors[0].getParameterTypes().length);
     }
 
-    @Test
-    public void testDoesntGenerateConstructorsWithoutConfig() throws Exception {
+    public static Class generateAndLoadClass(String schemaPath, String packageName, String className, Map<String, Object> config) throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile(schemaPath, packageName,
+                config);
 
-        Class noConstructors = generateAndLoadClass(
-                "/schema/constructors/requiredPropertyConstructors.json",
-                "com.example",
-                "com.example.RequiredPropertyConstructors",
-                config("propertyWordDelimiters", "_",
-                        "includeConstructors", false
-                ));
-        assertHasOnlyDefaultConstructor(noConstructors);
+        return resultsClassLoader.loadClass(className);
+    }
+
+    public static class AllPropertiesIT {
+
+        protected static Class typeWithRequired;
+        private static Class typeWithoutProperties;
+
+        //xxx there's a bit of duplication here in the name of performance; if we did this step as a Before method,
+        //we could factor out a super class between AllPropertiesIT and RequiredOnlyIT... but it makes the tests run
+        //more slowly
+        @BeforeClass
+        @SuppressWarnings("unchecked")
+        public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+
+            Map<String, Object> config = config("propertyWordDelimiters", "_",
+                    "includeConstructors", true
+            );
+            typeWithRequired = generateAndLoadClass(
+                    "/schema/constructors/requiredPropertyConstructors.json",
+                    "com.example",
+                    "com.example.RequiredPropertyConstructors",
+                    config);
+
+            typeWithoutProperties = generateAndLoadClass(
+                    "/schema/constructors/noPropertiesConstructor.json",
+                    "com.example",
+                    "com.example.NoPropertiesConstructor",
+                    config);
+        }
+
+        @Test
+        public void testGeneratesConstructorWithAllProperties() throws Exception {
+            assertHasModifier(JMod.PUBLIC, getArgsConstructor().getModifiers(), "public");
+
+        }
+        public Constructor getArgsConstructor() throws NoSuchMethodException {
+            return typeWithRequired.getConstructor(String.class, Integer.class, Boolean.class, String.class, String.class);
+        }
+
+        @Test
+        public void testNoConstructorWithoutProperties() throws Exception {
+            assertHasOnlyDefaultConstructor(typeWithoutProperties);
+        }
+    }
+
+    /**
+     * Tests with constructorsRequiredPropertiesOnly set to true
+     */
+    public static class RequiredOnlyIT  {
+
+        protected static Class typeWithRequired;
+        protected static Class typeWithoutRequired;
+
+        @BeforeClass
+        @SuppressWarnings("unchecked")
+        public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+
+            Map<String, Object> config = config("propertyWordDelimiters", "_",
+                    "includeConstructors", true,
+                    "constructorsRequiredPropertiesOnly", true
+            );
+            typeWithRequired = generateAndLoadClass(
+                    "/schema/constructors/requiredPropertyConstructors.json",
+                    "com.example",
+                    "com.example.RequiredPropertyConstructors",
+                    config);
+
+            typeWithoutRequired = generateAndLoadClass(
+                    "/schema/constructors/noRequiredPropertiesConstructor.json",
+                    "com.example",
+                    "com.example.NoRequiredPropertiesConstructor",
+                    config);
+        }
+
+        @Test
+        public void testCreatesPublicNoArgsConstructor() throws Exception {
+            Constructor constructor = typeWithRequired.getConstructor();
+
+            assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+        }
+
+        @Test
+        public void testCreatesConstructorWithRequiredParams() throws Exception {
+            Constructor constructor = getArgsConstructor();
+
+            assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+        }
+
+        public Constructor getArgsConstructor() throws NoSuchMethodException {
+            return typeWithRequired.getConstructor(String.class, Integer.class, Boolean.class);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void testConstructorAssignsFields() throws Exception {
+            Object instance = getArgsConstructor().newInstance("type", 5, true);
+
+            assertEquals("type", typeWithRequired.getMethod("getType").invoke(instance));
+            assertEquals(5, typeWithRequired.getMethod("getId").invoke(instance));
+            assertEquals(true, typeWithRequired.getMethod("getHasTickets").invoke(instance));
+        }
+
+        @Test
+        public void testNoConstructorWithoutRequiredParams() throws Exception {
+            assertHasOnlyDefaultConstructor(typeWithoutRequired);
+        }
+
+        @Test
+        public void testDoesntGenerateConstructorsWithoutConfig() throws Exception {
+
+            Class noConstructors = generateAndLoadClass(
+                    "/schema/constructors/requiredPropertyConstructors.json",
+                    "com.example",
+                    "com.example.RequiredPropertyConstructors",
+                    config("propertyWordDelimiters", "_",
+                            "includeConstructors", false
+                    ));
+            assertHasOnlyDefaultConstructor(noConstructors);
+        }
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
@@ -1,0 +1,112 @@
+package org.jsonschema2pojo.integration;
+
+import com.sun.codemodel.JMod;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
+import static org.junit.Assert.assertEquals;
+
+public class ConstructorsIT {
+
+    private static Class typeWithRequired;
+    private static Class typeWithoutRequired;
+
+    private static Map<String, Object> config;
+
+    @BeforeClass
+    @SuppressWarnings("unchecked")
+    public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+
+        config = config("propertyWordDelimiters", "_",
+                "includeConstructors", true
+        );
+        typeWithRequired = generateAndLoadClass(
+                "/schema/constructors/requiredPropertyConstructors.json",
+                "com.example",
+                "com.example.RequiredPropertyConstructors",
+                config);
+
+        typeWithoutRequired = generateAndLoadClass(
+                "/schema/constructors/noRequiredPropertiesConstructor.json",
+                "com.example",
+                "com.example.NoRequiredPropertiesConstructor",
+                config);
+    }
+
+    private static Class generateAndLoadClass(String schemaPath, String packageName, String className, Map<String, Object> config) throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile(schemaPath, packageName,
+                config);
+
+        return resultsClassLoader.loadClass(className);
+    }
+
+    @Test
+    public void testCreatesPublicNoArgsConstructor() throws Exception {
+        Constructor constructor = typeWithRequired.getConstructor();
+
+        assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+
+    public static void assertHasModifier(int modifier, int modifiers, String modifierName) {
+        assertEquals(
+                "Expected the bit " + modifierName + " (" + modifier + ")" + " to be set but got: " + modifiers,
+                modifier, modifier & modifiers);
+    }
+
+    @Test
+    public void testCreatesConstructorWithRequiredParams() throws Exception {
+        Constructor constructor = getArgsConstructor();
+
+        assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+
+    public Constructor getArgsConstructor() throws NoSuchMethodException {
+        return typeWithRequired.getConstructor(String.class, Integer.class, Boolean.class);
+    }
+
+    @Test
+    public void testConstructorAssignsFields() throws Exception {
+        Object instance = getArgsConstructor().newInstance("type", 5, true);
+
+        assertEquals("type", invokeGeneratedMethod("getType", instance));
+        assertEquals(5, invokeGeneratedMethod("getId", instance));
+        assertEquals(true, invokeGeneratedMethod("getHasTickets", instance));
+    }
+
+    private Object invokeGeneratedMethod(String method, Object instance) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        return typeWithRequired.getMethod(method).invoke(instance);
+    }
+
+    @Test
+    public void testNoConstructorWithoutRequiredParams() throws Exception {
+        assertHasOnlyDefaultConstructor(typeWithoutRequired);
+    }
+
+    private static void assertHasOnlyDefaultConstructor(Class cls) {
+        Constructor[] constructors = cls.getConstructors();
+
+        assertEquals(constructors.length, 1);
+
+        assertEquals("Expected " + typeWithoutRequired + " to only have the default, no-args constructor",
+                0, constructors[0].getParameterTypes().length);
+    }
+
+    @Test
+    public void testDoesntGenerateConstructorsWithoutConfig() throws Exception {
+
+        Class noConstructors = generateAndLoadClass(
+                "/schema/constructors/requiredPropertyConstructors.json",
+                "com.example",
+                "com.example.RequiredPropertyConstructors",
+                config("propertyWordDelimiters", "_",
+                        "includeConstructors", false
+                ));
+        assertHasOnlyDefaultConstructor(noConstructors);
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/noPropertiesConstructor.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/noPropertiesConstructor.json
@@ -1,0 +1,5 @@
+{
+    "type" : "object",
+    "properties" : {
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/noRequiredPropertiesConstructor.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/noRequiredPropertiesConstructor.json
@@ -1,0 +1,20 @@
+{
+    "type" : "object",
+    "properties" : {
+        "type" : {
+            "type" : "string"
+        },
+        "id" : {
+            "type" : "integer"
+        },
+        "has_tickets" : {
+            "type" : "boolean"
+        },
+        "provider" : {
+            "type" : "string"
+        },
+        "starttime" : {
+            "type" : "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/requiredPropertyConstructors.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/requiredPropertyConstructors.json
@@ -1,0 +1,24 @@
+{
+    "type" : "object",
+    "properties" : {
+        "type" : {
+            "type" : "string",
+            "default" : "event",
+            "required": true
+        },
+        "id" : {
+            "type" : "integer",
+            "required": true
+        },
+        "has_tickets" : {
+            "type" : "boolean",
+            "required": true
+        },
+        "provider" : {
+            "type" : "string"
+        },
+        "starttime" : {
+            "type" : "string"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -377,9 +377,16 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     /**
      * Whether to generate constructors or not
      * @parameter expression="${jsonschema2pojo.includeConstructors}"
-     * @since 0.4.8}"
+     * @since 0.4.8
      */
     private boolean includeConstructors = false;
+
+    /**
+     * Whether generated constructors should have parameters for all properties, or only required ones.
+     * @parameter expression="${jsonschema2pojo.constructorsRequiredPropertiesOnly}"
+     * @since 0.4.8
+     */
+    private boolean constructorsRequiredPropertiesOnly;
 
     /**
      * Executes the plugin, to read the given source and behavioural properties
@@ -613,5 +620,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isIncludeConstructors() {
         return includeConstructors;
+    }
+
+    /**
+     * Gets the 'constructorsRequiredPropertiesOnly' configuration option
+     *
+     * @return Whether generated constructors should have parameters for all properties, or only required ones.
+     */
+    @Override
+    public boolean isConstructorsRequiredPropertiesOnly() {
+        return constructorsRequiredPropertiesOnly;
     }
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -375,6 +375,13 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String classNameSuffix = "";
 
     /**
+     * Whether to generate constructors or not
+     * @parameter expression="${jsonschema2pojo.includeConstructors}"
+     * @since 0.4.8}"
+     */
+    private boolean includeConstructors = false;
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -596,5 +603,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public String getClassNameSuffix() {
         return classNameSuffix;
+    }
+
+    /**
+     * Gets the 'includeConstructors' configuration option
+     *
+     * @return Whether to generate constructors or not.
+     */
+    @Override
+    public boolean isIncludeConstructors() {
+        return includeConstructors;
     }
 }


### PR DESCRIPTION
I was looking for the ability to generate constructors, and saw the preexisting issue for it, so I decided to take a stab at implementing them. As requested in the ticket, parameters are only added to the constructor for required fields.

In terms of implementation, I made the constructor generation part of `ObjectRule`, my reasoning being that the constructor is something affected by all fields of an object, in a manner similar to `hashCode` and `equals`. This leads to some mildly ugly inspection of the `properties` node in the schema, in order to get the required properties. If it seems cleaner, I could move the generation of constructors to `PropertyRule`, with each property adding a param to the constructor (though it's a bit weirder to decide who creates the constructor in that case).

Let me know if there ought to be more test coverage; I added an integration test which I think covers the code paths.