### PR TITLE
Fixed "specimen" singular.

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
@@ -99,7 +99,9 @@ public class Inflector {
             .singular("(ess)$", "$1");
 
         builder.singular("men$", "man")
-            .plural("man$", "men");
+            .plural("man$", "men")
+            .singular("specimen", "specimen")
+            .plural("specimen", "specimens");
 
         builder.irregular("curve", "curves")
             .irregular("leaf", "leaves")

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
@@ -53,6 +53,11 @@ public class InflectorTest {
         assertThat(Inflector.getInstance().singularize("mattress"), is("mattress"));
         assertThat(Inflector.getInstance().singularize("address"), is("address"));
 
+        assertThat(Inflector.getInstance().singularize("men"), is("man"));
+        assertThat(Inflector.getInstance().singularize("women"), is("woman"));
+        assertThat(Inflector.getInstance().singularize("specimen"), is("specimen"));
+        assertThat(Inflector.getInstance().singularize("children"), is("child"));
+
         assertThat(Inflector.getInstance().singularize("s"), is("s"));
 
         assertThat(Inflector.getInstance().pluralize("mattress"), is("mattresses"));


### PR DESCRIPTION
Resolved #479.

Couldn't use the irregular feature as the "men" rule would still produce "speciman" as the singular.