### PR TITLE
Multiple enum array properties with same name cause JClassAlreadyExistsException

### DIFF
--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
+import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.util.NameHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EnumRuleTest {
+
+    private Schema schema = mock(Schema.class);
+    private NameHelper nameHelper = mock(NameHelper.class);
+    private Annotator annotator = mock(Annotator.class);
+    private RuleFactory ruleFactory = mock(RuleFactory.class);
+
+    private EnumRule rule = new EnumRule(ruleFactory);
+
+    @Before
+    public void wireUpConfig() {
+        when(ruleFactory.getNameHelper()).thenReturn(nameHelper);
+        when(ruleFactory.getAnnotator()).thenReturn(annotator);
+    }
+
+    @Test
+    public void applyGeneratesUniqueEnumNamesForMultipleEnumNodesWithSameName() {
+
+        Answer<String> firstArgAnswer = new FirstArgAnswer<String>();
+        when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
+        when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ArrayNode arrayNode = objectMapper.createArrayNode();
+        arrayNode.add("open");
+        arrayNode.add("closed");
+        ObjectNode enumNode = objectMapper.createObjectNode();
+        enumNode.put("type", "string");
+        enumNode.put("enum", arrayNode);
+
+        JType result1 = rule.apply("status", enumNode, jpackage, schema);
+        JType result2 = rule.apply("status", enumNode, jpackage, schema);
+
+        assertThat(result1.fullName(), is("org.jsonschema2pojo.rules.Status"));
+        assertThat(result2.fullName(), is("org.jsonschema2pojo.rules.Status_"));
+    }
+
+    private static class FirstArgAnswer<T> implements Answer<T> {
+        @Override
+        public T answer(InvocationOnMock invocation) throws Throwable {
+            Object[] args = invocation.getArguments();
+            //noinspection unchecked
+            return (T) args[0];
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -168,6 +168,16 @@ public class EnumIT {
     }
 
     @Test
+    public void multipleEnumArraysWithSameName() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/multipleEnumArraysWithSameName.json", "com.example");
+
+        resultsClassLoader.loadClass("com.example.MultipleEnumArraysWithSameName");
+        resultsClassLoader.loadClass("com.example.Status");
+        resultsClassLoader.loadClass("com.example.Status_");
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void jacksonCanMarshalEnums() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException, IOException {
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/multipleEnumArraysWithSameName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/multipleEnumArraysWithSameName.json
@@ -1,0 +1,35 @@
+{
+    "type": "object",
+    "properties": {
+        "foo": {
+            "type": "object",
+            "properties": {
+                "statuses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "open",
+                            "closed"
+                        ]
+                    }
+                }
+            }
+        },
+        "bar": {
+            "type": "object",
+            "properties": {
+                "statuses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "open",
+                            "closed"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The following Json causes JClassAlreadyExistsException
```javascript
{
    "type": "object",
    "properties": {
        "foo": {
            "type": "object",
            "properties": {
                "statuses": {
                    "type": "array",
                    "items": {
                        "type": "string",
                        "enum": [
                            "open",
                            "closed"
                        ]
                    }
                }
            }
        },
        "bar": {
            "type": "object",
            "properties": {
                "statuses": {
                    "type": "array",
                    "items": {
                        "type": "string",
                        "enum": [
                            "open",
                            "closed"
                        ]
                    }
                }
            }
        }
    }
}
```
In this case, as the enum item is inside arrays, the enum class is generated at the package level. If there are multiple enum properties with same name, there is a name collision. Changed the EnumRule code to append _ to the Enum name, if a class by that name is already found.