### PR TITLE
JUnit Rule for Jsonschema2Pojo

### DIFF
--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AdditionalPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AdditionalPropertiesIT.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.hamcrest.Matcher;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -39,6 +41,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 public class AdditionalPropertiesIT {
+    
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private ObjectMapper mapper = new ObjectMapper();
 
@@ -46,7 +50,7 @@ public class AdditionalPropertiesIT {
     @SuppressWarnings("unchecked")
     public void jacksonCanDeserializeOurAdditionalProperties() throws ClassNotFoundException, IOException, SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example");
 
         Class<?> classWithAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
 
@@ -67,7 +71,7 @@ public class AdditionalPropertiesIT {
     @SuppressWarnings("unchecked")
     public void jacksonCanDeserializeOurAdditionalPropertiesWithoutIncludeAccessors() throws ClassNotFoundException, IOException, SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAccessors", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAccessors", false));
 
         Class<?> classWithAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
 
@@ -86,7 +90,7 @@ public class AdditionalPropertiesIT {
     @Test
     public void jacksonCanSerializeOurAdditionalProperties() throws ClassNotFoundException, IOException, SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException, InstantiationException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example");
 
         Class<?> classWithAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
         String jsonWithAdditionalProperties = "{\"a\":1, \"b\":2};";
@@ -101,7 +105,7 @@ public class AdditionalPropertiesIT {
     @Test
     public void jacksonCanSerializeOurAdditionalPropertiesWithoutIncludeAccessors() throws ClassNotFoundException, IOException, SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException, InstantiationException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAccessors", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAccessors", false));
 
         Class<?> classWithAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
         String jsonWithAdditionalProperties = "{\"a\":1, \"b\":2};";
@@ -116,7 +120,7 @@ public class AdditionalPropertiesIT {
     @Test(expected = UnrecognizedPropertyException.class)
     public void additionalPropertiesAreNotDeserializableWhenDisallowed() throws ClassNotFoundException, SecurityException, NoSuchMethodException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/noAdditionalProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/noAdditionalProperties.json", "com.example");
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.NoAdditionalProperties");
 
@@ -127,7 +131,7 @@ public class AdditionalPropertiesIT {
     @Test(expected = UnrecognizedPropertyException.class)
     public void additionalPropertiesAreNotDeserializableWhenDisabledGlobally() throws ClassNotFoundException, SecurityException, NoSuchMethodException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAdditionalProperties", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAdditionalProperties", false));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
 
@@ -138,7 +142,7 @@ public class AdditionalPropertiesIT {
     @Test
     public void additionalPropertiesOfStringTypeOnly() throws SecurityException, NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/additionalPropertiesString.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesString.json", "com.example", config("generateBuilders", true));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.AdditionalPropertiesString");
         Method getter = classWithNoAdditionalProperties.getMethod("getAdditionalProperties");
@@ -157,7 +161,7 @@ public class AdditionalPropertiesIT {
     @Test
     public void additionalPropertiesOfObjectTypeCreatesNewClassForPropertyValues() throws SecurityException, NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/additionalPropertiesObject.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesObject.json", "com.example", config("generateBuilders", true));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.AdditionalPropertiesObject");
         Class<?> propertyValueType = resultsClassLoader.loadClass("com.example.AdditionalPropertiesObjectProperty");
@@ -178,7 +182,7 @@ public class AdditionalPropertiesIT {
     @Test(expected = NoSuchMethodException.class)
     public void additionalPropertiesBuilderAbsentIfNotConfigured() throws SecurityException, NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/additionalPropertiesObject.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesObject.json", "com.example");
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.AdditionalPropertiesObject");
         Class<?> propertyValueType = resultsClassLoader.loadClass("com.example.AdditionalPropertiesObjectProperty");
@@ -193,7 +197,7 @@ public class AdditionalPropertiesIT {
     @Test
     public void additionalPropertiesOfStringArrayTypeOnly() throws SecurityException, NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/additionalPropertiesArraysOfStrings.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesArraysOfStrings.json", "com.example", config("generateBuilders", true));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.AdditionalPropertiesArraysOfStrings");
         Method getter = classWithNoAdditionalProperties.getMethod("getAdditionalProperties");
@@ -213,7 +217,7 @@ public class AdditionalPropertiesIT {
     @Test
     public void additionalPropertiesOfBooleanTypeOnly() throws SecurityException, NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/additionalPropertiesPrimitiveBoolean.json", "com.example", config("usePrimitives", true, "generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesPrimitiveBoolean.json", "com.example", config("usePrimitives", true, "generateBuilders", true));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.AdditionalPropertiesPrimitiveBoolean");
         Method getter = classWithNoAdditionalProperties.getMethod("getAdditionalProperties");
@@ -231,7 +235,7 @@ public class AdditionalPropertiesIT {
 
     @Test
     public void withAdditionalPropertyStoresValue() throws Exception {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/additionalPropertiesString.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesString.json", "com.example", config("generateBuilders", true));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.AdditionalPropertiesString");
         Method getter = classWithNoAdditionalProperties.getMethod("getAdditionalProperties");
@@ -253,7 +257,7 @@ public class AdditionalPropertiesIT {
         mapper.configure(MapperFeature.AUTO_DETECT_SETTERS, false);
         mapper.setVisibilityChecker(mapper.getVisibilityChecker().with(Visibility.ANY));
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example");
 
         Class<?> classWithAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
         String jsonWithAdditionalProperties = "{\"a\":1, \"b\":2};";

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ArrayIT.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.assertThat;
 
 import java.lang.reflect.Method;
@@ -30,19 +29,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ArrayIT {
 
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     private static Class<?> classWithArrayProperties;
 
     @BeforeClass
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example");
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example");
 
         classWithArrayProperties = resultsClassLoader.loadClass("com.example.TypeWithArrayProperties");
 
@@ -199,7 +204,7 @@ public class ArrayIT {
 
     }
 
-    static abstract class PreserveOrder {
+    abstract class PreserveOrder {
         String annotationStyle;
 
         public PreserveOrder(String annotationStyle) {
@@ -207,7 +212,7 @@ public class ArrayIT {
         }
 
         public void test() throws Exception {
-            ClassLoader resultsClassLoader = generateAndCompile(
+            ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
                     "/schema/array/typeWithArrayProperties.json",
                     "com.example",
                     config("annotationStyle", annotationStyle));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
@@ -17,7 +17,6 @@
 package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.InvocationTargetException;
@@ -27,17 +26,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class DefaultIT {
+    
+    @ClassRule public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithDefaults;
 
     @BeforeClass
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/default/default.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example");
 
         classWithDefaults = resultsClassLoader.loadClass("com.example.Default");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
@@ -16,14 +16,15 @@
 
 package org.jsonschema2pojo.integration;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
@@ -34,15 +35,15 @@ import com.thoughtworks.qdox.model.Type;
 
 public class DescriptionIT {
 
+    @ClassRule public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     private static JavaClass classWithDescription;
 
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
 
-        File outputDirectory = generate("/schema/description/description.json", "com.example");
-        File generatedJavaFile = new File(outputDirectory, "com/example/Description.java");
-
-        compile(outputDirectory);
+        schemaRule.generateAndCompile("/schema/description/description.json", "com.example");
+        File generatedJavaFile = schemaRule.generated("com/example/Description.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
         javaDocBuilder.addSource(generatedJavaFile);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DynamicPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DynamicPropertiesIT.java
@@ -18,15 +18,18 @@ package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class DynamicPropertiesIT {
+    
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void shouldSetStringField() throws Throwable {
@@ -169,7 +172,7 @@ public class DynamicPropertiesIT {
 
     @Test
     public void shouldSetAdditionalProperty() throws Exception {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/dynamic/parentType.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/dynamic/parentType.json", "com.example");
 
         Class<?> parentType = resultsClassLoader.loadClass("com.example.ParentType");
         Object instance = parentType.newInstance();
@@ -189,7 +192,7 @@ public class DynamicPropertiesIT {
 
     @Test
     public void shouldGetAdditionalProperty() throws Exception {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/dynamic/parentType.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/dynamic/parentType.json", "com.example");
 
         Class<?> parentType = resultsClassLoader.loadClass("com.example.ParentType");
         Object instance = parentType.newInstance();
@@ -209,12 +212,12 @@ public class DynamicPropertiesIT {
                 equalTo("value"));
     }
 
-    public static void setDeclaredPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldGetter, Object value) throws Throwable {
+    public void setDeclaredPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldGetter, Object value) throws Throwable {
         setDeclaredPropertyTest(config(), schemaLocation, typeName, fieldType, fieldName, fieldGetter, value);
     }
 
-    public static void setDeclaredPropertyTest(Map<String, Object> config, String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldGetter, Object value) throws Throwable {
-        ClassLoader resultsClassLoader = generateAndCompile(schemaLocation, "com.example", config);
+    public void setDeclaredPropertyTest(Map<String, Object> config, String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldGetter, Object value) throws Throwable {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaLocation, "com.example", config);
 
         Class<?> type = resultsClassLoader.loadClass("com.example." + typeName);
         Object instance = type.newInstance();
@@ -233,9 +236,9 @@ public class DynamicPropertiesIT {
 
     }
 
-    public static void withDeclaredPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldGetter, Object value) throws Throwable {
+    public void withDeclaredPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldGetter, Object value) throws Throwable {
         ClassLoader resultsClassLoader =
-                generateAndCompile(schemaLocation, "com.example", config("generateBuilders", true));
+                schemaRule.generateAndCompile(schemaLocation, "com.example", config("generateBuilders", true));
 
         Class<?> type = resultsClassLoader.loadClass("com.example." + typeName);
         Object instance = type.newInstance();
@@ -256,8 +259,8 @@ public class DynamicPropertiesIT {
 
     }
 
-    public static void getDeclaredPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldSetter, Object value) throws Throwable {
-        ClassLoader resultsClassLoader = generateAndCompile(schemaLocation, "com.example");
+    public void getDeclaredPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, String fieldSetter, Object value) throws Throwable {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaLocation, "com.example");
 
         Class<?> parentType = resultsClassLoader.loadClass("com.example." + typeName);
         Object instance = parentType.newInstance();
@@ -276,7 +279,7 @@ public class DynamicPropertiesIT {
     }
 
     public void setAdditionalPropertyTest(String schemaLocation, String typeName, Class<?> fieldType, String fieldName, Object value) throws Throwable {
-        ClassLoader resultsClassLoader = generateAndCompile(schemaLocation, "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaLocation, "com.example");
 
         Class<?> parentType = resultsClassLoader.loadClass("com.example." + typeName);
         Object instance = parentType.newInstance();
@@ -299,7 +302,7 @@ public class DynamicPropertiesIT {
     }
 
     public void setPropertyTest(String schemaLocation, String typeName, String fieldName, Object value) throws Throwable {
-        ClassLoader resultsClassLoader = generateAndCompile(schemaLocation, "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaLocation, "com.example");
 
         Class<?> type = resultsClassLoader.loadClass("com.example." + typeName);
         Object instance = type.newInstance();
@@ -313,7 +316,7 @@ public class DynamicPropertiesIT {
     }
 
     public void getPropertyTest(String schemaLocation, String typeName, String fieldName) throws Throwable {
-        ClassLoader resultsClassLoader = generateAndCompile(schemaLocation, "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaLocation, "com.example");
 
         Class<?> type = resultsClassLoader.loadClass("com.example." + typeName);
         Object instance = type.newInstance();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -18,14 +18,17 @@ package org.jsonschema2pojo.integration;
 
 import static java.lang.reflect.Modifier.*;
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -35,6 +38,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SuppressWarnings("rawtypes")
 public class EnumIT {
+    
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class parentClass;
     private static Class<Enum> enumClass;
@@ -43,7 +49,7 @@ public class EnumIT {
     @SuppressWarnings("unchecked")
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/typeWithEnumProperty.json", "com.example", config("propertyWordDelimiters", "_"));
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/enum/typeWithEnumProperty.json", "com.example", config("propertyWordDelimiters", "_"));
 
         parentClass = resultsClassLoader.loadClass("com.example.TypeWithEnumProperty");
         enumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.TypeWithEnumProperty$EnumProperty");
@@ -114,7 +120,7 @@ public class EnumIT {
     @SuppressWarnings("unchecked")
     public void enumAtRootCreatesATopLevelType() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumAsRoot.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumAsRoot.json", "com.example");
 
         Class<Enum> rootEnumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.enums.EnumAsRoot");
 
@@ -127,7 +133,7 @@ public class EnumIT {
     @SuppressWarnings("unchecked")
     public void enumWithEmptyStringAsValue() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumWithEmptyString.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithEmptyString.json", "com.example");
 
         Class<Enum> emptyEnumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.EnumWithEmptyString");
 
@@ -140,7 +146,7 @@ public class EnumIT {
     @SuppressWarnings("unchecked")
     public void enumWithNullValue() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumWithNullValue.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithNullValue.json", "com.example");
 
         Class<Enum> nullEnumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.EnumWithNullValue");
 
@@ -152,7 +158,7 @@ public class EnumIT {
     @Test
     public void enumWithUppercaseProperty() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumWithUppercaseProperty.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithUppercaseProperty.json", "com.example");
 
         resultsClassLoader.loadClass("com.example.EnumWithUppercaseProperty");
         resultsClassLoader.loadClass("com.example.EnumWithUppercaseProperty$TimeFormat");
@@ -161,7 +167,7 @@ public class EnumIT {
     @Test
     public void enumWithExtendedCharacters() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumWithExtendedCharacters.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithExtendedCharacters.json", "com.example");
 
         resultsClassLoader.loadClass("com.example.EnumWithExtendedCharacters");
     }
@@ -169,7 +175,7 @@ public class EnumIT {
     @Test
     public void multipleEnumArraysWithSameName() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/multipleEnumArraysWithSameName.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/multipleEnumArraysWithSameName.json", "com.example");
 
         resultsClassLoader.loadClass("com.example.MultipleEnumArraysWithSameName");
         resultsClassLoader.loadClass("com.example.Status");
@@ -180,7 +186,7 @@ public class EnumIT {
     @SuppressWarnings({ "unchecked" })
     public void enumWithCustomJavaNames() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/enumWithCustomJavaNames.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithCustomJavaNames.json", "com.example");
 
         Class<?> typeWithEnumProperty = resultsClassLoader.loadClass("com.example.EnumWithCustomJavaNames");
         Class<Enum> enumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.EnumWithCustomJavaNames$EnumProperty");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -15,19 +15,22 @@ package org.jsonschema2pojo.integration;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class ExtendsIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings("rawtypes")
     public void extendsWithEmbeddedSchemaGeneratesParentType() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/extendsEmbeddedSchema.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsEmbeddedSchema.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.ExtendsEmbeddedSchema");
         Class supertype = resultsClassLoader.loadClass("com.example.ExtendsEmbeddedSchemaParent");
@@ -40,7 +43,7 @@ public class ExtendsIT {
     @SuppressWarnings("rawtypes")
     public void extendsWithRefToAnotherSchema() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/subtypeOfA.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfA.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfAParent");
@@ -53,7 +56,7 @@ public class ExtendsIT {
     @SuppressWarnings("rawtypes")
     public void extendsWithRefToAnotherSchemaThatIsAlreadyASubtype() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfAParent");
@@ -65,7 +68,7 @@ public class ExtendsIT {
     @Test(expected = ClassNotFoundException.class)
     public void extendsStringCausesNoNewTypeToBeGenerated() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/extendsString.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsString.json", "com.example");
         resultsClassLoader.loadClass("com.example.ExtendsString");
 
     }
@@ -73,7 +76,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings("rawtypes")
     public void extendsEquals() throws Exception {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example2");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example2");
         
         Class generatedType = resultsClassLoader.loadClass("com.example2.SubtypeOfSubtypeOfA");
         Object instance = generatedType.newInstance();
@@ -92,7 +95,7 @@ public class ExtendsIT {
     @SuppressWarnings("rawtypes")
     public void extendsSchemaWithinDefinitions() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/extendsSchemaWithinDefinitions.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsSchemaWithinDefinitions.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.Child");
         assertNotNull("no propertyOfChild field", subtype.getDeclaredField("propertyOfChild"));
@@ -104,9 +107,9 @@ public class ExtendsIT {
     }
 
     @Test
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public void extendsBuilderMethods() throws Exception {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfAParent");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/FormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/FormatIT.java
@@ -16,7 +16,6 @@
 
 package org.jsonschema2pojo.integration;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -32,7 +31,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,10 +45,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @RunWith(Parameterized.class)
 public class FormatIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithFormattedProperties;
 
-    @Parameters
+    @Parameters(name="{0}")
     public static List<Object[]> data() {
         return asList(new Object[][] {
                 /* { propertyName, expectedType, jsonValue, javaValue } */
@@ -85,7 +87,7 @@ public class FormatIT {
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example");
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example");
 
         classWithFormattedProperties = resultsClassLoader.loadClass("com.example.FormattedProperties");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
@@ -16,7 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -25,17 +27,17 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.junit.Assert.*;
 
 public class GenericTypeIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithGenericTypes;
 
     @BeforeClass
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
-        classWithGenericTypes = generateAndCompile("/schema/type/genericJavaType.json", "com.example").loadClass("com.example.GenericJavaType");
+        classWithGenericTypes = classSchemaRule.generateAndCompile("/schema/type/genericJavaType.json", "com.example").loadClass("com.example.GenericJavaType");
 
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
@@ -17,15 +17,18 @@
 package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class JacksonViewIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void javaJsonViewWithJackson1x() throws Exception {
@@ -47,7 +50,7 @@ public class JacksonViewIT {
     }
 
     private Annotation jsonViewTest(String annotationStyle, Class<? extends Annotation> annotationType) throws ClassNotFoundException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile(
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
                 "/schema/views/views.json",
                 "com.example",
                 config("annotationStyle", annotationStyle));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
@@ -17,7 +17,6 @@
 package org.jsonschema2pojo.integration;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.*;
 import static java.lang.String.format;
@@ -32,7 +31,9 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.net.QuotedPrintableCodec;
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.AbstractAnnotator;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -53,13 +54,14 @@ import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
 
 public class MediaIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
     private static Class<?> classWithMediaProperties;
     private static Class<byte[]> BYTE_ARRAY = byte[].class;
 
     @BeforeClass
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/media/mediaProperties.json", "com.example", config("customAnnotator", QuotedPrintableAnnotator.class.getName()));
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/media/mediaProperties.json", "com.example", config("customAnnotator", QuotedPrintableAnnotator.class.getName()));
 
         classWithMediaProperties = resultsClassLoader.loadClass("com.example.MediaProperties");
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PolymorphicIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PolymorphicIT.java
@@ -32,8 +32,10 @@
 package org.jsonschema2pojo.integration;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.assertNotNull;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -41,15 +43,15 @@ import org.junit.Test;
  * @author JAshe
  */
 public class PolymorphicIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
     
     @Test
-    @SuppressWarnings("rawtypes")
     public void extendsWithPolymorphicDeserialization() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/polymorphic/extendsSchema.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/polymorphic/extendsSchema.json", "com.example");
 
-        Class subtype = resultsClassLoader.loadClass("com.example.ExtendsSchema");
-        Class supertype = subtype.getSuperclass();
+        Class<?> subtype = resultsClassLoader.loadClass("com.example.ExtendsSchema");
+        Class<?> supertype = subtype.getSuperclass();
 
         assertNotNull(supertype.getAnnotation(JsonTypeInfo.class));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.integration;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -26,12 +26,15 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class PropertiesIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -39,7 +42,7 @@ public class PropertiesIT {
     @SuppressWarnings("rawtypes")
     public void propertiesWithNullValuesAreOmittedWhenSerialized() throws ClassNotFoundException, IntrospectionException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/nullProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/nullProperties.json", "com.example");
 
         Class generatedType = resultsClassLoader.loadClass("com.example.NullProperties");
         Object instance = generatedType.newInstance();
@@ -59,7 +62,7 @@ public class PropertiesIT {
     @SuppressWarnings("rawtypes")
     public void propertiesAreSerializedInCorrectOrder() throws ClassNotFoundException, IntrospectionException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/orderedProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/orderedProperties.json", "com.example");
 
         Class generatedType = resultsClassLoader.loadClass("com.example.OrderedProperties");
         Object instance = generatedType.newInstance();
@@ -83,7 +86,7 @@ public class PropertiesIT {
     @SuppressWarnings("rawtypes")
     public void usePrimitivesArgumentCausesPrimitiveTypes() throws ClassNotFoundException, IntrospectionException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("usePrimitives", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("usePrimitives", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
@@ -97,7 +100,7 @@ public class PropertiesIT {
     @SuppressWarnings("rawtypes")
     public void wordDelimitersCausesCamelCase() throws ClassNotFoundException, IntrospectionException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/propertiesWithWordDelimiters.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/propertiesWithWordDelimiters.json", "com.example",
                 config("usePrimitives", true, "propertyWordDelimiters", "_ -"));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.WordDelimit");
@@ -118,7 +121,7 @@ public class PropertiesIT {
     @Test
     public void propertyNamesThatAreJavaKeywordsCanBeSerialized() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/propertiesThatAreJavaKeywords.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/propertiesThatAreJavaKeywords.json", "com.example");
 
         Class<?> generatedType = resultsClassLoader.loadClass("com.example.PropertiesThatAreJavaKeywords");
 
@@ -136,7 +139,7 @@ public class PropertiesIT {
     @Test
     public void propertyCalledClassCanBeSerialized() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/propertyCalledClass.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/propertyCalledClass.json", "com.example");
 
         Class<?> generatedType = resultsClassLoader.loadClass("com.example.PropertyCalledClass");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RegressionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RegressionIT.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.io.File;
@@ -25,15 +25,18 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class RegressionIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings("rawtypes")
     public void pathWithSpacesInTheNameDoesNotFail() throws ClassNotFoundException, MalformedURLException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/regression/spaces in path.json", "com.example", Collections.<String, Object> emptyMap());
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/regression/spaces in path.json", "com.example", Collections.<String, Object> emptyMap());
 
         Class generatedType = resultsClassLoader.loadClass("com.example.SpacesInPath");
         assertThat(generatedType, is(notNullValue()));
@@ -43,7 +46,7 @@ public class RegressionIT {
     @Test
     public void underscoresInPropertyNamesRemainIntact() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/regression/underscores.json", "com.example", config("sourceType", "json", "propertyWordDelimiters", ""));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/regression/underscores.json", "com.example", config("sourceType", "json", "propertyWordDelimiters", ""));
 
         Class<?> generatedType = resultsClassLoader.loadClass("com.example.Underscores");
         generatedType.getMethod("getName");
@@ -53,7 +56,7 @@ public class RegressionIT {
     @Test
     @SuppressWarnings("rawtypes")
     public void filesWithExtensionPrefixesAreNotTruncated() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/regression/foo.baz.json", "com.example", Collections.<String, Object> emptyMap());
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/regression/foo.baz.json", "com.example", Collections.<String, Object> emptyMap());
 
         Class generatedType = resultsClassLoader.loadClass("com.example.FooBaz");
         assertThat(generatedType, is(notNullValue()));
@@ -64,7 +67,7 @@ public class RegressionIT {
     public void extendsChoosesCorrectSupertypeWhenTypeIsAlreadyGenerated() throws ClassNotFoundException, NoSuchMethodException, SecurityException, MalformedURLException {
         URL filteredSchemaUrl = new File("src/test/resources/schema/regression/extends").toURI().toURL();
 
-        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example", Collections.<String, Object> emptyMap());
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(filteredSchemaUrl, "com.example", Collections.<String, Object> emptyMap());
 
         Class parent = resultsClassLoader.loadClass("org.hawkular.bus.common.BasicMessage");
         Class subClass = resultsClassLoader.loadClass("org.abc.AuthMessage");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
@@ -21,7 +21,10 @@ import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.Type;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.File;
@@ -29,21 +32,18 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.compile;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generate;
 import static org.junit.Assert.assertThat;
 
 public class RequiredArrayIT extends RequiredIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithRequired;
 
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
 
-        File outputDirectory = generate("/schema/required/requiredArray.json", "com.example");
-        File generatedJavaFile = new File(outputDirectory, "com/example/RequiredArray.java");
-
-        compile(outputDirectory);
+        classSchemaRule.generateAndCompile("/schema/required/requiredArray.json", "com.example");
+        File generatedJavaFile = classSchemaRule.generated("com/example/RequiredArray.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
         javaDocBuilder.addSource(generatedJavaFile);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
@@ -16,14 +16,15 @@
 
 package org.jsonschema2pojo.integration;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
@@ -33,16 +34,15 @@ import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.Type;
 
 public class RequiredIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithRequired;
 
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
 
-        File outputDirectory = generate("/schema/required/required.json", "com.example");
-        File generatedJavaFile = new File(outputDirectory, "com/example/Required.java");
-
-        compile(outputDirectory);
+        classSchemaRule.generateAndCompile("/schema/required/required.json", "com.example");
+        File generatedJavaFile = classSchemaRule.generated("com/example/Required.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
         javaDocBuilder.addSource(generatedJavaFile);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
@@ -16,14 +16,15 @@
 
 package org.jsonschema2pojo.integration;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
@@ -33,16 +34,15 @@ import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.Type;
 
 public class TitleIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithTitle;
 
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
 
-        File outputDirectory = generate("/schema/title/title.json", "com.example");
-        File generatedJavaFile = new File(outputDirectory, "com/example/Title.java");
-
-        compile(outputDirectory);
+        classSchemaRule.generateAndCompile("/schema/title/title.json", "com.example");
+        File generatedJavaFile = classSchemaRule.generated("com/example/Title.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
         javaDocBuilder.addSource(generatedJavaFile);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
@@ -17,29 +17,33 @@
 package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
-import java.io.File;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class TypeIT {
+    
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
-    private static File generatedTypesDirectory;
     private static Class<?> classWithManyTypes;
 
     @BeforeClass
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
-        generatedTypesDirectory = generate("/schema/type/types.json", "com.example");
-        classWithManyTypes = compile(generatedTypesDirectory).loadClass("com.example.Types");
+        classWithManyTypes = classSchemaRule.generateAndCompile("/schema/type/types.json", "com.example")
+                .loadClass("com.example.Types");
 
     }
 
@@ -140,7 +144,7 @@ public class TypeIT {
         Method getterMethod = classWithManyTypes.getMethod("getReusedClasspathType");
 
         assertThat(getterMethod.getReturnType().getName(), is("java.util.Locale"));
-        assertThat(new File(generatedTypesDirectory, "java/util/Locale.java").exists(), is(false));
+        assertThat(classSchemaRule.generated("java/util/Locale.java").exists(), is(false));
 
     }
 
@@ -185,8 +189,8 @@ public class TypeIT {
 
     @Test
     public void maximumGreaterThanIntegerMaxCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/integerWithLongMaximumAsLong.json", "com.example");
-        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMaximumAsLong");
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMaximumAsLong.json", "com.example")
+                .loadClass("com.example.IntegerWithLongMaximumAsLong");
 
         Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
 
@@ -196,8 +200,8 @@ public class TypeIT {
 
     @Test
     public void maximumGreaterThanIntegerMaxCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/integerWithLongMaximumAsLong.json", "com.example", config("usePrimitives", true));
-        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMaximumAsLong");
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMaximumAsLong.json", "com.example", config("usePrimitives", true))
+                .loadClass("com.example.IntegerWithLongMaximumAsLong");
 
         Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
 
@@ -207,8 +211,8 @@ public class TypeIT {
 
     @Test
     public void minimumLessThanIntegerMinCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/integerWithLongMinimumAsLong.json", "com.example");
-        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMinimumAsLong");
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMinimumAsLong.json", "com.example")
+                .loadClass("com.example.IntegerWithLongMinimumAsLong");
 
         Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
 
@@ -218,8 +222,8 @@ public class TypeIT {
 
     @Test
     public void minimumLessThanIntegerMinCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/integerWithLongMinimumAsLong.json", "com.example", config("usePrimitives", true));
-        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerWithLongMinimumAsLong");
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMinimumAsLong.json", "com.example", config("usePrimitives", true))
+                .loadClass("com.example.IntegerWithLongMinimumAsLong");
 
         Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
 
@@ -229,8 +233,8 @@ public class TypeIT {
 
     @Test
     public void useLongIntegersParameterCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true));
-        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerAsLong");
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true))
+                .loadClass("com.example.IntegerAsLong");
 
         Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
 
@@ -240,8 +244,8 @@ public class TypeIT {
 
     @Test
     public void useLongIntegersParameterCausesPrimitiveIntsToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true, "usePrimitives", true));
-        Class<?> classWithLongProperty = compile(generatedTypesDirectory).loadClass("com.example.IntegerAsLong");
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true, "usePrimitives", true))
+                .loadClass("com.example.IntegerAsLong");
 
         Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
 
@@ -250,8 +254,8 @@ public class TypeIT {
 
     @Test
     public void useDoubleNumbersFalseCausesNumbersToBecomeFloats() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/numberAsFloat.json", "com.example", config("useDoubleNumbers", false));
-        Class<?> classWithDoubleProperty = compile(generatedTypesDirectory).loadClass("com.example.NumberAsFloat");
+        Class<?> classWithDoubleProperty = schemaRule.generateAndCompile("/schema/type/numberAsFloat.json", "com.example", config("useDoubleNumbers", false))
+                .loadClass("com.example.NumberAsFloat");
 
         Method getterMethod = classWithDoubleProperty.getMethod("getFloatProperty");
 
@@ -261,8 +265,8 @@ public class TypeIT {
 
     @Test
     public void useDoubleNumbersFalseCausesPrimitiveNumbersToBecomeFloats() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        File generatedTypesDirectory = generate("/schema/type/numberAsFloat.json", "com.example", config("useDoubleNumbers", false, "usePrimitives", true));
-        Class<?> classWithDoubleProperty = compile(generatedTypesDirectory).loadClass("com.example.NumberAsFloat");
+        Class<?> classWithDoubleProperty = schemaRule.generateAndCompile("/schema/type/numberAsFloat.json", "com.example", config("useDoubleNumbers", false, "usePrimitives", true))
+                .loadClass("com.example.NumberAsFloat");
 
         Method getterMethod = classWithDoubleProperty.getMethod("getFloatProperty");
 
@@ -272,7 +276,7 @@ public class TypeIT {
     @Test
     public void unionTypesChooseFirstTypePresent() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        Class<?> classWithUnionProperties = generateAndCompile("/schema/type/unionTypes.json", "com.example").loadClass("com.example.UnionTypes");
+        Class<?> classWithUnionProperties = schemaRule.generateAndCompile("/schema/type/unionTypes.json", "com.example").loadClass("com.example.UnionTypes");
 
         Method booleanGetter = classWithUnionProperties.getMethod("getBooleanProperty");
 
@@ -290,7 +294,7 @@ public class TypeIT {
     @SuppressWarnings("rawtypes")
     @Test
     public void typeNameConflictDoesNotCauseTypeReuse() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
-        Class<?> classWithNameConflict = generateAndCompile("/schema/type/typeNameConflict.json", "com.example").loadClass("com.example.TypeNameConflict");
+        Class<?> classWithNameConflict = schemaRule.generateAndCompile("/schema/type/typeNameConflict.json", "com.example").loadClass("com.example.TypeNameConflict");
 
         Method getterMethod = classWithNameConflict.getMethod("getTypeNameConflict");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLang3IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLang3IT.java
@@ -17,20 +17,24 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.not;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class CommonsLang3IT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void hashCodeAndEqualsUseCommonsLang2ByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        File generatedOutputDirectory = generate("/schema/properties/primitiveProperties.json", "com.example");
+        File generatedOutputDirectory = schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example");
 
         assertThat(generatedOutputDirectory, not(containsText("org.apache.commons.lang3.")));
         assertThat(generatedOutputDirectory, containsText("org.apache.commons.lang."));
@@ -40,7 +44,7 @@ public class CommonsLang3IT {
     @Test
     public void hashCodeAndEqualsUseCommonsLang3() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        File generatedOutputDirectory = generate("/schema/properties/primitiveProperties.json", "com.example",
+        File generatedOutputDirectory = schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example",
                 config("useCommonsLang3", true));
 
         assertThat(generatedOutputDirectory, not(containsText("org.apache.commons.lang.")));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -17,13 +17,15 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -37,11 +39,13 @@ import com.sun.codemodel.JMethod;
 
 public class CustomAnnotatorIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void defaultCustomAnnotatorIsNoop() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
                 config("annotationStyle", "none")); // turn off core annotations
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
@@ -56,7 +60,7 @@ public class CustomAnnotatorIT {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void customAnnotatorIsAbleToAddCustomAnnotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
                 config("annotationStyle", "none", // turn off core annotations
                         "customAnnotator", DeprecatingAnnotator.class.getName()));
 
@@ -73,7 +77,7 @@ public class CustomAnnotatorIT {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void customAnnotatorCanBeAppliedAlongsideCoreAnnotator() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
                 config("customAnnotator", DeprecatingAnnotator.class.getName()));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
@@ -93,7 +97,7 @@ public class CustomAnnotatorIT {
     public void invalidCustomAnnotatorClassCausesMojoException() {
 
         try {
-            generate("/schema/properties/primitiveProperties.json", "com.example", config("customAnnotator", "java.lang.String"));
+            schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example", config("customAnnotator", "java.lang.String"));
             fail();
         } catch (RuntimeException e) {
             assertThat(e.getCause(), is(instanceOf(MojoExecutionException.class)));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
@@ -27,13 +27,17 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jsonschema2pojo.exception.GenerationException;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class CustomDatesIT {
+    
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void defaultTypesAreNotCustom() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example");
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example");
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
 
@@ -51,7 +55,7 @@ public class CustomDatesIT {
     @Test
     public void dateTimeTypeCausesCustomDateTimeType() throws IntrospectionException, ClassNotFoundException {
         String clazz="org.joda.time.LocalDateTime";
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateTimeType", clazz));
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDateTime", clazz);
@@ -59,7 +63,7 @@ public class CustomDatesIT {
 
     @Test
     public void disablingDateTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateTimeType", null));
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDateTime", "java.util.Date");
@@ -68,7 +72,7 @@ public class CustomDatesIT {
     @Test
     public void dateTypeCausesCustomDateTimeType() throws IntrospectionException, ClassNotFoundException {
         String clazz="org.joda.time.LocalDate";
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateType", clazz));
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDate", clazz);
@@ -76,7 +80,7 @@ public class CustomDatesIT {
 
     @Test
     public void disablingDateTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateType", null));
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDate", "java.lang.String");
@@ -85,7 +89,7 @@ public class CustomDatesIT {
     @Test
     public void timeTypeCausesCustomTimeType() throws IntrospectionException, ClassNotFoundException {
         String clazz="org.joda.time.LocalTime";
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("timeType", clazz));
         Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithTime, "stringAsTime", clazz);
@@ -93,7 +97,7 @@ public class CustomDatesIT {
 
     @Test
     public void disablingTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("timeType", null));
         Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithTime, "stringAsTime", "java.lang.String");
@@ -101,19 +105,19 @@ public class CustomDatesIT {
 
     @Test(expected=GenerationException.class)
     public void throwsGenerationExceptionForUnknownDateTimeType() {
-        generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateTimeType", "org.jsonschema2pojo.integration.config.UnknownType"));
     }
 
     @Test(expected=GenerationException.class)
     public void throwsGenerationExceptionForUnknownDateType() {
-        generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateType", "org.jsonschema2pojo.integration.config.UnknownType"));
     }
 
     @Test(expected=GenerationException.class)
     public void throwsGenerationExceptionForUnknownTimeType() {
-        generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("timeType", "org.jsonschema2pojo.integration.config.UnknownType"));
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryIT.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JType;
 import org.joda.time.LocalDate;
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.jsonschema2pojo.rules.FormatRule;
 import org.jsonschema2pojo.rules.Rule;
 import org.jsonschema2pojo.rules.RuleFactory;
@@ -29,19 +30,19 @@ import java.lang.reflect.Method;
 
 import static org.hamcrest.Matchers.is;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.assertThat;
 
 public class CustomRuleFactoryIT {
 
+    @org.junit.Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public void customAnnotatorIsAbleToAddCustomAnnotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("customRuleFactory", TestRuleFactory.class.getName()));
 
-        Class generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
 
         Method getter = generatedType.getMethod("getStringAsDate");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/EmptyPackageNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/EmptyPackageNameIT.java
@@ -17,14 +17,18 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class EmptyPackageNameIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void shouldAllowEmptyPackageName() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/emptyPackageName", "",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/emptyPackageName", "",
                 config("includes", new String[] {}, "excludes", new String[] {}));
 
         resultsClassLoader.loadClass("LevelZeroType");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
@@ -17,18 +17,19 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
 import static org.jsonschema2pojo.integration.util.JsonAssert.*;
 import static org.junit.Assert.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -38,23 +39,23 @@ import com.google.gson.Gson;
 
 public class GsonIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void annotationStyleGsonProducesGsonAnnotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
 
-        File generatedOutputDirectory = generate("/json/examples/torrent.json", "com.example",
+        Class generatedType = schemaRule.generateAndCompile("/json/examples/torrent.json", "com.example",
                 config("annotationStyle", "gson",
                         "propertyWordDelimiters", "_",
-                        "sourceType", "json"));
+                        "sourceType", "json"))
+                .loadClass("com.example.Torrent");
 
-        assertThat(generatedOutputDirectory, not(containsText("org.codehaus.jackson")));
-        assertThat(generatedOutputDirectory, not(containsText("com.fasterxml.jackson")));
-        assertThat(generatedOutputDirectory, containsText("com.google.gson"));
-        assertThat(generatedOutputDirectory, containsText("@SerializedName"));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("org.codehaus.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.fasterxml.jackson")));
+        assertThat(schemaRule.getGenerateDir(), containsText("com.google.gson"));
+        assertThat(schemaRule.getGenerateDir(), containsText("@SerializedName"));
 
-        ClassLoader resultsClassLoader = compile(generatedOutputDirectory);
-
-        Class generatedType = resultsClassLoader.loadClass("com.example.Torrent");
         Method getter = generatedType.getMethod("getBuild");
 
         assertThat(generatedType.getAnnotation(JsonPropertyOrder.class), is(nullValue()));
@@ -65,13 +66,11 @@ public class GsonIT {
     @Test
     public void annotationStyleGsonMakesTypesThatWorkWithGson() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException, IOException {
 
-        File generatedOutputDirectory = generate("/json/examples/", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/examples/", "com.example",
                 config("annotationStyle", "gson",
                         "propertyWordDelimiters", "_",
                         "sourceType", "json",
                         "useLongIntegers", true));
-
-        ClassLoader resultsClassLoader = compile(generatedOutputDirectory);
 
         assertJsonRoundTrip(resultsClassLoader, "com.example.Torrent", "/json/examples/torrent.json");
         assertJsonRoundTrip(resultsClassLoader, "com.example.GetUserData", "/json/examples/GetUserData.json");
@@ -81,7 +80,7 @@ public class GsonIT {
     @Test
     public void enumValuesAreSerializedCorrectly() throws ClassNotFoundException, NoSuchMethodException, SecurityException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/enum/typeWithEnumProperty.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/typeWithEnumProperty.json", "com.example",
                 config("annotationStyle", "gson",
                         "propertyWordDelimiters", "_"));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsIT.java
@@ -17,12 +17,14 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,10 +32,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IncludeAccessorsIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void beansIncludeGettersAndSettersByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
@@ -46,7 +50,7 @@ public class IncludeAccessorsIT {
     @Test
     public void beansOmitGettersAndSettersWhenAccessorsAreDisabled() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeAccessors", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeAccessors", false));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
@@ -69,7 +73,7 @@ public class IncludeAccessorsIT {
     @Test
     public void beansWithoutAccessorsRoundTripJsonCorrectly() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException, InstantiationException, IllegalAccessException, IOException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeAccessors", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeAccessors", false));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsPropertiesIT.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 import static org.fest.util.Lists.newArrayList;
 
@@ -32,6 +32,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -59,6 +61,8 @@ public class IncludeAccessorsPropertiesIT {
         });
     }
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     private String path;
     private String typeName;
     private Map<String, Object> includeAccessorsFalse;
@@ -73,7 +77,7 @@ public class IncludeAccessorsPropertiesIT {
 
     @Test
     public void noGettersOrSettersWhenFalse() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile(path, PACKAGE, includeAccessorsFalse);
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(path, PACKAGE, includeAccessorsFalse);
         Class generatedType = resultsClassLoader.loadClass(typeName);
 
         assertThat("getters and setters should not exist", generatedType.getDeclaredMethods(), everyItemInArray(anyOf(methodWhitelist(), not(fieldGetterOrSetter()))));
@@ -81,7 +85,7 @@ public class IncludeAccessorsPropertiesIT {
 
     @Test
     public void hasGettersOrSettersWhenTrue() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile(path, PACKAGE, includeAccessorsTrue);
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(path, PACKAGE, includeAccessorsTrue);
         Class generatedType = resultsClassLoader.loadClass(typeName);
 
         assertThat("a getter or setter should be found.", generatedType.getDeclaredMethods(), hasItemInArray(allOf(not(methodWhitelist()), fieldGetterOrSetter())));
@@ -89,7 +93,7 @@ public class IncludeAccessorsPropertiesIT {
 
     @Test
     public void onlyHasPublicInstanceFieldsWhenFalse() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile(path, PACKAGE, includeAccessorsFalse);
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(path, PACKAGE, includeAccessorsFalse);
         Class generatedType = resultsClassLoader.loadClass(typeName);
 
         assertThat("only public instance fields exist", generatedType.getDeclaredFields(), everyItemInArray(anyOf(hasModifiers(Modifier.STATIC), fieldWhitelist(), hasModifiers(Modifier.PUBLIC))));
@@ -97,7 +101,7 @@ public class IncludeAccessorsPropertiesIT {
 
     @Test
     public void noPublicInstanceFieldsWhenTrue() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile(path, PACKAGE, includeAccessorsTrue);
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(path, PACKAGE, includeAccessorsTrue);
         Class generatedType = resultsClassLoader.loadClass(typeName);
 
         assertThat("only public instance fields exist", generatedType.getDeclaredFields(), everyItemInArray(anyOf(not(hasModifiers(Modifier.PUBLIC)), fieldWhitelist())));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeHashCodeAndEqualsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeHashCodeAndEqualsIT.java
@@ -16,18 +16,22 @@
 
 package org.jsonschema2pojo.integration.config;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IncludeHashCodeAndEqualsIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void beansIncludeHashCodeAndEqualsByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
@@ -39,7 +43,7 @@ public class IncludeHashCodeAndEqualsIT {
 
     @Test
     public void beansOmitHashCodeAndEqualsWhenConfigIsSet() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeHashcodeAndEquals", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeHashcodeAndEquals", false));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -18,7 +18,7 @@ package org.jsonschema2pojo.integration.config;
 
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.beans.PropertyDescriptor;
@@ -33,23 +33,27 @@ import javax.validation.Validator;
 
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.FileSearchMatcher;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 @SuppressWarnings("rawtypes")
 public class IncludeJsr303AnnotationsIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     private static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();;
 
     @Test
     public void jsrAnnotationsAreNotIncludedByDefault() throws ClassNotFoundException {
-        File outputDirectory = generate("/schema/jsr303/all.json", "com.example");
+        File outputDirectory = schemaRule.generate("/schema/jsr303/all.json", "com.example");
 
         assertThat(outputDirectory, not(containsText("javax.validation")));
     }
 
     @Test
     public void jsrAnnotationsAreNotIncludedWhenSwitchedOff() throws ClassNotFoundException {
-        File outputDirectory = generate("/schema/jsr303/all.json", "com.example",
+        File outputDirectory = schemaRule.generate("/schema/jsr303/all.json", "com.example",
                 config("includeJsr303Annotations", false));
 
         assertThat(outputDirectory, not(containsText("javax.validation")));
@@ -58,7 +62,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303DecimalMinValidationIsAddedForSchemaRuleMinimum() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/minimum.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/minimum.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.Minimum");
@@ -76,7 +80,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303DecimalMaxValidationIsAddedForSchemaRuleMaximum() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/maximum.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/maximum.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.Maximum");
@@ -94,7 +98,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303SizeValidationIsAddedForSchemaRuleMinItems() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/minItems.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/minItems.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.MinItems");
@@ -112,7 +116,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303SizeValidationIsAddedForSchemaRuleMaxItems() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/maxItems.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/maxItems.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.MaxItems");
@@ -129,7 +133,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303SizeValidationIsAddedForSchemaRuleMinItemsAndMaxItems() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/minAndMaxItems.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/minAndMaxItems.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.MinAndMaxItems");
@@ -151,7 +155,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303PatternValidationIsAddedForSchemaRulePattern() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/pattern.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/pattern.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.Pattern");
@@ -168,7 +172,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303NotNullValidationIsAddedForSchemaRuleRequired() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/required.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/required.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.Required");
@@ -185,7 +189,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303SizeValidationIsAddedForSchemaRuleMinLength() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/minLength.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/minLength.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.MinLength");
@@ -202,7 +206,7 @@ public class IncludeJsr303AnnotationsIT {
     @Test
     public void jsr303SizeValidationIsAddedForSchemaRuleMaxLength() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/maxLength.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/maxLength.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.MaxLength");
@@ -218,7 +222,7 @@ public class IncludeJsr303AnnotationsIT {
 
     @Test
     public void jsr303ValidAnnotationIsAddedForObject() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/validObject.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/validObject.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class validObjectType = resultsClassLoader.loadClass("com.example.ValidObject");
@@ -237,7 +241,7 @@ public class IncludeJsr303AnnotationsIT {
 
     @Test
     public void jsr303ValidAnnotationIsAddedForArray() throws ClassNotFoundException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/validArray.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/validArray.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class validArrayType = resultsClassLoader.loadClass("com.example.ValidArray");
@@ -260,7 +264,7 @@ public class IncludeJsr303AnnotationsIT {
 
     @Test
     public void jsr303ValidAnnotationIsAddedForArrayWithRef() throws ClassNotFoundException, NoSuchFieldException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/jsr303/validArray.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/validArray.json", "com.example",
                 config("includeJsr303Annotations", true));
 
         Class validArrayType = resultsClassLoader.loadClass("com.example.ValidArray");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringIT.java
@@ -16,18 +16,22 @@
 
 package org.jsonschema2pojo.integration.config;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class IncludeToStringIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void beansIncludeToStringByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
@@ -39,7 +43,7 @@ public class IncludeToStringIT {
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void beansOmitHashCodeAndEqualsWhenConfigIsSet() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeToString", false));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeToString", false));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
@@ -30,13 +30,17 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class JodaDatesIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void defaultTypesAreNotJoda() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example");
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example");
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
 
@@ -53,7 +57,7 @@ public class JodaDatesIT {
 
     @Test
     public void useJodaDatesCausesJodaDateTimeDates() throws IntrospectionException, ClassNotFoundException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("useJodaDates", true));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -63,7 +67,7 @@ public class JodaDatesIT {
 
     @Test
     public void disablingJodaDatesCausesJavaUtilDates() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("useJodaDates", false));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -73,7 +77,7 @@ public class JodaDatesIT {
 
     @Test
     public void useJodaLocalDatesCausesJodaLocalDateDates() throws IntrospectionException, ClassNotFoundException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example", config
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example", config
                 ("useJodaLocalDates", true));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -83,7 +87,7 @@ public class JodaDatesIT {
 
     @Test
     public void disablingJodaLocalDatesCausesStrings() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("useJodaLocalDates", false));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -93,7 +97,7 @@ public class JodaDatesIT {
 
     @Test
     public void useJodaLocalTimesCausesJodaLocalTimeDates() throws IntrospectionException, ClassNotFoundException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("useJodaLocalTimes", true));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -103,7 +107,7 @@ public class JodaDatesIT {
 
     @Test
     public void disablingJodaLocalTimesCausesStrings() throws ClassNotFoundException, IntrospectionException {
-        ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("useJodaLocalTimes", false));
 
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -113,7 +117,7 @@ public class JodaDatesIT {
 
     @Test
     public void useJodaDatesCausesDateTimeDefaultValues() throws ClassNotFoundException, IntrospectionException, InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
-        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example",
                 config("useJodaDates", true));
 
         Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
@@ -128,7 +132,7 @@ public class JodaDatesIT {
     @Test
     public void useJodaDatesCausesDateTimeAsStringDefaultValues() throws ClassNotFoundException,
             IntrospectionException, InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
-        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example",
                 config("useJodaDates", true));
 
         Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
@@ -143,7 +147,7 @@ public class JodaDatesIT {
     @Test
     public void useJodaLocalDatesCausesLocalDateDefaultValues() throws ClassNotFoundException, IntrospectionException,
             InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
-        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example",
                 config("useJodaLocalDates", true));
 
         Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");
@@ -158,7 +162,7 @@ public class JodaDatesIT {
     @Test
     public void useJodaLocalTimesCausesLocalTimeDefaultValues() throws ClassNotFoundException, IntrospectionException,
             InstantiationException, IllegalAccessException, NoSuchMethodException, SecurityException, InvocationTargetException {
-        ClassLoader classLoader = generateAndCompile("/schema/default/default.json", "com.example",
+        ClassLoader classLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example",
                 config("useJodaLocalTimes", true));
 
         Class<?> classWithDefaults = classLoader.loadClass("com.example.Default");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OutputEncodingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OutputEncodingIT.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.io.File;
@@ -25,13 +25,17 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 import org.apache.commons.io.IOUtils;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class OutputEncodingIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void writeExtendedCharactersAsUtf8SourceCodeByDefault() throws IOException {
-        File outputDirectory = generate("/schema/regression/extendedCharacters.json", "com.example");
+        File outputDirectory = schemaRule.generate("/schema/regression/extendedCharacters.json", "com.example");
         File sourceFile = new File(outputDirectory, "com/example/ExtendedCharacters.java");
         String javaSource = IOUtils.toString(new FileInputStream(sourceFile), "utf-8");
 
@@ -46,7 +50,7 @@ public class OutputEncodingIT {
         try {
             System.setProperty("file.encoding", "Cp1252");
 
-            File outputDirectory = generate("/schema/regression/extendedCharacters.json", "com.example");
+            File outputDirectory = schemaRule.generate("/schema/regression/extendedCharacters.json", "com.example");
             File sourceFile = new File(outputDirectory, "com/example/ExtendedCharacters.java");
             String javaSource = IOUtils.toString(new FileInputStream(sourceFile), "utf-8");
 
@@ -60,7 +64,7 @@ public class OutputEncodingIT {
     @Test
     public void writeExtendedCharactersAsSingleByteSourceCode() throws IOException {
 
-        File outputDirectory = generate("/schema/regression/extendedCharacters.json", "com.example", config("outputEncoding", "iso-8859-5"));
+        File outputDirectory = schemaRule.generate("/schema/regression/extendedCharacters.json", "com.example", config("outputEncoding", "iso-8859-5"));
 
         File sourceFile = new File(outputDirectory, "com/example/ExtendedCharacters.java");
         String javaSource = IOUtils.toString(new FileInputStream(sourceFile), "iso-8859-5");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
@@ -17,13 +17,14 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.ParcelUtils.*;
 import static org.junit.Assert.*;
 
-import java.io.File;
 import java.io.IOException;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -38,11 +39,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Config(manifest=Config.NONE)
 public class ParcelableIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void parcelableTreeIsParcelable() throws ClassNotFoundException, IOException {
-        File generatedTypesDirectory = generate("/schema/parcelable/parcelable-schema.json", "com.example", 
-                config("parcelable", true));
-        Class<?> parcelableType = compile(generatedTypesDirectory).loadClass("com.example.ParcelableSchema");
+        Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-schema.json", "com.example", 
+                config("parcelable", true))
+                .loadClass("com.example.ParcelableSchema");
         
         Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-data.json"), parcelableType);
         String key = "example";

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/PrefixSuffixIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/PrefixSuffixIT.java
@@ -16,90 +16,94 @@
 
 package org.jsonschema2pojo.integration.config;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class PrefixSuffixIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void defaultClassPrefix() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
         resultsClassLoader.loadClass("com.example.PrimitiveProperties");
     }
 
     @Test
     public void customClassPrefix() throws ClassNotFoundException{
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","Abstract"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","Abstract"));
         resultsClassLoader.loadClass("com.example.AbstractPrimitiveProperties");
     }
     
     @Test
     public void noCapsCustomClassPrefix() throws ClassNotFoundException{
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","abstract"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","abstract"));
         resultsClassLoader.loadClass("com.example.abstractPrimitiveProperties");
     }
 
     @Test
     public void defaultClassSuffix() throws ClassNotFoundException{
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
         resultsClassLoader.loadClass("com.example.PrimitiveProperties");
     }
 
     @Test
     public void customClassSuffix() throws ClassNotFoundException{
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","Dao"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","Dao"));
         resultsClassLoader.loadClass("com.example.PrimitivePropertiesDao");
     }
     
     @Test
     public void noCapsCustomClassSuffix() throws ClassNotFoundException{
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","dao"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","dao"));
         resultsClassLoader.loadClass("com.example.PrimitivePropertiesdao");
     }
 
     @Test(expected = ClassNotFoundException.class)
     public void NotExistingClassPrefix() throws ClassNotFoundException{
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","Abstract"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","Abstract"));
         resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
     }
 
     @Test(expected = ClassNotFoundException.class)
     public void NotExistingClassSufix() throws ClassNotFoundException{
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","Dao"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","Dao"));
         resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
     }
 
     @Test(expected = ClassNotFoundException.class)
     public void SuffixWithDefaultPackageName() throws ClassNotFoundException{
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "", config("classNameSuffix","Dao"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "", config("classNameSuffix","Dao"));
         resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
     }
 
     @Test(expected = ClassNotFoundException.class)
     public void PrefixWithDefaultPackageName() throws ClassNotFoundException{
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitiveProperties.json", "", config("classNamePrefix","Abstract"));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "", config("classNamePrefix","Abstract"));
         resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
     }
 
     @Test
     public void customClassPrefixNoJavaType() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
                 "com.example", config("classNamePrefix","Prefix"));
         resultsClassLoader.loadClass("com.example.PrefixPrimitivePropertiesNoJavaType");
     }
     
     @Test
     public void customClassPrefixNoCapsNoJavaType() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
                 "com.example", config("classNamePrefix","prefix"));
         resultsClassLoader.loadClass("com.example.prefixPrimitivePropertiesNoJavaType");
     }
@@ -107,7 +111,7 @@ public class PrefixSuffixIT {
     @Test
     public void customClassSuffixNoJavaType() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
                 "com.example", config("classNameSuffix","Suffix"));
         resultsClassLoader.loadClass("com.example.PrimitivePropertiesNoJavaTypeSuffix");
     }
@@ -115,14 +119,14 @@ public class PrefixSuffixIT {
     @Test
     public void customClassSuffixNoCapsNoJavaType() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
                 "com.example", config("classNameSuffix","suffix"));
         resultsClassLoader.loadClass("com.example.PrimitivePropertiesNoJavaTypesuffix");
     }
 
     @Test
     public void customClassPrefixAndSuffixNoJavaType() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitivePropertiesNoJavaType.json",
                 "com.example", config("classNamePrefix", "Prefix", "classNameSuffix","Suffix"));
         resultsClassLoader.loadClass("com.example.PrefixPrimitivePropertiesNoJavaTypeSuffix");
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RemoveOldOutputIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RemoveOldOutputIT.java
@@ -18,12 +18,15 @@ package org.jsonschema2pojo.integration.config;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 
-import java.io.File;
 import java.net.URL;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class RemoveOldOutputIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test(expected = ClassNotFoundException.class)
     public void removeOldOutputCausesOldTypesToBeDeleted() throws ClassNotFoundException {
@@ -31,11 +34,10 @@ public class RemoveOldOutputIT {
         URL schema1 = getClass().getResource("/schema/properties/primitiveProperties.json");
         URL schema2 = getClass().getResource("/schema/properties/orderedProperties.json");
 
-        File outputDirectory = createTemporaryOutputFolder();
-        generate(schema1, "com.example", config("removeOldOutput", true), outputDirectory);
-        generate(schema2, "com.example", config("removeOldOutput", true), outputDirectory);
+        schemaRule.generate(schema1, "com.example", config("removeOldOutput", true));
+        schemaRule.generate(schema2, "com.example", config("removeOldOutput", true));
 
-        compile(outputDirectory).loadClass("com.example.PrimitiveProperties");
+        schemaRule.compile().loadClass("com.example.PrimitiveProperties");
 
     }
 
@@ -45,11 +47,10 @@ public class RemoveOldOutputIT {
         URL schema1 = getClass().getResource("/schema/properties/primitiveProperties.json");
         URL schema2 = getClass().getResource("/schema/properties/orderedProperties.json");
 
-        File outputDirectory = createTemporaryOutputFolder();
-        generate(schema1, "com.example", config(), outputDirectory);
-        generate(schema2, "com.example", config(), outputDirectory);
+        schemaRule.generate(schema1, "com.example", config());
+        schemaRule.generate(schema2, "com.example", config());
 
-        compile(outputDirectory).loadClass("com.example.PrimitiveProperties");
+        schemaRule.compile().loadClass("com.example.PrimitiveProperties");
 
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
@@ -17,14 +17,14 @@
 package org.jsonschema2pojo.integration.filtering;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -33,6 +33,8 @@ import org.junit.Test;
  * @author Christian Trimble
  */
 public class FilteringIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     URL filteredSchemaUrl;
     URL subSchemaUrl;
     
@@ -44,7 +46,7 @@ public class FilteringIT {
 
     @Test
     public void shouldFilterFiles() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(filteredSchemaUrl, "com.example",
                 config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
 
         resultsClassLoader.loadClass("com.example.Included");
@@ -52,7 +54,7 @@ public class FilteringIT {
     
     @Test(expected=ClassNotFoundException.class)
     public void shouldNotProcessExcludedFiles() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example",
+        ClassLoader resultsClassLoader =schemaRule. generateAndCompile(filteredSchemaUrl, "com.example",
                 config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
 
         resultsClassLoader.loadClass("com.example.Excluded");
@@ -60,7 +62,7 @@ public class FilteringIT {
 
     @Test
     public void shouldIncludeNestedFilesWithFiltering() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile(filteredSchemaUrl, "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(filteredSchemaUrl, "com.example",
                 config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
 
         resultsClassLoader.loadClass("com.example.sub.Sub");
@@ -68,7 +70,7 @@ public class FilteringIT {
 
     @Test
     public void shouldUseDefaultExcludesWithoutIncludesAndExcludes() throws ClassNotFoundException {
-        ClassLoader resultsClassLoader = generateAndCompile(subSchemaUrl, "com.example.sub",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(subSchemaUrl, "com.example.sub",
                 config("includes", new String[] {}, "excludes", new String[] {}));
 
         resultsClassLoader.loadClass("com.example.sub.Sub");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/JsonTypesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/JsonTypesIT.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.integration.json;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -25,18 +25,22 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonTypesIT {
+    
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     public void simpleTypesInExampleAreMappedToCorrectJavaTypes() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/simpleTypes.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/simpleTypes.json", "com.example",
                 config("sourceType", "json"));
 
         Class<?> generatedType = resultsClassLoader.loadClass("com.example.SimpleTypes");
@@ -54,7 +58,7 @@ public class JsonTypesIT {
     @Test(expected = ClassNotFoundException.class)
     public void simpleTypeAtRootProducesNoJavaTypes() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/simpleTypeAsRoot.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/simpleTypeAsRoot.json", "com.example",
                 config("sourceType", "json"));
 
         resultsClassLoader.loadClass("com.example.SimpleTypeAsRoot");
@@ -65,7 +69,7 @@ public class JsonTypesIT {
     @SuppressWarnings("unchecked")
     public void complexTypesProduceObjects() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/complexObject.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/complexObject.json", "com.example",
                 config("sourceType", "json"));
 
         Class<?> complexObjectClass = resultsClassLoader.loadClass("com.example.ComplexObject");
@@ -90,7 +94,7 @@ public class JsonTypesIT {
     @SuppressWarnings("rawtypes")
     public void arrayTypePropertiesProduceLists() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/array.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/array.json", "com.example",
                 config("sourceType", "json"));
 
         Class<?> arrayType = resultsClassLoader.loadClass("com.example.Array");
@@ -113,7 +117,7 @@ public class JsonTypesIT {
     @Test(expected = ClassNotFoundException.class)
     public void arrayAtRootProducesNoJavaTypes() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/arrayAsRoot.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/arrayAsRoot.json", "com.example",
                 config("sourceType", "json"));
 
         resultsClassLoader.loadClass("com.example.ArrayAsRoot");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/RealJsonExamplesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/RealJsonExamplesIT.java
@@ -17,23 +17,27 @@
 package org.jsonschema2pojo.integration.json;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import java.util.List;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RealJsonExamplesIT {
 
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     public void getUserDataProducesValidTypes() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/examples/GetUserData.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/examples/GetUserData.json", "com.example",
                 config("sourceType", "json",
                         "useLongIntegers", true));
 
@@ -56,7 +60,7 @@ public class RealJsonExamplesIT {
     @Test
     public void torrentProducesValidTypes() throws Exception {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/json/examples/torrent.json", "com.example",
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/examples/torrent.json", "com.example",
                 config("sourceType", "json",
                         "propertyWordDelimiters", "_"));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/AbsoluteRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/AbsoluteRefIT.java
@@ -17,7 +17,6 @@
 package org.jsonschema2pojo.integration.ref;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.junit.Assert.*;
 
 import java.io.File;
@@ -26,17 +25,20 @@ import java.io.IOException;
 import java.net.URL;
 
 import org.apache.commons.io.IOUtils;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class AbsoluteRefIT {
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void absoluteRefIsReadSuccessfully() throws ClassNotFoundException, NoSuchMethodException, IOException {
 
         File schemaWithAbsoluteRef = createSchemaWithAbsoluteRef();
 
-        File generatedOutputDirectory = generate(schemaWithAbsoluteRef.toURI().toURL(), "com.example");
-        Class<?> absoluteRefClass = compile(generatedOutputDirectory).loadClass("com.example.AbsoluteRef");
+        Class<?> absoluteRefClass = schemaRule.generateAndCompile(schemaWithAbsoluteRef.toURI().toURL(), "com.example")
+                .loadClass("com.example.AbsoluteRef");
 
         Class<?> addressClass = absoluteRefClass.getMethod("getAddress").getReturnType();
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
@@ -16,21 +16,24 @@
 
 package org.jsonschema2pojo.integration.ref;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class ClasspathRefIT {
+
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classpathRefsClass;
 
     @BeforeClass
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
-        ClassLoader classpathRefsClassLoader = generateAndCompile("/schema/ref/classpathRefs.json", "com.example");
+        ClassLoader classpathRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/classpathRefs.json", "com.example");
 
         classpathRefsClass = classpathRefsClassLoader.loadClass("com.example.ClasspathRefs");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/CyclicalRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/CyclicalRefIT.java
@@ -16,19 +16,22 @@
 
 package org.jsonschema2pojo.integration.ref;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class CyclicalRefIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void cyclicalRefsAreReadSuccessfully() throws ClassNotFoundException, NoSuchMethodException {
 
-        ClassLoader resultsClassLoader = generateAndCompile("/schema/ref/subdirectory1/refToSubdirectory2.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/ref/subdirectory1/refToSubdirectory2.json", "com.example");
 
         Class class1 = resultsClassLoader.loadClass("com.example.RefToSubdirectory2");
         Class class2 = resultsClassLoader.loadClass("com.example.RefToSubdirectory1");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/FragmentRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/FragmentRefIT.java
@@ -17,14 +17,15 @@
 package org.jsonschema2pojo.integration.ref;
 
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
 
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.jsonschema2pojo.rules.RuleFactory;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,12 +35,14 @@ import com.sun.codemodel.JPackage;
 
 public class FragmentRefIT {
 
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
     private static Class<?> fragmentRefsClass;
 
     @BeforeClass
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
-        ClassLoader fragmentRefsClassLoader = generateAndCompile("/schema/ref/fragmentRefs.json", "com.example");
+        ClassLoader fragmentRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/fragmentRefs.json", "com.example");
 
         fragmentRefsClass = fragmentRefsClassLoader.loadClass("com.example.FragmentRefs");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/HttpRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/HttpRefIT.java
@@ -16,21 +16,24 @@
 
 package org.jsonschema2pojo.integration.ref;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class HttpRefIT {
+
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> httpRefsClass;
 
     @BeforeClass
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
-        ClassLoader httpRefsClassLoader = generateAndCompile("/schema/ref/httpRefs.json", "com.example");
+        ClassLoader httpRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/httpRefs.json", "com.example");
 
         httpRefsClass = httpRefsClassLoader.loadClass("com.example.HttpRefs");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RelativeRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RelativeRefIT.java
@@ -16,24 +16,27 @@
 
 package org.jsonschema2pojo.integration.ref;
 
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class RelativeRefIT {
+
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> relativeRefsClass;
 
     @BeforeClass
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
-        ClassLoader relativeRefsClassLoader = generateAndCompile("/schema/ref/refsToA.json", "com.example");
+        ClassLoader relativeRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/refsToA.json", "com.example");
 
         relativeRefsClass = relativeRefsClassLoader.loadClass("com.example.RefsToA");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
@@ -17,7 +17,6 @@
 package org.jsonschema2pojo.integration.util;
 
 import static org.apache.commons.io.FileUtils.*;
-import static org.apache.commons.lang3.StringUtils.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -25,7 +24,6 @@ import static org.mockito.Mockito.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -34,10 +32,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.fest.util.Lists;
+import org.fest.util.Strings;
 import org.jsonschema2pojo.maven.Jsonschema2PojoMojo;
 import org.jsonschema2pojo.util.URLUtil;
 
@@ -121,24 +122,28 @@ public class CodeGenerationHelper {
      */
     public static ClassLoader compile(File sourceDirectory) {
 
-        return compile(sourceDirectory, new ArrayList<String>(), new HashMap<String, Object>());
+        return compile(sourceDirectory, new ArrayList<File>(), new HashMap<String, Object>());
 
     }
     
-    public static ClassLoader compile(File sourceDirectory, List<String> classpath ) {
+    public static ClassLoader compile(File sourceDirectory, List<File> classpath ) {
         return compile(sourceDirectory, classpath, new HashMap<String, Object>());
     }
 
-    public static ClassLoader compile(File sourceDirectory, List<String> classpath, Map<String, Object> config) {
+    public static ClassLoader compile(File sourceDirectory, List<File> classpath, Map<String, Object> config) {
+      return compile(sourceDirectory, sourceDirectory, classpath, config);
+    }
+    
+    public static ClassLoader compile(File sourceDirectory, File outputDirectory, List<File> classpath, Map<String, Object> config) {
 
-        List<String> fullClasspath = new ArrayList<String>();
+        List<File> fullClasspath = new ArrayList<File>();
         fullClasspath.addAll(classpath);
-        fullClasspath.add(System.getProperty("java.class.path"));
+        fullClasspath.addAll(CodeGenerationHelper.classpathToFileArray(System.getProperty("java.class.path")));
 
-        new Compiler().compile(sourceDirectory, join(fullClasspath, File.pathSeparatorChar), (String)config.get("targetVersion"));
+        new Compiler().compile(sourceDirectory, outputDirectory, fullClasspath, (String)config.get("targetVersion"));
 
         try {
-            return URLClassLoader.newInstance(new URL[] { sourceDirectory.toURI().toURL() }, Thread.currentThread().getContextClassLoader());
+            return URLClassLoader.newInstance(new URL[] { outputDirectory.toURI().toURL() }, Thread.currentThread().getContextClassLoader());
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
@@ -162,7 +167,7 @@ public class CodeGenerationHelper {
 
         File outputDirectory = generate(schema, targetPackage, configValues);
 
-        return compile(outputDirectory, new ArrayList<String>(), configValues);
+        return compile(outputDirectory, new ArrayList<File>(), configValues);
 
     }
 
@@ -178,7 +183,7 @@ public class CodeGenerationHelper {
 
         File outputDirectory = generate(schema, targetPackage, configValues);
 
-        return compile(outputDirectory, new ArrayList<String>(), configValues);
+        return compile(outputDirectory, new ArrayList<File>(), configValues);
 
     }
 
@@ -231,5 +236,18 @@ public class CodeGenerationHelper {
         }
 
         return values;
+    }
+
+    private static List<File> classpathToFileArray( String classpath ) {
+        List<File> files = Lists.newArrayList();
+        
+        if( Strings.isNullOrEmpty(classpath)) return files;
+        
+        String[] paths = classpath.split(Pattern.quote(File.pathSeparator));
+        for( String path : paths ) {
+            if( Strings.isNullOrEmpty(classpath) ) continue;
+            files.add(new File(path));
+        }
+        return files;
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Compiler.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Compiler.java
@@ -19,12 +19,17 @@ package org.jsonschema2pojo.integration.util;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import static java.util.Arrays.*;
+import java.util.Arrays;
+
 import java.util.Collection;
+import java.util.List;
+
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
+
 import static org.apache.commons.io.FileUtils.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -36,26 +41,29 @@ import static org.junit.Assert.*;
  */
 public class Compiler {
 
-    public void compile(File directory, String classpath) {
-        compile(directory, classpath, null);
-    }
-
-    public void compile(File directory, String classpath, String targetVersion) {
-        
+    public void compile(File sourceDirectory, File outputDirectory, List<File> classpath, String targetVersion ) {
         targetVersion = targetVersion == null ? "1.6" : targetVersion;
 
         JavaCompiler javaCompiler = ToolProvider.getSystemJavaCompiler();
         StandardJavaFileManager fileManager = javaCompiler.getStandardFileManager(null, null, null);
 
-        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(findAllSourceFiles(directory));
+        if (outputDirectory != null) {
+            try {
+                fileManager.setLocation(StandardLocation.CLASS_OUTPUT,
+                        Arrays.asList(outputDirectory));
+                fileManager.setLocation(StandardLocation.CLASS_PATH, classpath);
+            } catch (IOException e) {
+                throw new RuntimeException("could not set output directory", e);
+            }
+        }
+
+        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(findAllSourceFiles(sourceDirectory));
 
         ArrayList<String> options = new ArrayList<String>();
         options.add("-source");
         options.add(targetVersion);
         options.add("-target");
         options.add(targetVersion);
-        options.add("-classpath");
-        options.add(classpath);
         options.add("-encoding");
         options.add("UTF8");
         options.add("-Xlint:-options");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright ¬© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import static org.apache.commons.io.FileUtils.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * A JUnit rule that executes JsonSchema2Pojo.
+ *
+ * @author Christian Trimble
+ *
+ */
+public class Jsonschema2PojoRule implements TestRule {
+
+    private File generateDir;
+    private File compileDir;
+    private boolean active = false;
+    private boolean sourceDirInitialized = false;
+    private boolean classesDirInitialized = false;
+    private ClassLoader classLoader;
+
+    /**
+     * Gets the target directory for generate calls.
+     *
+     * @return The target directory for generate calls.
+     */
+    public File getGenerateDir() {
+        checkActive();
+        sourceDirInitialized = ensureDirectoryInitialized(generateDir, sourceDirInitialized);
+        return generateDir;
+    }
+
+    /**
+     * Gets the target directory for compile calls.
+     *
+     * @return The target directory for compile calls.
+     */
+    public File getCompileDir() {
+        checkActive();
+        classesDirInitialized = ensureDirectoryInitialized(compileDir, classesDirInitialized);
+        return compileDir;
+    }
+
+    /**
+     * Returns the class loader for compiled classes. Only defined after calling
+     * a compile method.
+     *
+     * @return The class loader for compiled classes.
+     */
+    public ClassLoader getClassLoader() {
+        checkActive();
+        return classLoader;
+    }
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                active = true;
+                try {
+                    File testRoot = methodNameDir(classNameDir(rootDirectory(), description.getClassName()),
+                            description.getMethodName());
+                    generateDir = new File(testRoot, "generate");
+                    compileDir = new File(testRoot, "compile");
+
+                    base.evaluate();
+                } finally {
+                    generateDir = null;
+                    compileDir = null;
+                    classLoader = null;
+                    sourceDirInitialized = false;
+                    classesDirInitialized = false;
+                    active = false;
+                }
+            }
+        };
+    }
+
+    public File generate(String schema, String targetPackage) {
+        return generate(schema, targetPackage, emptyConfig());
+    }
+
+    public File generate(URL schema, String targetPackage) {
+        return generate(schema, targetPackage, emptyConfig());
+    }
+
+    public File generate(String schema, String targetPackage, Map<String, Object> configValues) {
+        return generate(schemaUrl(schema), targetPackage, configValues);
+    }
+
+    public File generate(final URL schema, final String targetPackage, final Map<String, Object> configValues) {
+        CodeGenerationHelper.generate(schema, targetPackage, configValues, getGenerateDir());
+        return generateDir;
+    }
+
+    public ClassLoader compile() {
+        return compile(emptyClasspath(), emptyConfig());
+    }
+
+    public ClassLoader compile(List<File> classpath) {
+        return compile(classpath, emptyConfig());
+    }
+
+    public ClassLoader compile(List<File> classpath, Map<String, Object> config) {
+        if (classLoader != null) {
+            throw new IllegalStateException("cannot recompile sources");
+        }
+        classLoader = CodeGenerationHelper.compile(getGenerateDir(), getCompileDir(), classpath, config);
+        return classLoader;
+    }
+
+    public ClassLoader generateAndCompile(String schema, String targetPackage, Map<String, Object> configValues) {
+        generate(schema, targetPackage, configValues);
+        return compile(emptyClasspath(), configValues);
+    }
+
+    public ClassLoader generateAndCompile(String schema, String targetPackage) {
+        generate(schema, targetPackage);
+        return compile();
+    }
+
+    public ClassLoader generateAndCompile(URL schema, String targetPackage) {
+        generate(schema, targetPackage);
+        return compile(emptyClasspath(), emptyConfig());
+    }
+
+    public ClassLoader generateAndCompile(URL schema, String targetPackage, Map<String, Object> configValues) {
+        generate(schema, targetPackage, configValues);
+        return compile(emptyClasspath(), configValues);
+    }
+
+    public File generated(String relativeSourcePath) {
+        return new File(generateDir, relativeSourcePath);
+    }
+
+    private void checkActive() {
+        if (active != true) {
+            throw new IllegalStateException("cannot access Jsonschema2PojoRule state when inactive");
+        }
+    }
+
+    private static List<File> emptyClasspath() {
+        return new ArrayList<File>();
+    }
+
+    private static Map<String, Object> emptyConfig() {
+        return new HashMap<String, Object>();
+    }
+
+    private static URL schemaUrl(String schema) {
+        URL schemaUrl = Jsonschema2PojoRule.class.getResource(schema);
+        assertThat("Unable to read schema resource from the classpath: " + schema, schemaUrl, is(notNullValue()));
+        return schemaUrl;
+    }
+
+    static File rootDirectory() {
+        return new File("target" + File.separator + "jsonschema2pojo");
+    }
+
+    static File classNameDir(File baseDir, String className) throws IOException {
+        return new File(baseDir, classNameToPath(className));
+    }
+
+    static final Pattern methodNamePattern = compilePattern("\\A([^\\[]+)(?:\\[(.*)\\])?\\Z");
+
+    /**
+     * Returns the compiled pattern, or null if the pattern could not compile.
+     */
+    static Pattern compilePattern(String pattern) {
+        try {
+            return Pattern.compile(pattern);
+        } catch (Exception e) {
+            System.err.println("Could not compile pattern " + pattern);
+            e.printStackTrace(System.err);
+            return null;
+        }
+    }
+
+    static File methodNameDir(File baseDir, String methodName) throws IOException {
+        if (methodName == null)
+            methodName = "class";
+        Matcher matcher = methodNamePattern.matcher(methodName);
+
+        if (matcher.matches()) {
+            if (matcher.group(2) != null) {
+                baseDir = new File(baseDir, safeDirName(matcher.group(2)));
+            }
+            return new File(baseDir, safeDirName(matcher.group(1)));
+        } else {
+            throw new IOException("cannot transform methodName (" + methodName + ") into path");
+        }
+    }
+
+    static boolean ensureDirectoryInitialized(File dir, boolean isInitialized) {
+        if (!isInitialized) {
+            try {
+                forceMkdir(dir);
+                cleanDirectory(dir);
+            } catch (IOException ioe) {
+                throw new RuntimeException("could not clean directory", ioe);
+            }
+        }
+        return true;
+    }
+
+    static String safeDirName(String label) {
+        return label.replaceAll("[^a-zA-Z1-9]+", "_");
+    }
+
+    static String classNameToPath(String className) {
+        return className
+                .replaceAll("\\A(?:.*\\.)?([^\\.]*)\\Z", "$1")
+                .replaceAll("\\$", File.separator);
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRuleTest.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRuleTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright ¬© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.util;
+
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
+
+@RunWith(Enclosed.class)
+public class Jsonschema2PojoRuleTest {
+
+    public static class MethodTests {
+        @Rule
+        public Jsonschema2PojoRule rule = new Jsonschema2PojoRule();
+
+        @Test
+        public void sourcesWillCompile() throws ClassNotFoundException {
+            ClassLoader resultsClassLoader = rule.generateAndCompile("/schema/default/default.json", "com.example");
+            resultsClassLoader.loadClass("com.example.Default");
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ParameterizedTest {
+        @Rule
+        public Jsonschema2PojoRule rule = new Jsonschema2PojoRule();
+
+        @SuppressWarnings("unchecked")
+        @Parameters(name = "{0}")
+        public static Collection<Object[]> parameters() {
+            return Arrays.asList(new Object[][] { { "label1" }, { "label2" }, { "../../../" } });
+        }
+
+        public ParameterizedTest(String label) {
+        }
+
+        @Test
+        public void sourcesForLabelsWillCompile() throws ClassNotFoundException {
+            ClassLoader resultsClassLoader = rule.generateAndCompile("/schema/default/default.json", "com.example");
+            resultsClassLoader.loadClass("com.example.Default");
+        }
+    }
+}


### PR DESCRIPTION
This PR defines a JUnit Rule for executing Jsonschema2Pojo and modifies the test cases to use the rule.  This rule was added to make generated output easier to find on the file system.  Instead of creating temporary files with random names, this rule creates source files under `target/jsonschema2pojo`.  Output directories for individual tests are created based on the test's `className` and `methodName`, as reported by JUnit.

Notes:

- `InitializeCollectionsIT.java` was converted to a parameterized test.  This allowed the test to work with the rule, without adding additional complexity.
- Test class paths are now represented as `List<File>` instead of `List<String>`, as this works better with the compiler's file manager.