### PR TITLE
Allowing javaType to properly handle nested generic classes.

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -273,7 +273,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
 
     private void addInterfaces(JDefinedClass jclass, JsonNode javaInterfaces) {
         for (JsonNode i : javaInterfaces) {
-            jclass._implements(resolveType(jclass._package(), i.asText()));
+            jclass._implements(resolveType(jclass._package().owner(), i.asText()));
         }
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -16,10 +16,16 @@
 
 package org.jsonschema2pojo.rules;
 
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
+import static org.jsonschema2pojo.util.TypeUtil.resolveType;
 
 import java.util.Iterator;
 
+import com.sun.codemodel.ClassType;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JMod;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 
@@ -27,6 +33,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JClassContainer;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JType;
+import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
+import org.jsonschema2pojo.util.TypeUtil;
 
 /**
  * Applies the "type" schema rule.
@@ -172,12 +180,10 @@ public class TypeRule implements Rule<JClassContainer, JType> {
     }
 
     private JType getJavaType(String javaTypeName, JCodeModel owner) {
-
-        if (isPrimitive(javaTypeName, owner)) {
-            return primitiveType(javaTypeName, owner);
-        } else {
-            return owner.ref(javaTypeName);
+        try {
+            return resolveType(owner, ruleFactory.getNameHelper(), javaTypeName);
+        }  catch (ClassNotFoundException e) {
+            return owner.ref(Object.class);
         }
     }
-
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -16,14 +16,17 @@
 
 package org.jsonschema2pojo.util;
 
-import static java.lang.Character.*;
-import static javax.lang.model.SourceVersion.*;
-import static org.apache.commons.lang3.StringUtils.*;
-
+import com.sun.codemodel.JType;
 import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
 
-import com.sun.codemodel.JType;
+import static java.lang.Character.isDigit;
+import static javax.lang.model.SourceVersion.isKeyword;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.containsAny;
+import static org.apache.commons.lang3.StringUtils.remove;
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
 
 public class NameHelper {
 
@@ -120,5 +123,27 @@ public class NameHelper {
         }
 
         return getterName;
+    }
+
+    public String getClassName(String className) {
+        String conditionedClassName = replaceIllegalCharacters(capitalize(className));
+        String normalizedName = normalizeName(conditionedClassName);
+        return getJavaTypeClassName(normalizedName);
+    }
+
+    public String getJavaTypeClassName(String javaType) {
+        String genericParameters = javaType.contains("<") ? "<" + substringAfter(javaType, "<") : "";
+        String baseName = substringBefore(javaType, "<");
+        return configureTypeName(baseName) + genericParameters;
+    }
+
+    private String configureTypeName(String typeName) {
+        int index = typeName.lastIndexOf(".") + 1;
+        if (index >= 0 && index < typeName.length()) {
+            return "" + typeName.substring(0, index) + generationConfig.getClassNamePrefix() +
+                    typeName.substring(index) + generationConfig.getClassNameSuffix();
+        } else {
+            return typeName;
+        }
     }
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import org.jsonschema2pojo.util.NameHelper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -48,6 +49,7 @@ public class TypeRuleTest {
     @Before
     public void wireUpConfig() {
         when(ruleFactory.getGenerationConfig()).thenReturn(config);
+        when(ruleFactory.getNameHelper()).thenReturn(new NameHelper(config));
     }
 
     @Test


### PR DESCRIPTION
Currently the pojo tool does not support referencing a jsonschema who's root schema has a javaType with a nested Generic Parameter. The example below exhibits the issue. This PR fixes the problem. 

example
```json
Schema A
{
  "$schema": "http://json-schema.org/draft-03/schema",
  "javaType": "java.util.ArrayList<java.util.ArrayList<Integer>>"
}

Schema B
{
  "$schema": "http://json-schema.org/draft-03/schema",
  "type": "object",
  "properties": {
    "reference": {
      "$ref": "./schemaA.json"
    }
  }
}
```