### PR TITLE
Adding support for required array from http://tools.ietf.org/html/draft-...

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NameHelper.java
@@ -20,6 +20,7 @@ import static java.lang.Character.*;
 import static javax.lang.model.SourceVersion.isKeyword;
 import static org.apache.commons.lang3.StringUtils.*;
 
+import com.sun.codemodel.JType;
 import org.apache.commons.lang3.text.WordUtils;
 
 import org.jsonschema2pojo.GenerationConfig;
@@ -81,5 +82,41 @@ public class NameHelper {
         }
 
         return jsonFieldName;
+    }
+
+
+    /**
+     * Generate setter method name for property. 
+     * @param propertyName
+     * @return
+     */
+    public String getSetterName(String propertyName) {
+        propertyName = replaceIllegalCharacters(propertyName);
+        String setterName = "set" + capitalize(capitalizeTrailingWords(propertyName));
+
+        if (setterName.equals("setClass")) {
+            setterName = "setClass_";
+        }
+
+        return setterName;
+    }
+
+
+    /**
+     * Generate getter method name for property.
+     * @param propertyName
+     * @param type
+     * @return
+     */
+    public String getGetterName(String propertyName, JType type) {
+        String prefix = type.equals(type.owner()._ref(boolean.class)) ? "is" : "get";
+        propertyName = replaceIllegalCharacters(propertyName);
+        String getterName = prefix + capitalize(capitalizeTrailingWords(propertyName));
+
+        if (getterName.equals("getClass")) {
+            getterName = "getClass_";
+        }
+
+        return getterName;
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -124,6 +124,10 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         ruleFactory.getAdditionalPropertiesRule().apply(nodeName, node.get("additionalProperties"), jclass, schema);
+        
+        if (node.has("required")) {
+            ruleFactory.getRequiredArrayRule().apply(nodeName, node.get("required"), jclass, schema);
+        }
 
         if (ruleFactory.getGenerationConfig().isIncludeHashcodeAndEquals()) {
             addHashCode(jclass);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -182,32 +182,17 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         return builder;
     }
 
-    private String getSetterName(String propertyName) {
-        propertyName = ruleFactory.getNameHelper().replaceIllegalCharacters(propertyName);
-        String setterName = "set" + capitalize(ruleFactory.getNameHelper().capitalizeTrailingWords(propertyName));
-
-        if (setterName.equals("setClass")) {
-            setterName = "setClass_";
-        }
-
-        return setterName;
-    }
-
     private String getBuilderName(String propertyName) {
         propertyName = ruleFactory.getNameHelper().replaceIllegalCharacters(propertyName);
         return "with" + capitalize(ruleFactory.getNameHelper().capitalizeTrailingWords(propertyName));
     }
 
+    private String getSetterName(String propertyName) {
+        return ruleFactory.getNameHelper().getSetterName(propertyName);
+    }
+
     private String getGetterName(String propertyName, JType type) {
-        String prefix = type.equals(type.owner()._ref(boolean.class)) ? "is" : "get";
-        propertyName = ruleFactory.getNameHelper().replaceIllegalCharacters(propertyName);
-        String getterName = prefix + capitalize(ruleFactory.getNameHelper().capitalizeTrailingWords(propertyName));
-
-        if (getterName.equals("getClass")) {
-            getterName = "getClass_";
-        }
-
-        return getterName;
+        return ruleFactory.getNameHelper().getGetterName(propertyName, type);
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.*;
+import org.jsonschema2pojo.Schema;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.capitalize;
+
+/**
+ * Applies the "required" JSON schema rule.
+ *
+ * @see <a
+ * href="http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3">http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3</a>
+ */
+public class RequiredArrayRule implements Rule<JDefinedClass, JDefinedClass> {
+
+    private final RuleFactory ruleFactory;
+
+    public static final String REQUIRED_COMMENT_TEXT = "\n(Required)";
+
+    protected RequiredArrayRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    @Override
+    public JDefinedClass apply(String nodeName, JsonNode node, JDefinedClass jclass, Schema schema) {
+        List<String> requiredFieldMethods = new ArrayList<String>();
+
+        for (Iterator iterator = node.elements(); iterator.hasNext(); ) {
+            String fieldName = ((JsonNode) iterator.next()).asText();
+            JFieldVar field = jclass.fields().get(fieldName);
+
+            if (field == null) {
+                continue;
+            }
+
+            addJavaDoc(field);
+
+            if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
+                addNotNullAnnotation(field);
+            }
+
+            requiredFieldMethods.add(getGetterName(fieldName, field.type()));
+            requiredFieldMethods.add(getSetterName(fieldName));
+        }
+
+        updateGetterSetterJavaDoc(jclass, requiredFieldMethods);
+
+        return jclass;
+    }
+
+    private void updateGetterSetterJavaDoc(JDefinedClass jclass, List<String> requiredFieldMethods) {
+        for (Iterator methods = jclass.methods().iterator(); methods.hasNext(); ) {
+            JMethod method = (JMethod) methods.next();
+            if (requiredFieldMethods.contains(method.name())) {
+                addJavaDoc(method);
+            }
+        }
+    }
+
+    private void addNotNullAnnotation(JFieldVar field) {
+        field.annotate(NotNull.class);
+    }
+
+
+    private void addJavaDoc(JDocCommentable docCommentable) {
+        JDocComment javadoc = docCommentable.javadoc();
+        javadoc.append(REQUIRED_COMMENT_TEXT);
+    }
+
+    private String getSetterName(String propertyName) {
+        return ruleFactory.getNameHelper().getSetterName(propertyName);
+    }
+
+    private String getGetterName(String propertyName, JType type) {
+        return ruleFactory.getNameHelper().getGetterName(propertyName, type);
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -121,6 +121,14 @@ public class RuleFactory {
     }
 
     /**
+     * Provides a rule instance that should be applied when a "required"
+     * declaration is found in the schema.
+     *
+     * @return a schema rule that can handle the "required" declaration.
+     */
+    public Rule<JDefinedClass, JDefinedClass> getRequiredArrayRule() { return new RequiredArrayRule(this); }
+
+    /**
      * Provides a rule instance that should be applied when a "properties"
      * declaration is found in the schema.
      * 
@@ -150,6 +158,7 @@ public class RuleFactory {
     public Rule<JDocCommentable, JDocComment> getRequiredRule() {
         return new RequiredRule(this);
     }
+    
 
     /**
      * Provides a rule instance that should be applied to a node to find its

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.sun.codemodel.*;
+import org.jsonschema2pojo.GenerationConfig;
+import org.junit.Test;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequiredArrayRuleTest {
+
+    private static final String TARGET_CLASS_NAME = RequiredArrayRuleTest.class.getName() + ".DummyClass";
+
+    private RequiredArrayRule rule = new RequiredArrayRule(new RuleFactory());
+
+    @Test
+    public void shouldUpdateJavaDoc() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        jclass.field(JMod.PRIVATE, jclass.owner().ref(String.class), "fooBar");
+        jclass.field(JMod.PRIVATE, jclass.owner().ref(String.class), "foo");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode requiredNode = mapper.createArrayNode().add("fooBar");
+
+        rule.apply("Class", requiredNode, jclass, null);
+
+        JDocComment fooBarJavaDoc = jclass.fields().get("fooBar").javadoc();
+        JDocComment fooJavaDoc = jclass.fields().get("foo").javadoc();
+
+
+        assertThat(fooBarJavaDoc.size(), is(1));
+        assertThat((String) fooBarJavaDoc.get(0), is(RequiredRule.REQUIRED_COMMENT_TEXT));
+
+        assertThat(fooJavaDoc.size(), is(0));
+    }
+
+
+    @Test
+    public void shouldUpdateAnnotations() throws JClassAlreadyExistsException {
+        setupRuleFactoryToIncludeJsr303();
+        
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        jclass.field(JMod.PRIVATE, jclass.owner().ref(String.class), "fooBar");
+        jclass.field(JMod.PRIVATE, jclass.owner().ref(String.class), "foo");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode requiredNode = mapper.createArrayNode().add("fooBar");
+
+        rule.apply("Class", requiredNode, jclass, null);
+
+        Collection<JAnnotationUse> fooBarAnnotations = jclass.fields().get("fooBar").annotations();
+        Collection<JAnnotationUse> fooAnnotations = jclass.fields().get("foo").annotations();
+
+        assertThat(fooBarAnnotations.size(), is(1));
+        assertThat(fooBarAnnotations.iterator().next().getAnnotationClass().name(), is(NotNull.class.getSimpleName()));
+
+        assertThat(fooAnnotations.size(), is(0));
+    }
+    
+    private void setupRuleFactoryToIncludeJsr303() {
+        GenerationConfig config = mock(GenerationConfig.class);
+        RuleFactory ruleFactory = new RuleFactory();
+        ruleFactory.setGenerationConfig(config);
+        rule = new RequiredArrayRule(ruleFactory);
+        when(config.isIncludeJsr303Annotations()).thenReturn(true);
+    }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredRuleTest.java
@@ -30,7 +30,7 @@ import com.sun.codemodel.JDocComment;
 
 public class RequiredRuleTest {
 
-    private static final String TARGET_CLASS_NAME = ArrayRuleTest.class.getName() + ".DummyClass";
+    private static final String TARGET_CLASS_NAME = RequiredRuleTest.class.getName() + ".DummyClass";
 
     private RequiredRule rule = new RequiredRule(new RuleFactory());
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaField;
+import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.Type;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.compile;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generate;
+import static org.junit.Assert.assertThat;
+
+public class RequiredArrayIT extends RequiredIT {
+
+    private static JavaClass classWithRequired;
+
+    @BeforeClass
+    public static void generateClasses() throws ClassNotFoundException, IOException {
+
+        File outputDirectory = generate("/schema/required/requiredArray.json", "com.example");
+        File generatedJavaFile = new File(outputDirectory, "com/example/RequiredArray.java");
+
+        compile(outputDirectory);
+
+        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        javaDocBuilder.addSource(generatedJavaFile);
+
+        classWithRequired = javaDocBuilder.getClassByName("com.example.RequiredArray");
+    }
+
+    @Test
+    public void requiredAppearsInFieldJavadoc() throws IOException {
+
+        JavaField javaField = classWithRequired.getFieldByName("requiredProperty");
+        String javaDocComment = javaField.getComment();
+
+        assertThat(javaDocComment, containsString("(Required)"));
+
+    }
+
+    @Test
+    public void requiredAppearsInGetterJavadoc() throws IOException {
+
+        JavaMethod javaMethod = classWithRequired.getMethodBySignature("getRequiredProperty", new Type[] {});
+        String javaDocComment = javaMethod.getComment();
+
+        assertThat(javaDocComment, containsString("(Required)"));
+
+    }
+
+    @Test
+    public void requiredAppearsInSetterJavadoc() throws IOException {
+
+        JavaMethod javaMethod = classWithRequired.getMethodBySignature("setRequiredProperty", new Type[] { new Type("java.lang.String") });
+        String javaDocComment = javaMethod.getComment();
+
+        assertThat(javaDocComment, containsString("(Required)"));
+
+    }
+
+    @Test
+    public void nonRequiredFiedHasNoRequiredText() throws IOException {
+
+        JavaField javaField = classWithRequired.getFieldByName("nonRequiredProperty");
+        String javaDocComment = javaField.getComment();
+
+        assertThat(javaDocComment, not(containsString("(Required)")));
+
+    }
+
+    @Test
+    public void notRequiredIsTheDefault() throws IOException {
+
+        JavaField javaField = classWithRequired.getFieldByName("defaultNotRequiredProperty");
+        String javaDocComment = javaField.getComment();
+
+        assertThat(javaDocComment, not(containsString("(Required)")));
+
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredArray.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredArray.json
@@ -1,0 +1,15 @@
+{
+    "type" : "object",
+    "properties" : {
+        "requiredProperty" : {
+            "type" : "string"
+        },
+        "nonRequiredProperty" : {
+            "type" : "string"
+        },
+        "defaultNotRequiredProperty" : {
+            "type" : "string"
+        }
+    },
+    "required": [ "requiredProperty"]
+}


### PR DESCRIPTION
Adding support for required array from http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3

As described under https://github.com/joelittlejohn/jsonschema2pojo/issues/323 

In json_schema v4, the idiomatic way to do required properties is with a required array at the end of the object:

```javascript
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "$ref": "#/definitions/abc",
  "id": "resource:///json_schema/match/abc.json#",
  "definitions": {
    "abc": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string"
        },
        "age": {
          "type": "string"
        }
      },
      "required": ["name", "age"]
    }
  }
}
```
