### PR TITLE
Resolves warnings for 'cannot find symbol' in CLI package.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>2.10.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Upgraded the javadoc plugin to 2.10.1 to resolve warnings.