### PR TITLE
Added options to generate Joda LocalDate and LocalTime for date and time formatted strings

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -98,6 +98,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private String outputEncoding = "UTF-8";
 
     private boolean useJodaDates = false;
+
+    private boolean useJodaLocalDates = false;
+
+    private boolean useJodaLocalTimes = false;
     
     private boolean useCommonsLang3 = false;
 
@@ -436,6 +440,30 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
+     * Sets the 'useJodaLocalDates' property of this class
+     *
+     * @param useJodaLocalDates
+     *            Whether to use {@link org.joda.time.LocalDate} instead of
+     *            string when adding string fields of format date
+     *            (not date-time) to generated Java types.
+     */
+    public void setUseJodaLocalDates(boolean useJodaLocalDates) {
+        this.useJodaLocalDates = useJodaLocalDates;
+    }
+
+    /**
+     * Sets the 'useJodaLocalTimes' property of this class
+     *
+     * @param useJodaLocalTimes
+     *            Whether to use {@link org.joda.time.LocalTime} instead of
+     *            string when adding string fields of format time
+     *            (not date-time) to generated Java types.
+     */
+    public void setUseJodaLocalTimes(boolean useJodaLocalTimes) {
+        this.useJodaLocalTimes = useJodaLocalTimes;
+    }
+
+    /**
      * Sets the 'useCommonsLang3' property of this class
      * 
      * @param useCommonsLang3
@@ -578,6 +606,16 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseJodaDates() {
         return useJodaDates;
+    }
+
+    @Override
+    public boolean isUseJodaLocalDates() {
+        return useJodaLocalDates;
+    }
+
+    @Override
+    public boolean isUseJodaLocalTimes() {
+        return useJodaLocalTimes;
     }
     
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -178,10 +178,23 @@
       </tr>
       <tr>
         <td valign="top">useJodaDates</td>
-        <td valign="top">Whether to use <code>org.joda.time.DateTime</code> instead of <code>java.util.Date</code> when adding date type fields to generated Java types.</td>
+        <td valign="top">Whether to use <code>org.joda.time.DateTime</code> instead of <code>java.util.Date</code>
+            when adding date-time type fields to generated Java types.</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>
       </tr>
-      <tr>
+        <tr>
+            <td valign="top">useJodaLocalDates</td>
+            <td valign="top">Whether to use <code>org.joda.time.LocalDate</code> instead of String
+                when adding string fields with format date to generated Java types.</td>
+            <td align="center" valign="top">No (default <code>false</code>)</td>
+        </tr>
+        <tr>
+            <td valign="top">useJodaLocalTimes</td>
+            <td valign="top">Whether to use <code>org.joda.time.LocalTime</code> instead of String
+                when adding string fields with format time to generated Java types.</td>
+            <td align="center" valign="top">No (default <code>false</code>)</td>
+        </tr>
+        <tr>
         <td valign="top">useLongIntegers</td>
         <td valign="top">Whether to use the java type <code>long</code> (or <code>Long</code>) instead of <code>int</code> (or <code>Integer</code>) when representing the JSON Schema type 'integer'.</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -107,8 +107,17 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-e", "--output-encoding" }, description = "The character encoding that should be used when writing the generated Java source files.")
     private String outputEncoding = "UTF-8";
 
-    @Parameter(names = { "-j", "--joda-dates" }, description = "Whether to use org.joda.time.DateTime instead of java.util.Date when adding date type fields to generated Java types.")
+    @Parameter(names = { "-j", "--joda-dates" }, description = "Whether to use org.joda.time.DateTime instead of java" +
+            ".util.Date when adding date-time type fields to generated Java types.")
     private boolean useJodaDates = false;
+
+    @Parameter(names = { "-jd", "--joda-local-dates" }, description = "Whether to use org.joda.time.LocalDate instead" +
+            "of String when adding date type fields to generated Java types.")
+    private boolean useJodaLocalDates = false;
+
+    @Parameter(names = { "-jt", "--joda-local-times" }, description = "Whether to use org.joda.time.LocalTime instead" +
+            "of String when adding time type fields to generated Java types.")
+    private boolean useJodaLocalTimes = false;
 
     @Parameter(names = { "-c3", "--commons-lang3" }, description = "Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals, hashCode and toString methods.")
     private boolean useCommonsLang3 = false;
@@ -245,6 +254,16 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isUseJodaDates() {
         return useJodaDates;
+    }
+
+    @Override
+    public boolean isUseJodaLocalDates() {
+        return useJodaLocalDates;
+    }
+
+    @Override
+    public boolean isUseJodaLocalTimes() {
+        return useJodaLocalTimes;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -165,6 +165,22 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return false;
     }
 
+    /**
+     * @return false
+     */
+    @Override
+    public boolean isUseJodaLocalDates() {
+        return false;
+    }
+
+    /**
+     * @return false
+     */
+    @Override
+    public boolean isUseJodaLocalTimes() {
+        return false;
+    }
+
     @Override
     public boolean isUseCommonsLang3() {
         return false;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -208,6 +208,25 @@ public interface GenerationConfig {
     boolean isUseJodaDates();
 
     /**
+     * Gets the 'useJodaLocalDates' configuration option.
+     *
+     * @return Whether to use {@link org.joda.time.LocalDate} instead of string
+     *         when adding string type fields with a format of date
+     *         (not date-time) to generated Java types.
+     */
+    boolean isUseJodaLocalDates();
+
+
+    /**
+     * Gets the 'useJodaLocalTimes' configuration option.
+     *
+     * @return Whether to use {@link org.joda.time.LocalTime} instead of string
+     *         when adding string type fields with a format of time
+     *         (not date-time) to generated Java types.
+     */
+    boolean isUseJodaLocalTimes();
+
+    /**
      * Gets the 'useCommonsLang3' configuration option.
      * 
      * @return Whether to use commons-lang 3.x imports instead of commons-lang

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Set;
 import static org.apache.commons.lang3.StringUtils.*;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.jsonschema2pojo.Schema;
 
 /**
@@ -112,13 +114,20 @@ public class DefaultRule implements Rule<JFieldVar, JFieldVar> {
         } else if (fieldType.fullName().equals(boolean.class.getName())) {
             return JExpr.lit(Boolean.parseBoolean(node.asText()));
 
-        } else if (fieldType.fullName().equals(getDateType().getName())) {
+        } else if (fieldType.fullName().equals(getDateTimeType().getName())) {
             long millisecs = parseDateToMillisecs(node.asText());
 
-            JInvocation newDate = JExpr._new(fieldType);
-            newDate.arg(JExpr.lit(millisecs));
+            JInvocation newDateTime = JExpr._new(fieldType);
+            newDateTime.arg(JExpr.lit(millisecs));
 
-            return newDate;
+            return newDateTime;
+
+        } else if (fieldType.fullName().equals(LocalDate.class.getName()) ||
+                   fieldType.fullName().equals(LocalTime.class.getName())) {
+
+            JInvocation stringParseableTypeInstance = JExpr._new(fieldType);
+            stringParseableTypeInstance.arg(JExpr.lit(node.asText()));
+            return stringParseableTypeInstance;
 
         } else if (fieldType.fullName().equals(long.class.getName())) {
             return JExpr.lit(Long.parseLong(node.asText()));
@@ -137,7 +146,7 @@ public class DefaultRule implements Rule<JFieldVar, JFieldVar> {
 
     }
 
-    private Class<?> getDateType() {
+    private Class<?> getDateTimeType() {
         return ruleFactory.getGenerationConfig().isUseJodaDates() ? DateTime.class : Date.class;
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -22,6 +22,8 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 
@@ -47,9 +49,9 @@ public class FormatRule implements Rule<JType, JType> {
      * <p>
      * This rule maps format values to Java types:
      * <ul>
-     * <li>"format":"date-time" =&gt; {@link java.util.Date}
-     * <li>"format":"date" =&gt; {@link String}
-     * <li>"format":"time" =&gt; {@link String}
+     * <li>"format":"date-time" =&gt; {@link java.util.Date} or {@link org.joda.time.DateTime} (if config useJodaDates is set)
+     * <li>"format":"date" =&gt; {@link String} or {@link org.joda.time.LocalDate} (if config useJodaLocalDates is set)
+     * <li>"format":"time" =&gt; {@link String} or {@link org.joda.time.LocalTime} (if config useJodaLocalTimes is set)
      * <li>"format":"utc-millisec" =&gt; <code>long</code>
      * <li>"format":"regex" =&gt; {@link java.util.regex.Pattern}
      * <li>"format":"color" =&gt; {@link String}
@@ -78,13 +80,13 @@ public class FormatRule implements Rule<JType, JType> {
     public JType apply(String nodeName, JsonNode node, JType baseType, Schema schema) {
 
         if (node.asText().equals("date-time")) {
-            return baseType.owner().ref(getDateType());
+            return baseType.owner().ref(getDateTimeType());
 
         } else if (node.asText().equals("date")) {
-            return baseType.owner().ref(String.class);
+            return baseType.owner().ref(getDateOnlyType());
 
         } else if (node.asText().equals("time")) {
-            return baseType.owner().ref(String.class);
+            return baseType.owner().ref(getTimeOnlyType());
 
         } else if (node.asText().equals("utc-millisec")) {
             return unboxIfNecessary(baseType.owner().ref(Long.class), ruleFactory.getGenerationConfig());
@@ -125,8 +127,16 @@ public class FormatRule implements Rule<JType, JType> {
 
     }
 
-    private Class<?> getDateType() {
+    private Class<?> getDateTimeType() {
         return ruleFactory.getGenerationConfig().isUseJodaDates() ? DateTime.class : Date.class;
+    }
+
+    private Class<?> getDateOnlyType() {
+        return ruleFactory.getGenerationConfig().isUseJodaLocalDates() ? LocalDate.class : String.class;
+    }
+
+    private Class<?> getTimeOnlyType() {
+        return ruleFactory.getGenerationConfig().isUseJodaLocalTimes() ? LocalTime.class : String.class;
     }
 
     private JType unboxIfNecessary(JType type, GenerationConfig config) {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static java.util.Arrays.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.SchemaStore;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JType;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+
+@RunWith(Parameterized.class)
+public class FormatRuleJodaTest {
+
+    private GenerationConfig config = mock(GenerationConfig.class);
+    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+
+    private final String formatValue;
+    private final Class<?> expectedType;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return asList(new Object[][] {
+                { "date-time", DateTime.class },
+                { "date", LocalDate.class },
+                { "time", LocalTime.class }});
+    }
+
+    public FormatRuleJodaTest(String formatValue, Class<?> expectedType) {
+        this.formatValue = formatValue;
+        this.expectedType = expectedType;
+    }
+
+    @Before
+    public void setupConfig() {
+        when(config.isUseJodaLocalTimes()).thenReturn(true);
+        when(config.isUseJodaLocalDates()).thenReturn(true);
+        when(config.isUseJodaDates()).thenReturn(true);
+    }
+
+    @Test
+    public void applyGeneratesTypeFromFormatValue() {
+        TextNode formatNode = TextNode.valueOf(formatValue);
+
+        JType result = rule.apply("fooBar", formatNode, new JCodeModel().ref(String.class), null);
+
+        assertThat(result.fullName(), equalTo(expectedType.getName()));
+    }
+
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -51,6 +51,8 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean removeOldOutput
   String outputEncoding
   boolean useJodaDates
+  boolean useJodaLocalDates
+  boolean useJodaLocalTimes
   boolean useCommonsLang3
   FileFilter fileFilter
   boolean initializeCollections
@@ -77,6 +79,8 @@ public class JsonSchemaExtension implements GenerationConfig {
     sourceType = SourceType.JSONSCHEMA
     outputEncoding = 'UTF-8'
     useJodaDates = false
+    useJodaLocalDates = false
+    useJodaLocalTimes = false
     useCommonsLang3 = false
     fileFilter = new AllFileFilter()
     initializeCollections = true
@@ -168,6 +172,8 @@ public class JsonSchemaExtension implements GenerationConfig {
        |removeOldOutput = ${removeOldOutput}
        |outputEncoding = ${outputEncoding}
        |useJodaDates = ${useJodaDates}
+       |useJodaLocalDates = ${useJodaLocalDates}
+       |useJodaLocalTimes = ${useJodaLocalTimes}
        |useCommonsLang3 = ${useCommonsLang3}
        |initializeCollections = ${initializeCollections}
        |classNamePrefix = ${classNamePrefix}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
@@ -88,22 +88,22 @@ public class DefaultIT {
     }
 
     @Test
-    public void dateAsMillisecPropertyHasCorrectDefaultValue() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+    public void dateTimeAsMillisecPropertyHasCorrectDefaultValue() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
         Object instance = classWithDefaults.newInstance();
 
-        Method getter = classWithDefaults.getMethod("getDateWithDefault");
+        Method getter = classWithDefaults.getMethod("getDateTimeWithDefault");
 
         assertThat((Date) getter.invoke(instance), is(equalTo(new Date(123456789))));
 
     }
 
     @Test
-    public void dateAsStringPropertyHasCorrectDefaultValue() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+    public void dateTimeAsStringPropertyHasCorrectDefaultValue() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
         Object instance = classWithDefaults.newInstance();
 
-        Method getter = classWithDefaults.getMethod("getDateAsStringWithDefault");
+        Method getter = classWithDefaults.getMethod("getDateTimeAsStringWithDefault");
 
         assertThat((Date) getter.invoke(instance), is(equalTo(new Date(1298539523112L))));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
@@ -24,56 +24,156 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.junit.Test;
 
 public class JodaDatesIT {
 
     @Test
-    public void defaultDateTypeIsJavaUtilDate() throws ClassNotFoundException, IntrospectionException {
+    public void defaultTypesAreNotJoda() throws ClassNotFoundException, IntrospectionException {
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example");
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
 
-        Method getter = new PropertyDescriptor("stringAsDateTime", classWithDate).getReadMethod();
+        List<String[]> nonJodaTypes = Arrays.asList(
+            new String[] {"stringAsDateTime", "java.util.Date"},
+            new String[] {"stringAsDate", "java.lang.String"},
+            new String[] {"stringAsTime", "java.lang.String"}
+        );
 
-        assertThat(getter.getReturnType().getName(), is("java.util.Date"));
+        for (String[] nonJodaType : nonJodaTypes) {
+            assertTypeIsExpected(classWithDate, nonJodaType[0], nonJodaType[1]);
+        }
     }
 
     @Test
     public void useJodaDatesCausesJodaDateTimeDates() throws IntrospectionException, ClassNotFoundException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example", config("useJodaDates", true));
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("useJodaDates", true));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
 
-        Method getter = new PropertyDescriptor("stringAsDateTime", classWithDate).getReadMethod();
-
-        assertThat(getter.getReturnType().getName(), is("org.joda.time.DateTime"));
+        assertTypeIsExpected(classWithDate, "stringAsDateTime", "org.joda.time.DateTime");
     }
 
     @Test
     public void disablingJodaDatesCausesJavaUtilDates() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example", config("useJodaDates", false));
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("useJodaDates", false));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
 
-        Method getter = new PropertyDescriptor("stringAsDateTime", classWithDate).getReadMethod();
+        assertTypeIsExpected(classWithDate, "stringAsDateTime", "java.util.Date");
+    }
 
-        assertThat(getter.getReturnType().getName(), is("java.util.Date"));
+    @Test
+    public void useJodaLocalDatesCausesJodaLocalDateDates() throws IntrospectionException, ClassNotFoundException {
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example", config
+                ("useJodaLocalDates", true));
+
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+
+        assertTypeIsExpected(classWithDate, "stringAsDate", "org.joda.time.LocalDate");
+    }
+
+    @Test
+    public void disablingJodaLocalDatesCausesStrings() throws ClassNotFoundException, IntrospectionException {
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("useJodaLocalDates", false));
+
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+
+        assertTypeIsExpected(classWithDate, "stringAsDate", "java.lang.String");
+    }
+
+    @Test
+    public void useJodaLocalTimesCausesJodaLocalTimeDates() throws IntrospectionException, ClassNotFoundException {
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("useJodaLocalTimes", true));
+
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+
+        assertTypeIsExpected(classWithDate, "stringAsTime", "org.joda.time.LocalTime");
+    }
+
+    @Test
+    public void disablingJodaLocalTimesCausesStrings() throws ClassNotFoundException, IntrospectionException {
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("useJodaLocalTimes", false));
+
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+
+        assertTypeIsExpected(classWithDate, "stringAsTime", "java.lang.String");
     }
 
     @Test
     public void useJodaDatesCausesDateTimeDefaultValues() throws ClassNotFoundException, IntrospectionException, InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
-        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example", config("useJodaDates", true));
+        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+                config("useJodaDates", true));
 
         Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
 
         Object instance = classWithDefaults.newInstance();
 
-        Method getter = classWithDefaults.getMethod("getDateWithDefault");
+        Method getter = classWithDefaults.getMethod("getDateTimeWithDefault");
 
         assertThat((DateTime) getter.invoke(instance), is(equalTo(new DateTime(123456789))));
+    }
+
+    @Test
+    public void useJodaDatesCausesDateTimeAsStringDefaultValues() throws ClassNotFoundException,
+            IntrospectionException, InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
+        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+                config("useJodaDates", true));
+
+        Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
+
+        Object instance = classWithDefaults.newInstance();
+
+        Method getter = classWithDefaults.getMethod("getDateTimeAsStringWithDefault");
+
+        assertThat((DateTime) getter.invoke(instance), is(equalTo(new DateTime("2011-02-24T09:25:23.112+0000"))));
+    }
+
+    @Test
+    public void useJodaLocalDatesCausesLocalDateDefaultValues() throws ClassNotFoundException, IntrospectionException,
+            InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
+        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+                config("useJodaLocalDates", true));
+
+        Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
+
+        Object instance = classWithDefaults.newInstance();
+
+        Method getter = classWithDefaults.getMethod("getDateAsStringWithDefault");
+
+        assertThat((LocalDate) getter.invoke(instance), is(equalTo(new LocalDate("2015-03-04"))));
+    }
+
+    @Test
+    public void useJodaLocalTimesCausesLocalTimeDefaultValues() throws ClassNotFoundException, IntrospectionException,
+            InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
+        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+                config("useJodaLocalTimes", true));
+
+        Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
+
+        Object instance = classWithDefaults.newInstance();
+
+        Method getter = classWithDefaults.getMethod("getTimeAsStringWithDefault");
+
+        assertThat((LocalTime) getter.invoke(instance), is(equalTo(new LocalTime("16:15:00"))));
+    }
+
+    private void assertTypeIsExpected(Class<?> classInstance, String propertyName, String expectedType)
+            throws IntrospectionException {
+        Method getter = new PropertyDescriptor(propertyName, classInstance).getReadMethod();
+        assertThat(getter.getReturnType().getName(), is(expectedType));
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/ant/build.xml
+++ b/jsonschema2pojo-integration-tests/src/test/resources/ant/build.xml
@@ -38,6 +38,8 @@
                          includeJsr303Annotations="true"
                          classpathRef="custom.libs"
                          useJodaDates="true"
+                         useJodaLocalDates="true"
+                         useJodaLocalTimes="true"
                          useCommonsLang3="true"
                          initializeCollections="false">
             <classpath>

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/default/default.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/default/default.json
@@ -17,15 +17,25 @@
             "type" : "boolean",
             "default" : true
         },
-        "dateWithDefault" : {
+        "dateTimeWithDefault" : {
             "type" : "string",
             "format" : "date-time",
             "default" : 123456789
         },
-        "dateAsStringWithDefault" : {
+        "dateTimeAsStringWithDefault" : {
             "type" : "string",
             "format" : "date-time",
             "default" : "2011-02-24T09:25:23.112+0000"
+        },
+        "dateAsStringWithDefault" : {
+            "type" : "string",
+            "format" : "date",
+            "default" : "2015-03-04"
+        },
+        "timeAsStringWithDefault" : {
+            "type" : "string",
+            "format" : "time",
+            "default" : "16:15:00"
         },
         "utcmillisecWithDefault" : {
             "type" : "integer",

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -312,6 +312,26 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean useJodaDates = false;
 
     /**
+     * Whether to use {@link org.joda.time.LocalDate} instead of string
+     * when adding string type fields of format date (not date-time) to
+     * generated Java types.
+     *
+     * @parameter expression="${jsonschema2pojo.useJodaLocalDates}" default="false"
+     * @since 0.4.9
+     */
+    private boolean useJodaLocalDates = false;
+
+    /**
+     * Whether to use {@link org.joda.time.LocalTime} instead of string
+     * when adding string type fields of format time (not date-time) to
+     * generated Java types.
+     *
+     * @parameter expression="${jsonschema2pojo.useJodaLocalTimes}" default="false"
+     * @since 0.4.9
+     */
+    private boolean useJodaLocalTimes = false;
+
+    /**
      * Whether to use commons-lang 3.x imports instead of commons-lang 2.x
      * imports when adding equals, hashCode and toString methods.
      * 
@@ -567,6 +587,16 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isUseJodaDates() {
         return useJodaDates;
+    }
+
+    @Override
+    public boolean isUseJodaLocalDates() {
+        return useJodaLocalDates;
+    }
+
+    @Override
+    public boolean isUseJodaLocalTimes() {
+        return useJodaLocalTimes;
     }
 
     @Override


### PR DESCRIPTION
https://github.com/joelittlejohn/jsonschema2pojo/issues/298

I'm pretty sure I covered everything here. I added 2 new config flags - useJodaLocalDates and useJodaLocalTimes. If those are set to true, and the schema is type string with format date or format time, the generated class properties will have types of LocalDate and LocalTime, respectively.

I've run the integration tests, and manually packaged a test version, using the maven plugin in my application to use this version, and verified that the class gets generated correctly.