### PR TITLE
Fix for equals method triggering warning in sonarqube

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -382,8 +382,9 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         JBlock body = equals.body();
 
+        body._if(otherObject.eq(JExpr._null()))._then()._return(JExpr.FALSE);
         body._if(otherObject.eq(JExpr._this()))._then()._return(JExpr.TRUE);
-        body._if(otherObject._instanceof(jclass).eq(JExpr.FALSE))._then()._return(JExpr.FALSE);
+        body._if(otherObject.invoke("getClass").ne(JExpr._this().invoke("getClass")))._then()._return(JExpr.FALSE);
 
         JVar rhsVar = body.decl(jclass, "rhs").init(JExpr.cast(jclass, otherObject));
         JClass equalsBuilderClass = jclass.owner().ref(equalsBuilder);


### PR DESCRIPTION
fix for issue #415

Updated the equals method generated so that it compares getClass of this and other instead of using instanceof which can break on subclasses