### PR TITLE
Added support for custom date-time, date, time classes. 

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -124,7 +124,13 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private String targetVersion = "1.6";
 
     private boolean includeDynamicAccessors = true;
-
+    
+    private String dateTimeType = null;
+    
+    private String timeType = null;
+    
+    private String dateType = null;
+    
     /**
      * Execute this task (it's expected that all relevant setters will have been
      * called by Ant to provide task configuration <em>before</em> this method
@@ -763,4 +769,20 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public boolean isIncludeDynamicAccessors() {
         return includeDynamicAccessors;
     }
+
+    @Override
+    public String getDateTimeType() {
+        return dateTimeType;
+    }
+
+    @Override
+    public String getDateType() {
+        return dateType;
+    }
+
+    @Override
+    public String getTimeType() {
+        return timeType;
+    }
+
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -238,6 +238,21 @@
         <td valign="top">The target version for generated source files.</td>
         <td align="center" valign="top">No (default <code>1.6</code>)</td>
       </tr>
+      <tr>
+        <td valign="top">dateTimeType</td>
+        <td valign="top">Specify class to use i.e.<code>java.time.LocalDateTime</code> instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.</td>
+        <td align="center" valign="top">default <code>null</code></td>
+      </tr>
+      <tr>
+        <td valign="top">dateType</td>
+        <td valign="top">Specify class to use i.e.<code>java.time.LocalDate</code> instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.</td>
+        <td align="center" valign="top">default <code>null</code></td>
+      </tr>
+      <tr>
+        <td valign="top">timeType</td>
+        <td valign="top">Specify class to use i.e.<code>java.time.LocalTime</code> instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.</td>
+        <td align="center" valign="top">default <code>null</code></td>
+      </tr>
     </table>
 
     <h3>Examples</h3>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -111,6 +111,15 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-jt", "--joda-local-times" }, description = "Whether to use org.joda.time.LocalTime instead" + "of String when adding time type fields to generated Java types.")
     private boolean useJodaLocalTimes = false;
 
+    @Parameter(names = { "-dtt", "--datetime-class" }, description = "Specify datetime class")
+    private String dateTimeType = null;
+
+    @Parameter(names = { "-tt", "--time-class" }, description = "Specify time class")
+    private String timeType = null;
+
+    @Parameter(names = { "-dt", "--date-class" }, description = "Specify date class")
+    private String dateType = null;
+    
     @Parameter(names = { "-c3", "--commons-lang3" }, description = "Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals, hashCode and toString methods.")
     private boolean useCommonsLang3 = false;
 
@@ -335,6 +344,21 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isIncludeDynamicAccessors() {
         return !disableDynamicAccessors;
+    }
+
+    @Override
+    public String getDateTimeType() {
+        return dateTimeType;
+    }
+
+    @Override
+    public String getDateType() {
+        return dateType;
+    }
+
+    @Override
+    public String getTimeType() {
+        return timeType;
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -256,6 +256,21 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return true;
     }
 
+    @Override
+    public String getDateTimeType() {
+        return null;
+    }
+
+    @Override
+    public String getDateType() {
+        return null;
+    }
+
+    @Override
+    public String getTimeType() {
+        return null;
+    }
+
     /**
      * @return <code>1.6</code>
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -317,5 +317,32 @@ public interface GenerationConfig {
      *         or to omit these methods.
      */
     boolean isIncludeDynamicAccessors();
+    
+    
+    /**
+     * Allow to specifiy a class for date-time jsonschema type. Could be JSR310, Joda, ...  
+     * [org.joda.time.LocalDateTime,java.time.LocalDateTime, ...]
+     * java.time.* require JVM8 or greater
+     * @return
+     */
+    String getDateTimeType();
+    
+    
+    /**
+     * Allow to specifiy a class for date-time jsonschema type. Could be JSR310, Joda, ...  
+     * [org.joda.time.LocalDate,java.time.LocalDate, ...]
+     * java.time.* require JVM8 or greater
+     * @return
+     */
+    String getDateType();
+    
+    /**
+     * Allow to specifiy a class for date-time jsonschema type. Could be JSR310, Joda, ...  
+     * [org.joda.time.LocalTime,java.time.LocalTime, ...]
+     * java.time.* require JVM8 or greater
+     * @return
+     */
+    String getTimeType();
+        
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -128,14 +128,45 @@ public class FormatRule implements Rule<JType, JType> {
     }
 
     private Class<?> getDateTimeType() {
+        String type=ruleFactory.getGenerationConfig().getDateTimeType();
+        if (type!=null && type.length()>0){
+            try {
+                Class<?> clazz=Class.forName(type);
+                return clazz;
+            } 
+            catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            }
+        }
         return ruleFactory.getGenerationConfig().isUseJodaDates() ? DateTime.class : Date.class;
     }
 
     private Class<?> getDateOnlyType() {
+        String type=ruleFactory.getGenerationConfig().getDateType();
+        if (type!=null && type.length()>0){
+            try {
+                Class<?> clazz=Class.forName(type);
+                return clazz;
+            } 
+            catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            }
+            
+        }        
         return ruleFactory.getGenerationConfig().isUseJodaLocalDates() ? LocalDate.class : String.class;
     }
 
     private Class<?> getTimeOnlyType() {
+        String type=ruleFactory.getGenerationConfig().getTimeType();
+        if (type!=null && type.length()>0){
+            try {
+                Class<?> clazz=Class.forName(type);
+                return clazz;
+            } 
+            catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            }
+        }      
         return ruleFactory.getGenerationConfig().isUseJodaLocalTimes() ? LocalTime.class : String.class;
     }
 

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -59,6 +59,9 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean useJodaDates
   boolean useJodaLocalDates
   boolean useJodaLocalTimes
