### PR TITLE
adding "required" attribute to JsonProperty annotation

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
@@ -42,11 +42,11 @@ public abstract class AbstractAnnotator implements Annotator {
     }
 
     @Override
-    public void propertyGetter(JMethod getter, String propertyName) {
+    public void propertyGetter(JMethod getter, String propertyName, JsonNode propertyNode) {
     }
 
     @Override
-    public void propertySetter(JMethod setter, String propertyName) {
+    public void propertySetter(JMethod setter, String propertyName, JsonNode propertyNode) {
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
@@ -73,8 +73,10 @@ public interface Annotator {
      *            JSON property
      * @param propertyName
      *            the name of the JSON property that this getter gets
+     * @param propertyNode
+     *            the schema node defining this property
      */
-    void propertyGetter(JMethod getter, String propertyName);
+    void propertyGetter(JMethod getter, String propertyName, JsonNode propertyNode);
 
     /**
      * Add the necessary annotation to mark a Java method as the setter for a
@@ -85,8 +87,10 @@ public interface Annotator {
      *            JSON property
      * @param propertyName
      *            the name of the JSON property that this setter sets
+     * @param propertyNode
+     *            the schema node defining this property
      */
-    void propertySetter(JMethod setter, String propertyName);
+    void propertySetter(JMethod setter, String propertyName, JsonNode propertyNode);
 
     /**
      * Add the necessary annotation to mark a Java method as the getter for

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
@@ -65,16 +65,16 @@ public class CompositeAnnotator implements Annotator {
     }
 
     @Override
-    public void propertyGetter(JMethod getter, String propertyName) {
+    public void propertyGetter(JMethod getter, String propertyName, JsonNode propertyNode) {
         for (Annotator annotator : annotators) {
-            annotator.propertyGetter(getter, propertyName);
+            annotator.propertyGetter(getter, propertyName, propertyNode);
         }
     }
 
     @Override
-    public void propertySetter(JMethod setter, String propertyName) {
+    public void propertySetter(JMethod setter, String propertyName, JsonNode propertyNode) {
         for (Annotator annotator : annotators) {
-            annotator.propertySetter(setter, propertyName);
+            annotator.propertySetter(setter, propertyName, propertyNode);
         }
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
@@ -72,12 +72,12 @@ public class Jackson1Annotator extends AbstractAnnotator {
     }
 
     @Override
-    public void propertyGetter(JMethod getter, String propertyName) {
+    public void propertyGetter(JMethod getter, String propertyName, JsonNode propertyNode) {
         getter.annotate(JsonProperty.class).param("value", propertyName);
     }
 
     @Override
-    public void propertySetter(JMethod setter, String propertyName) {
+    public void propertySetter(JMethod setter, String propertyName, JsonNode propertyNode) {
         setter.annotate(JsonProperty.class).param("value", propertyName);
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -61,7 +61,10 @@ public class Jackson2Annotator extends AbstractAnnotator {
 
     @Override
     public void propertyField(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
-        field.annotate(JsonProperty.class).param("value", propertyName);
+        field.annotate(JsonProperty.class)
+                .param("value", propertyName)
+                .param("required", propertyNode.has("required") && propertyNode.get("required").asBoolean());
+
         if (field.type().erasure().equals(field.type().owner().ref(Set.class))) {
             field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
         }
@@ -73,13 +76,18 @@ public class Jackson2Annotator extends AbstractAnnotator {
     }
 
     @Override
-    public void propertyGetter(JMethod getter, String propertyName) {
-        getter.annotate(JsonProperty.class).param("value", propertyName);
+    public void propertyGetter(JMethod getter, String propertyName, JsonNode propertyNode) {
+        getter.annotate(JsonProperty.class)
+                .param("value", propertyName)
+                .param("required", propertyNode.has("required") && propertyNode.get("required").asBoolean());
+
     }
 
     @Override
-    public void propertySetter(JMethod setter, String propertyName) {
-        setter.annotate(JsonProperty.class).param("value", propertyName);
+    public void propertySetter(JMethod setter, String propertyName, JsonNode propertyNode) {
+        setter.annotate(JsonProperty.class)
+                .param("value", propertyName)
+                .param("required", propertyNode.has("required") && propertyNode.get("required").asBoolean());
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -82,10 +82,10 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         ruleFactory.getAnnotator().propertyField(field, jclass, nodeName, node);
 
         if (ruleFactory.getGenerationConfig().isIncludeAccessors()) {
-            JMethod getter = addGetter(jclass, field, nodeName);
+            JMethod getter = addGetter(jclass, field, nodeName, node);
             propertyAnnotations(nodeName, node, schema, getter);
 
-            JMethod setter = addSetter(jclass, field, nodeName);
+            JMethod setter = addSetter(jclass, field, nodeName, node);
             propertyAnnotations(nodeName, node, schema, setter);
         }
 
@@ -144,7 +144,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         return node.path("type").asText().equals("array");
     }
 
-    private JMethod addGetter(JDefinedClass c, JFieldVar field, String jsonPropertyName) {
+    private JMethod addGetter(JDefinedClass c, JFieldVar field, String jsonPropertyName, JsonNode propertyNode) {
         JMethod getter = c.method(JMod.PUBLIC, field.type(), getGetterName(jsonPropertyName, field.type()));
 
         // add @returns
@@ -153,12 +153,12 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         JBlock body = getter.body();
         body._return(field);
 
-        ruleFactory.getAnnotator().propertyGetter(getter, jsonPropertyName);
+        ruleFactory.getAnnotator().propertyGetter(getter, jsonPropertyName, propertyNode);
 
         return getter;
     }
 
-    private JMethod addSetter(JDefinedClass c, JFieldVar field, String jsonPropertyName) {
+    private JMethod addSetter(JDefinedClass c, JFieldVar field, String jsonPropertyName, JsonNode propertyNode) {
         JMethod setter = c.method(JMod.PUBLIC, void.class, getSetterName(jsonPropertyName));
 
         // add @param
@@ -168,7 +168,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         JBlock body = setter.body();
         body.assign(JExpr._this().ref(field), param);
 
-        ruleFactory.getAnnotator().propertySetter(setter, jsonPropertyName);
+        ruleFactory.getAnnotator().propertySetter(setter, jsonPropertyName, propertyNode);
 
         return setter;
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -122,12 +122,12 @@ public class CustomAnnotatorIT {
         }
 
         @Override
-        public void propertyGetter(JMethod getter, String propertyName) {
+        public void propertyGetter(JMethod getter, String propertyName, JsonNode propertyNode) {
             getter.annotate(Deprecated.class);
         }
 
         @Override
-        public void propertySetter(JMethod setter, String propertyName) {
+        public void propertySetter(JMethod setter, String propertyName, JsonNode propertyNode) {
             setter.annotate(Deprecated.class);
         }
 


### PR DESCRIPTION
This adds "required=true" or "required=false" to @JsonProperty annotations on fields, getters and setters but unfortunately this ONLY works if the "required" flag is set on the individual property in the JSON schema. If using "required" array in the schema, that still is ignored. I don't know how to fix that. Hopefully, someone else does :)

So if you have this in your schema, this will add the "required" annotation attribute:

    "properties": {
        "msg": {
          "type": "string",
          "required": true
        }
    }

    but this will not:

      "required": ["msg"]