### PR TITLE
Use minimum and maximum value of an integer property to determine java type long

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -148,7 +148,9 @@ public class TypeRule implements Rule<JClassContainer, JType> {
      */
     private JType getIntegerType(JCodeModel owner, JsonNode node, GenerationConfig config) {
 
-        if (config.isUseLongIntegers()) {
+        if (config.isUseLongIntegers() ||
+                (node.has("minimum") && node.get("minimum").isLong()) ||
+                (node.has("maximum") && node.get("maximum").isLong())) {
             return unboxIfNecessary(owner.ref(Long.class), config);
         } else {
             return unboxIfNecessary(owner.ref(Integer.class), config);

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -177,6 +177,134 @@ public class TypeRuleTest {
     }
 
     @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongPrimitiveWhenMaximumGreaterThanIntegerMax() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("maximum", Integer.MAX_VALUE + 1L);
+
+        when(config.isUsePrimitives()).thenReturn(true);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is("long"));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongWhenMaximumGreaterThanIntegerMax() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("maximum", Integer.MAX_VALUE + 1L);
+
+        when(config.isUsePrimitives()).thenReturn(false);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is(Long.class.getName()));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongPrimitiveWhenMaximumLessThanIntegerMin() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("maximum", Integer.MIN_VALUE - 1L);
+
+        when(config.isUsePrimitives()).thenReturn(true);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is("long"));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongWhenMaximumLessThanIntegerMin() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("maximum", Integer.MIN_VALUE - 1L);
+
+        when(config.isUsePrimitives()).thenReturn(false);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is(Long.class.getName()));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongPrimitiveWhenMinimumLessThanIntegerMin() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("minimum", Integer.MIN_VALUE - 1L);
+
+        when(config.isUsePrimitives()).thenReturn(true);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is("long"));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongWhenMinimumLessThanIntegerMin() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("minimum", Integer.MIN_VALUE - 1L);
+
+        when(config.isUsePrimitives()).thenReturn(false);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is(Long.class.getName()));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongPrimitiveWhenMinimumGreaterThanIntegerMax() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("minimum", Integer.MAX_VALUE + 1L);
+
+        when(config.isUsePrimitives()).thenReturn(true);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is("long"));
+    }
+
+    @Test
+    public void applyGeneratesIntegerUsingJavaTypeLongWhenMinimumGreaterThanIntegerMax() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "integer");
+        objectNode.put("minimum", Integer.MAX_VALUE + 1L);
+
+        when(config.isUsePrimitives()).thenReturn(false);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is(Long.class.getName()));
+    }
+
+    @Test
     public void applyGeneratesIntegerUsingJavaTypeBigInteger() {
 
         JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
@@ -184,6 +184,50 @@ public class TypeIT {
     }
 
     @Test
+    public void maximumGreaterThanIntegerMaxCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        File generatedTypesDirectory = generate("/schema/type/integerWithLongMaximumAsLong.json", "com.example");
+        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMaximumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void maximumGreaterThanIntegerMaxCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        File generatedTypesDirectory = generate("/schema/type/integerWithLongMaximumAsLong.json", "com.example", config("usePrimitives", true));
+        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMaximumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+
+    }
+
+    @Test
+    public void minimumLessThanIntegerMinCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        File generatedTypesDirectory = generate("/schema/type/integerWithLongMinimumAsLong.json", "com.example");
+        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMinimumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void minimumLessThanIntegerMinCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        File generatedTypesDirectory = generate("/schema/type/integerWithLongMinimumAsLong.json", "com.example", config("usePrimitives", true));
+        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMinimumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+
+    }
+
+    @Test
     public void useLongIntegersParameterCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
         File generatedTypesDirectory = generate("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true));
         Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerAsLong");

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/type/integerWithLongMaximumAsLong.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/type/integerWithLongMaximumAsLong.json
@@ -1,0 +1,9 @@
+{
+  "type" : "object",
+  "properties" : {
+    "longProperty" : {
+      "type" : "integer",
+      "maximum": 2147483648
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/type/integerWithLongMinimumAsLong.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/type/integerWithLongMinimumAsLong.json
@@ -1,0 +1,9 @@
+{
+  "type" : "object",
+  "properties" : {
+    "longProperty" : {
+      "type" : "integer",
+      "minimum": -2147483649
+    }
+  }
+}


### PR DESCRIPTION
Use the minimum and maximum properties as a hint to the java type of an integer.

Given the simple json object below we can infer that the type will be a long because the minimum value is to small.
```
{
  "type" : "object",
  "properties" : {
    "longProperty" : {
      "type" : "integer",
      "minimum": -2147483649
    }
  }
}
```



resolves #375