### PR TITLE
Cleanup for new date time type feature

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -122,13 +122,13 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private boolean includeAccessors = true;
     
     private String targetVersion = "1.6";
-    
+
     private boolean includeDynamicAccessors = true;
-    
+
     private String dateTimeType = null;
-    
+
     private String timeType = null;
-    
+
     private String dateType = null;
 
 
@@ -769,7 +769,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isIncludeDynamicAccessors() {
         return includeDynamicAccessors;
-    }    
+    }
 
     @Override
     public String getDateTimeType() {

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -215,12 +215,12 @@
       </tr>
       <tr>
         <td valign="top">useJodaLocalDates</td>
-        <td valign="top">Whether to use <code>org.joda.time.LocalDate</code> instead of String when adding string fields with format date to generated Java types.</td>
+        <td valign="top">Whether to use <code>org.joda.time.LocalDate</code> instead of <code>java.lang.String</code> when adding string fields with format date to generated Java types.</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>
       </tr>
       <tr>
         <td valign="top">useJodaLocalTimes</td>
-        <td valign="top">Whether to use <code>org.joda.time.LocalTime</code> instead of String when adding string fields with format time to generated Java types.</td>
+        <td valign="top">Whether to use <code>org.joda.time.LocalTime</code> instead of <code>java.lang.String</code> when adding string fields with format time to generated Java types.</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>
       </tr>
       <tr>
@@ -237,23 +237,37 @@
         <td valign="top">targetVersion</td>
         <td valign="top">The target version for generated source files.</td>
         <td align="center" valign="top">No (default <code>1.6</code>)</td>
-      </tr>      
+      </tr>
       <tr>
         <td valign="top">dateTimeType</td>
-        <td valign="top">Specify class to use i.e.<code>java.time.LocalDateTime</code> instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.</td>
-        <td align="center" valign="top">default <code>null</code></td>
+        <td valign="top">The java type to use instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.
+          <ul>
+            <li><code>org.joda.time.LocalDateTime</code> (Joda)</li>
+            <li><code>java.time.LocalDateTime</code> (JSR310)</li>
+          </ul>
+        </td>
+        <td align="center" valign="top">No</td>
       </tr>
       <tr>
         <td valign="top">dateType</td>
-        <td valign="top">Specify class to use i.e.<code>java.time.LocalDate</code> instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.</td>
-        <td align="center" valign="top">default <code>null</code></td>
+        <td valign="top">The java type to use instead of <code>java.lang.String</code> when adding string fields with format date to generated Java types.
+          <ul>
+            <li><code>org.joda.time.LocalDate</code> (Joda)</li>
+            <li><code>java.time.LocalDate</code> (JSR310)</li>
+          </ul>
+        </td>
+        <td align="center" valign="top">No</td>
       </tr>
       <tr>
         <td valign="top">timeType</td>
-        <td valign="top">Specify class to use i.e.<code>java.time.LocalTime</code> instead of <code>java.util.Date</code> when adding date-time type fields to generated Java types.</td>
-        <td align="center" valign="top">default <code>null</code></td>
+        <td valign="top">The java type to use instead of <code>java.lang.String</code> when adding string fields with format time to generated Java types.
+          <ul>
+            <li><code>org.joda.time.LocalTime</code> (Joda)</li>
+            <li><code>java.time.LocalTime</code> (JSR310)</li>
+          </ul>
+        </td>
+        <td align="center" valign="top">No</td>
       </tr>
-	  
     </table>
 
     <h3>Examples</h3>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -119,7 +119,7 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-dt", "--date-class" }, description = "Specify date class")
     private String dateType = null;
-    
+
     @Parameter(names = { "-c3", "--commons-lang3" }, description = "Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals, hashCode and toString methods.")
     private boolean useCommonsLang3 = false;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -271,7 +271,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isIncludeDynamicAccessors() {
         return true;
     }
-    
+
     @Override
     public String getDateTimeType() {
         return null;
@@ -285,5 +285,5 @@ public class DefaultGenerationConfig implements GenerationConfig {
     @Override
     public String getTimeType() {
         return null;
-    }    
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -272,7 +272,7 @@ public interface GenerationConfig {
     String getClassNameSuffix();
 
     /**
-     * Gets the 'includeConstructors' configuration option
+     * Gets the 'includeConstructors' configuration option.
      *
      * @return Whether to generate constructors or not.
      */
@@ -287,7 +287,7 @@ public interface GenerationConfig {
     boolean isConstructorsRequiredPropertiesOnly();
 
     /**
-     * Gets the 'includeAdditionalProperties' configuration option
+     * Gets the 'includeAdditionalProperties' configuration option.
      *
      * @return Whether to allow 'additional properties' support in objects.
      *         Setting this to false will disable additional properties support,
@@ -296,7 +296,7 @@ public interface GenerationConfig {
     boolean isIncludeAdditionalProperties();
 
     /**
-     * Gets the 'includeAccessors' configuration option
+     * Gets the 'includeAccessors' configuration option.
      *
      * @return Whether to include getters/setters or to omit these accessor
      *         methods and create public fields instead.
@@ -304,44 +304,65 @@ public interface GenerationConfig {
     boolean isIncludeAccessors();
 
     /**
-     * Gets the 'targetVersion' configuration option
+     * Gets the 'targetVersion' configuration option.
      * 
      *  @return The target version for generated source files.
      */
     String getTargetVersion();
 
     /**
-     * Gets the `includeDynamicAccessors` configuraiton option
+     * Gets the `includeDynamicAccessors` configuraiton option.
      *
      * @return Whether to include dynamic getters, setters, and builders
      *         or to omit these methods.
      */
     boolean isIncludeDynamicAccessors();
-    
+
     /**
-     * Allow to specifiy a class for date-time jsonschema type. Could be JSR310, Joda, ...  
-     * [org.joda.time.LocalDateTime,java.time.LocalDateTime, ...]
-     * java.time.* require JVM8 or greater
-     * @return
+     * Gets the `dateTimeType` configuration option.
+     *         <p>
+     *         Example values:
+     *         <ul>
+     *         <li><code>org.joda.time.LocalDateTime</code> (Joda)</li>
+     *         <li><code>java.time.LocalDateTime</code> (JSR310)</li>
+     *         <li><code>null</code> (default behavior)</li>
+     *         </ul>
+     *
+     * @return The java type to use instead of {@link java.util.Date}
+     *         when adding date type fields to generate Java types.
      */
     String getDateTimeType();
-    
-    
+
     /**
-     * Allow to specifiy a class for date-time jsonschema type. Could be JSR310, Joda, ...  
-     * [org.joda.time.LocalDate,java.time.LocalDate, ...]
-     * java.time.* require JVM8 or greater
-     * @return
+     * Gets the `dateType` configuration option.
+     *         <p>
+     *         Example values:
+     *         <ul>
+     *         <li><code>org.joda.time.LocalDate</code> (Joda)</li>
+     *         <li><code>java.time.LocalDate</code> (JSR310)</li>
+     *         <li><code>null</code> (default behavior)</li>
+     *         </ul>
+     *
+     * @return The java type to use instead of string
+     *         when adding string type fields with a format of date (not
+     *         date-time) to generated Java types.
      */
     String getDateType();
-    
+
     /**
-     * Allow to specifiy a class for date-time jsonschema type. Could be JSR310, Joda, ...  
-     * [org.joda.time.LocalTime,java.time.LocalTime, ...]
-     * java.time.* require JVM8 or greater
-     * @return
+     * Gets the `timeType` configuration option.
+     *         <p>
+     *         Example values:
+     *         <ul>
+     *         <li><code>org.joda.time.LocalTime</code> (Joda)</li>
+     *         <li><code>java.time.LocalTime</code> (JSR310)</li>
+     *         <li><code>null</code> (default behavior)</li>
+     *         </ul>
+     *
+     * @return The java type to use instead of string
+     *         when adding string type fields with a format of time (not
+     *         date-time) to generated Java types.
      */
     String getTimeType();
-    
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -136,7 +136,7 @@ public class FormatRule implements Rule<JType, JType> {
             try {
                 Class<?> clazz=Class.forName(type);
                 return clazz;
-            } 
+            }
             catch (ClassNotFoundException e) {
                 throw new GenerationException(format("could not load java type %s for date-time format", type), e);
             }
@@ -150,12 +150,11 @@ public class FormatRule implements Rule<JType, JType> {
             try {
                 Class<?> clazz=Class.forName(type);
                 return clazz;
-            } 
+            }
             catch (ClassNotFoundException e) {
                 throw new GenerationException(format("could not load java type %s for date format", type), e);
             }
-            
-        }        
+        }
         return ruleFactory.getGenerationConfig().isUseJodaLocalDates() ? LocalDate.class : String.class;
     }
 
@@ -165,11 +164,11 @@ public class FormatRule implements Rule<JType, JType> {
             try {
                 Class<?> clazz=Class.forName(type);
                 return clazz;
-            } 
+            }
             catch (ClassNotFoundException e) {
                 throw new GenerationException(format("could not load java type %s for time format", type), e);
             }
-        }      
+        }
         return ruleFactory.getGenerationConfig().isUseJodaLocalTimes() ? LocalTime.class : String.class;
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -26,9 +26,12 @@ import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.exception.GenerationException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JType;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static java.lang.String.format;
 
 /**
  * Applies the "format" schema rule.
@@ -129,13 +132,13 @@ public class FormatRule implements Rule<JType, JType> {
 
     private Class<?> getDateTimeType() {
         String type=ruleFactory.getGenerationConfig().getDateTimeType();
-        if (type!=null && type.length()>0){
+        if (!isEmpty(type)){
             try {
                 Class<?> clazz=Class.forName(type);
                 return clazz;
             } 
             catch (ClassNotFoundException e) {
-                e.printStackTrace();
+                throw new GenerationException(format("could not load java type %s for date-time format", type), e);
             }
         }
         return ruleFactory.getGenerationConfig().isUseJodaDates() ? DateTime.class : Date.class;
@@ -143,13 +146,13 @@ public class FormatRule implements Rule<JType, JType> {
 
     private Class<?> getDateOnlyType() {
         String type=ruleFactory.getGenerationConfig().getDateType();
-        if (type!=null && type.length()>0){
+        if (!isEmpty(type)){
             try {
                 Class<?> clazz=Class.forName(type);
                 return clazz;
             } 
             catch (ClassNotFoundException e) {
-                e.printStackTrace();
+                throw new GenerationException(format("could not load java type %s for date format", type), e);
             }
             
         }        
@@ -158,13 +161,13 @@ public class FormatRule implements Rule<JType, JType> {
 
     private Class<?> getTimeOnlyType() {
         String type=ruleFactory.getGenerationConfig().getTimeType();
-        if (type!=null && type.length()>0){
+        if (!isEmpty(type)){
             try {
                 Class<?> clazz=Class.forName(type);
                 return clazz;
             } 
             catch (ClassNotFoundException e) {
-                e.printStackTrace();
+                throw new GenerationException(format("could not load java type %s for time format", type), e);
             }
         }      
         return ruleFactory.getGenerationConfig().isUseJodaLocalTimes() ? LocalTime.class : String.class;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
@@ -22,14 +22,11 @@ import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
+import org.jsonschema2pojo.exception.GenerationException;
 import org.junit.Test;
 
 public class CustomDatesIT {
@@ -62,7 +59,6 @@ public class CustomDatesIT {
     
     @Test
     public void disablingDateTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
-        String clazz="org.joda.time.LocalDateTime";
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateTimeType", null));
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -80,7 +76,6 @@ public class CustomDatesIT {
     
     @Test
     public void disablingDateTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
-        String clazz="org.joda.time.LocalDate";
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("dateType", null));
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
@@ -98,13 +93,30 @@ public class CustomDatesIT {
     
     @Test
     public void disablingTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
-        String clazz="org.joda.time.LocalTime";
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("timeType", null));
         Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithTime, "stringAsTime", "java.lang.String");
     }    
    
+
+    @Test(expected=GenerationException.class)
+    public void throwsGenerationExceptionForUnknownDateTimeType() {
+        generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("dateTimeType", "org.jsonschema2pojo.integration.config.UnknownType"));
+    }
+
+    @Test(expected=GenerationException.class)
+    public void throwsGenerationExceptionForUnknownDateType() {
+        generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("dateType", "org.jsonschema2pojo.integration.config.UnknownType"));
+    }
+
+    @Test(expected=GenerationException.class)
+    public void throwsGenerationExceptionForUnknownTimeType() {
+        generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("timeType", "org.jsonschema2pojo.integration.config.UnknownType"));
+    }
 
     private void assertTypeIsExpected(Class<?> classInstance, String propertyName, String expectedType)
             throws IntrospectionException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
@@ -56,7 +56,7 @@ public class CustomDatesIT {
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDateTime", clazz);
     }
-    
+
     @Test
     public void disablingDateTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
@@ -73,7 +73,7 @@ public class CustomDatesIT {
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDate", clazz);
     }
-    
+
     @Test
     public void disablingDateTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
@@ -81,7 +81,7 @@ public class CustomDatesIT {
         Class<?> classWithDate = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithDate, "stringAsDate", "java.lang.String");
     }
-    
+
     @Test
     public void timeTypeCausesCustomTimeType() throws IntrospectionException, ClassNotFoundException {
         String clazz="org.joda.time.LocalTime";
@@ -90,15 +90,14 @@ public class CustomDatesIT {
         Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithTime, "stringAsTime", clazz);
     }
-    
+
     @Test
     public void disablingTimeTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
         ClassLoader classLoader = generateAndCompile("/schema/format/formattedProperties.json", "com.example",
                 config("timeType", null));
         Class<?> classWithTime = classLoader.loadClass("com.example.FormattedProperties");
         assertTypeIsExpected(classWithTime, "stringAsTime", "java.lang.String");
-    }    
-   
+    }
 
     @Test(expected=GenerationException.class)
     public void throwsGenerationExceptionForUnknownDateTimeType() {

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -332,7 +332,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.4.9
      */
     private boolean useJodaLocalTimes = false;
-    
+
     private String dateTimeType = null;
     private String timeType = null;
     private String dateType = null;


### PR DESCRIPTION
Cleans up some minor issues with the new date time functionality:

1. correct formatting
2. make documentation consistent with existing documentation
3. fail with `GenerationException` if date/time types are specified, but cannot be loaded.