+  String dateTimeType
+  String dateType
+  String timeType
   boolean useLongIntegers
   boolean usePrimitives
   FileFilter fileFilter
@@ -85,6 +88,9 @@ public class JsonSchemaExtension implements GenerationConfig {
     useJodaDates = false
     useJodaLocalDates = false
     useJodaLocalTimes = false
+    dateTimeType = null
+    dateType = null
+    timeType = null
     useCommonsLang3 = false
     parcelable = false
     fileFilter = new AllFileFilter()
@@ -151,6 +157,9 @@ public class JsonSchemaExtension implements GenerationConfig {
        |useJodaDates = ${useJodaDates}
        |useJodaLocalDates = ${useJodaLocalDates}
        |useJodaLocalTimes = ${useJodaLocalTimes}
+       |dateTimeType = ${dateTimeType}
+       |dateType = ${dateType}
+       |timeType = ${timeType}
        |useCommonsLang3 = ${useCommonsLang3}
        |parcelable = ${parcelable}
        |initializeCollections = ${initializeCollections}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.Assert.*;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.junit.Test;
+
+public class CustomDatesIT {
+
+    @Test
+    public void defaultTypesAreNotCustom() throws ClassNotFoundException, IntrospectionException {
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example");
+
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+
+        List<String[]> nonJodaTypes = Arrays.asList(
+            new String[] {"stringAsDateTime", "java.util.Date"},
+            new String[] {"stringAsDate", "java.lang.String"},
+            new String[] {"stringAsTime", "java.lang.String"}
+        );
+
+        for (String[] nonJodaType : nonJodaTypes) {
+            assertTypeIsExpected(classWithDate, nonJodaType[0], nonJodaType[1]);
+        }
+    }
+
+    @Test
+    public void dateTimeTypeCausesCustomDateTimeType() throws IntrospectionException, ClassNotFoundException {
+    	String clazz="org.joda.time.LocalDateTime";
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("dateTimeType", clazz));
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+        assertTypeIsExpected(classWithDate, "stringAsDateTime", clazz);
+    }
+    
+    @Test
+    public void disablingDateTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
+    	String clazz="org.joda.time.LocalDateTime";
+    	ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("dateTimeType", null));
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+        assertTypeIsExpected(classWithDate, "stringAsDateTime", "java.util.Date");
+    }
+
+    @Test
+    public void dateTypeCausesCustomDateTimeType() throws IntrospectionException, ClassNotFoundException {
+    	String clazz="org.joda.time.LocalDate";
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("dateType", clazz));
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+        assertTypeIsExpected(classWithDate, "stringAsDate", clazz);
+    }
+    
+    @Test
+    public void disablingDateTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
+    	String clazz="org.joda.time.LocalDate";
+    	ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("dateType", null));
+        Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
+        assertTypeIsExpected(classWithDate, "stringAsDate", "java.lang.String");
+    }
+    
+    @Test
+    public void timeTypeCausesCustomTimeType() throws IntrospectionException, ClassNotFoundException {
+    	String clazz="org.joda.time.LocalTime";
+        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("timeType", clazz));
+        Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
+        assertTypeIsExpected(classWithTime, "stringAsTime", clazz);
+    }
+    
+    @Test
+    public void disablingTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
+    	String clazz="org.joda.time.LocalTime";
+    	ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("timeType", null));
+        Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
+        assertTypeIsExpected(classWithTime, "stringAsTime", "java.lang.String");
+    }    
+   
+
+    private void assertTypeIsExpected(Class<?> classInstance, String propertyName, String expectedType)
+            throws IntrospectionException {
+        Method getter = new PropertyDescriptor(propertyName, classInstance).getReadMethod();
+        assertThat(getter.getReturnType().getName(), is(expectedType));
+    }
+
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -332,6 +332,12 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.4.9
      */
     private boolean useJodaLocalTimes = false;
+    
+    private String dateTimeType = null;
+
+    private String timeType = null;
+
+    private String dateType = null;
 
     /**
      * Whether to use commons-lang 3.x imports instead of commons-lang 2.x
@@ -747,6 +753,21 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isIncludeDynamicAccessors() {
         return includeDynamicAccessors;
+    }
+
+    @Override
+    public String getDateTimeType() {
+        return dateTimeType;
+    }
+
+    @Override
+    public String getDateType() {
+        return dateType;
+    }
+
+    @Override
+    public String getTimeType() {
+        return timeType;
     }
 
 }


### PR DESCRIPTION
Allow to specify jsr310 classes i.e. java.time.* (jdk 8)
but mantain compatibility at compile level 1.6 as previous.
Updated also cli, maven, and ant but not gradle