### PR TITLE
add support for jackson's JsonView

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
@@ -29,6 +29,7 @@ import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.annotate.JsonValue;
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.annotate.JsonView;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JAnnotationArrayMember;
@@ -62,6 +63,11 @@ public class Jackson1Annotator extends AbstractAnnotator {
         field.annotate(JsonProperty.class).param("value", propertyName);
         if (field.type().erasure().equals(field.type().owner().ref(Set.class))) {
             field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
+        }
+
+        if (propertyNode.has("javaJsonView")) {
+            field.annotate(JsonView.class).param(
+                "value", field.type().owner().ref(propertyNode.get("javaJsonView").asText()));
         }
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sun.codemodel.JAnnotationArrayMember;
@@ -63,6 +64,11 @@ public class Jackson2Annotator extends AbstractAnnotator {
         field.annotate(JsonProperty.class).param("value", propertyName);
         if (field.type().erasure().equals(field.type().owner().ref(Set.class))) {
             field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
+        }
+
+        if (propertyNode.has("javaJsonView")) {
+            field.annotate(JsonView.class).param(
+                "value", field.type().owner().ref(propertyNode.get("javaJsonView").asText()));
         }
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/com/example/MyJsonViewClass.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/com/example/MyJsonViewClass.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class MyJsonViewClass {}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ViewIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ViewIT.java
@@ -28,15 +28,9 @@ import org.junit.Test;
 public class ViewIT {
     static abstract class JsonViewTest {
         String annotationStyle;
-        Class<?> jsonViewClass;
 
         public JsonViewTest(String annotationStyle) {
             this.annotationStyle = annotationStyle;
-            if (annotationStyle.equals("jackson1")) {
-                this.jsonViewClass = org.codehaus.jackson.map.annotate.JsonView.class; 
-            } else {
-                this.jsonViewClass = com.fasterxml.jackson.annotation.JsonView.class;
-            }
         }
 
         public void test() throws ClassNotFoundException, NoSuchFieldException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ViewIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ViewIT.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.Assert.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+
+public class ViewIT {
+    static abstract class JsonViewTest {
+        String annotationStyle;
+        Class<?> jsonViewClass;
+
+        public JsonViewTest(String annotationStyle) {
+            this.annotationStyle = annotationStyle;
+            if (annotationStyle.equals("jackson1")) {
+                this.jsonViewClass = org.codehaus.jackson.map.annotate.JsonView.class; 
+            } else {
+                this.jsonViewClass = com.fasterxml.jackson.annotation.JsonView.class;
+            }
+        }
+
+        public void test() throws ClassNotFoundException, NoSuchFieldException {
+            ClassLoader resultsClassLoader = generateAndCompile(
+                "/schema/views/views.json", 
+                "com.example", 
+                config("annotationStyle", annotationStyle));
+
+            Class<?> pojo = resultsClassLoader.loadClass("com.example.Views");
+            Field inView = pojo.getDeclaredField("inView");
+            assertThat(getJsonViewAnnotation(inView), notNullValue());
+
+            assertThat(getJsonViewAnnotationValue(inView), equalTo("MyJsonViewClass"));
+
+            Field notInView = pojo.getDeclaredField("notInView");
+            assertThat(getJsonViewAnnotation(notInView), nullValue());
+        }
+
+        protected abstract <T extends Annotation> T getJsonViewAnnotation(Field f);
+        protected abstract String getJsonViewAnnotationValue(Field f);
+    }
+
+    @Test
+    public void checkViewJackson1() throws Exception {
+        new JsonViewTest("jackson1") {
+            @Override
+            @SuppressWarnings({"unchecked"})
+            protected <T extends Annotation> T getJsonViewAnnotation(Field f)  {
+                return (T) f.getAnnotation(org.codehaus.jackson.map.annotate.JsonView.class);
+            }
+
+            @Override
+            protected String getJsonViewAnnotationValue(Field f) {
+                org.codehaus.jackson.map.annotate.JsonView jv = 
+                    f.getAnnotation(org.codehaus.jackson.map.annotate.JsonView.class);
+                return jv.value()[0].getSimpleName();
+            }
+        }.test();
+    }
+
+    @Test
+    public void checkViewJackson2() throws Exception {
+        new JsonViewTest("jackson2") {
+            @Override
+            @SuppressWarnings({"unchecked"})
+            protected <T extends Annotation> T getJsonViewAnnotation(Field f)  {
+                return (T) f.getAnnotation(com.fasterxml.jackson.annotation.JsonView.class);
+            }
+
+            @Override
+            protected String getJsonViewAnnotationValue(Field f) {
+                com.fasterxml.jackson.annotation.JsonView jv = 
+                    f.getAnnotation(com.fasterxml.jackson.annotation.JsonView.class);
+                return jv.value()[0].getSimpleName();
+            }
+        }.test();
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/views/views.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/views/views.json
@@ -1,0 +1,12 @@
+{
+    "type" : "object",
+    "properties" : {
+        "notInView": {
+            "type": "string"
+        },
+        "inView": {
+            "type": "string",
+            "javaJsonView": "com.example.MyJsonViewClass"
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I have a need to use jackson's JsonView annotation with your wonderful library.  Here is the change I made to make use of that feature.  It adds handling of the "javaJsonView" field name to the schema json.  This causes a @JsonView annotation to appear on the resulting field of the pojo.

cheers,
Jon