### PR TITLE
Allow empty package names

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
@@ -18,6 +18,8 @@ package org.jsonschema2pojo;
 
 import com.sun.codemodel.CodeWriter;
 import com.sun.codemodel.JCodeModel;
+
+import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -28,7 +30,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
 import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import org.apache.commons.io.FilenameUtils;
 import org.jsonschema2pojo.exception.GenerationException;
@@ -111,9 +115,13 @@ public class Jsonschema2Pojo {
             if (child.isFile()) {
                 mapper.generate(codeModel, getNodeName(child.toURI().toURL()), defaultString(packageName), child.toURI().toURL());
             } else {
-                generateRecursive(config, mapper, codeModel, packageName + "." + child.getName(), Arrays.asList(child.listFiles(config.getFileFilter())));
+                generateRecursive(config, mapper, codeModel, childQualifiedName(packageName, child.getName()), Arrays.asList(child.listFiles(config.getFileFilter())));
             }
         }
+    }
+    
+    private static String childQualifiedName( String parentQualifiedName, String childSimpleName ) {
+        return isEmpty(parentQualifiedName) ? childSimpleName : parentQualifiedName + "." + childSimpleName;
     }
 
     private static void removeOldOutput(File targetDirectory) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/EmptyPackageNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/EmptyPackageNameIT.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright ¬© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
+
+import org.junit.Test;
+
+public class EmptyPackageNameIT {
+    @Test
+    public void shouldAllowEmptyPackageName() throws ClassNotFoundException {
+        ClassLoader resultsClassLoader = generateAndCompile("/schema/emptyPackageName", "",
+                config("includes", new String[] {}, "excludes", new String[] {}));
+
+        resultsClassLoader.loadClass("LevelZeroType");
+        resultsClassLoader.loadClass("levelOne.LevelOneType");
+        resultsClassLoader.loadClass("levelOne.levelTwo.LevelTwoType");
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/emptyPackageName/levelOne/levelOneType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/emptyPackageName/levelOne/levelOneType.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A schema at the first level of packaging.",
+  "type": "object",
+  "properties": {
+    "name": {
+    	"type": "string"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/emptyPackageName/levelOne/levelTwo/levelTwoType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/emptyPackageName/levelOne/levelTwo/levelTwoType.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A schema at the second level of packaging.",
+  "type": "object",
+  "properties": {
+    "name": {
+    	"type": "string"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/emptyPackageName/levelZeroType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/emptyPackageName/levelZeroType.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A schema in the root package.",
+  "type": "object",
+  "properties": {
+    "name": {
+    	"type": "string"
+    }
+  }
+}


### PR DESCRIPTION
This PR corrects an issue where the `targetPackage` is empty and source files were being generated with a `package .;` statement.

This update has the following known limitation:  If the source directory contains a directory that is a java keyword, like `/default`, then the generated source will be invalid.  Not sure if handling key words should be part of this PR or another.