### PR TITLE
Fix path to jar in windows script for the case it is run not from home dir

### DIFF
--- a/jsonschema2pojo-cli/src/main/scripts/jsonschema2pojo.bat
+++ b/jsonschema2pojo-cli/src/main/scripts/jsonschema2pojo.bat
@@ -15,4 +15,4 @@
 @REM
 
 @echo off
-java -jar ${project.build.finalName}.jar %*
+java -jar "%~dp0${project.build.finalName}.jar" %*


### PR DESCRIPTION
Hi guys, I've run windows cli jsonschema2pojo.bat cli and it failed with error saying jar file is not found. Problem was that I've run the script not from jsonschema2pojo home, but from my own folder, and path to the jsonschema2pojo jar in the script is relative to jsonschema2pojo home.

Here's fix for the issue. I've changed relative path to the jar to absolute path, so now the windows cli runner works fine not just from jsonschema2pojo home.