### PR TITLE
Use refschema rather than parent to resolvRef's in PropertyRule.

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -129,7 +129,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         if (node.has("$ref")) {
             Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText());
             JsonNode refNode = refSchema.getContent();
-            return resolveRefs(refNode, parent);
+            return resolveRefs(refNode, refSchema);
         } else {
             return node;
         }


### PR DESCRIPTION
This change resolves an issue I've been having locally, where using a $ref to local definitions does not work.

The issue: https://github.com/joelittlejohn/jsonschema2pojo/issues/321
