### PR TITLE
Corrected Exclude Pattern Behavior with Maven.

### DIFF
--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
@@ -19,6 +19,12 @@ package org.jsonschema2pojo.integration.filtering;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -27,11 +33,34 @@ import org.junit.Test;
  * @author Christian Trimble
  */
 public class FilteringIT {
+    URL filteredSchemaUrl;
+    
+    @Before
+    public void setUp() throws MalformedURLException {
+        filteredSchemaUrl = new File("./src/test/resources/schema/filtering").toURI().toURL();
+    }
+
     @Test
     public void shouldFilterFiles() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/filtering", "com.example",
+        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example",
                 config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
 
         resultsClassLoader.loadClass("com.example.Included");
+    }
+    
+    @Test(expected=ClassNotFoundException.class)
+    public void shouldNotProcessExcludedFiles() throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example",
+                config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
+
+        resultsClassLoader.loadClass("com.example.Excluded");
+    }
+
+    @Test
+    public void shouldIncludeNestedFilesWithFiltering() throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example",
+                config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
+
+        resultsClassLoader.loadClass("com.example.sub.Sub");
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
@@ -34,10 +34,12 @@ import org.junit.Test;
  */
 public class FilteringIT {
     URL filteredSchemaUrl;
+    URL subSchemaUrl;
     
     @Before
     public void setUp() throws MalformedURLException {
         filteredSchemaUrl = new File("./src/test/resources/schema/filtering").toURI().toURL();
+        subSchemaUrl = new File("./src/test/resources/schema/filtering/sub").toURI().toURL();
     }
 
     @Test
@@ -62,5 +64,14 @@ public class FilteringIT {
                 config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
 
         resultsClassLoader.loadClass("com.example.sub.Sub");
+    }
+
+    @Test
+    public void shouldUseDefaultExcludesWithoutIncludesAndExcludes() throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile(subSchemaUrl, "com.example.sub",
+                config("includes", new String[] {}, "excludes", new String[] {}));
+
+        resultsClassLoader.loadClass("com.example.sub.Sub");
+        resultsClassLoader.loadClass("com.example.sub.sub2.Sub");
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
@@ -170,6 +170,14 @@ public class CodeGenerationHelper {
 
     }
 
+    public static ClassLoader generateAndCompile(URL schema, String targetPackage, Map<String, Object> configValues) {
+
+        File outputDirectory = generate(schema, targetPackage, configValues);
+
+        return compile(outputDirectory);
+
+    }
+
     public static File createTemporaryOutputFolder() {
 
         String tempDirectoryName = System.getProperty("java.io.tmpdir");

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/.svn/svn.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/.svn/svn.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "a schema that should be exluded.",
+    "description": "a location on s3",
     "type": "object",
     "properties": {
         "prop": {

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/.svn/sub.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/.svn/sub.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "a generic sub document",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/sub.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/sub.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "a schema that should be exluded.",
+    "description": "a generic sub document",
     "type": "object",
     "properties": {
         "prop": {

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/sub2/.svn/sub.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/sub2/.svn/sub.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "a generic sub document",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/sub2/sub.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/filtering/sub/sub2/sub.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "a generic sub document",
+    "type": "object",
+    "properties": {
+        "prop": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -472,10 +472,14 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
             throw new MojoExecutionException("One of sourceDirectory or sourcePaths must be provided");
         }
 
-        if (filteringEnabled()) {
+        if (filteringEnabled() || (sourceDirectory != null && sourcePaths == null) ) {
 
             if (sourceDirectory == null) {
                 throw new MojoExecutionException("Source includes and excludes require the sourceDirectory property");
+            }
+
+            if( sourcePaths != null ) {
+                throw new MojoExecutionException("Source includes and excludes are incompatible with the sourcePaths property");
             }
 
             fileFilter = createFileFilter();

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/MatchPatternsFileFilter.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/MatchPatternsFileFilter.java
@@ -113,7 +113,7 @@ public class MatchPatternsFileFilter implements FileFilter {
         try {
             String path = relativePath(file);
             return file.isDirectory() ?
-                    includePatterns.matchesPatternStart(path, caseSensitive) && !excludePatterns.matchesPatternStart(path, caseSensitive) :
+                    includePatterns.matchesPatternStart(path, caseSensitive) && !excludePatterns.matches(path, caseSensitive) :
                     includePatterns.matches(path, caseSensitive) && !excludePatterns.matches(path, caseSensitive);
         } catch (IOException e) {
             return false;

--- a/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
+++ b/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
@@ -73,6 +73,24 @@ public class MatchPatternsFileFilterTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void shouldIncludeMatchesAndDirectoriesWhenIncludingAndDefaultExcludes() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addIncludes(asList("**/*.json"))
+                .addDefaultExcludes()
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("all of the files were found.", asList(files),
+                hasItems(
+                        equalTo(file("sub1")),
+                        equalTo(file("excluded")),
+                        equalTo(file("example.json"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void shouldNoIncludedUnmatchedFiles() throws IOException {
         fileFilter = new MatchPatternsFileFilter.Builder()
                 .addIncludes(asList("**/*.json"))
@@ -123,6 +141,58 @@ public class MatchPatternsFileFilterTest {
         assertThat("the markdown file was not found.", asList(files), not(hasItem(file("excluded"))));
     }
 
+    @Test
+    public void ahouldNotExcludeRegularDirectoriesWithDefaultExcludes() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addDefaultExcludes()
+                .addIncludes(asList("**"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("the sub directory was not found.", asList(files), hasItem(file("excluded")));
+    }
+
+    @Test
+    public void shouldExcludeSvnDirectoriesWithDefaultExcludes() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addDefaultExcludes()
+                .addIncludes(asList("**"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = basedir.listFiles(fileFilter);
+
+        assertThat("the files in .svn directory were execluded.", asList(files), not(hasItems(file(".svn"))));
+    }
+
+    @Test
+    public void shouldExcludeFilesInSvnDirectoriesWithDefaultExcludes() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addDefaultExcludes()
+                .addIncludes(asList("**/*.json"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = new File(basedir, ".svn").listFiles(fileFilter);
+
+        assertThat("the files in .svn directory were execluded.", asList(files), not(hasItems(file("svn-file.json"))));
+    }
+
+    @Test
+    public void shouldExcludeNestedFilesInSvnDirectoriesWithDefaultExcludes() throws IOException {
+        fileFilter = new MatchPatternsFileFilter.Builder()
+                .addDefaultExcludes()
+                .addIncludes(asList("**/*.json"))
+                .withSourceDirectory(basedir.getCanonicalPath())
+                .build();
+
+        File[] files = new File(basedir, ".svn/sub").listFiles(fileFilter);
+
+        assertThat("the files in .svn directory were execluded.", asList(files), not(hasItems(file("sub-svn-file.json"))));
+    }
+    
     private File file(String relativePath) {
         return new File(basedir, relativePath);
     }

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/.svn/sub/sub-svn-file.json
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/.svn/sub/sub-svn-file.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "a schema that should be exluded.",
     "type": "object",
     "properties": {
         "prop": {

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/.svn/svn-file.json
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/schema/.svn/svn-file.json
@@ -1,10 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "a schema that should be exluded.",
     "type": "object",
     "properties": {
-        "prop": {
-            "type": "string"
+        "subProp": {
+            "$ref": "sub/sub-svn-file.json"
         }
     }
 }


### PR DESCRIPTION
The default set of exclude directories was causing all files to be excluded.  This corrects that issue and adds tests related to the default exclude list.  This is related to #332.

This PR also adds the default set of maven excludes anytime the sourceDirectory property is supplied without the sourcePaths property.