### PR TITLE
Change includeDynamicAccessors default to false in the CLI.

### DIFF
--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -144,8 +144,8 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-tv", "--target-version" }, description = "The target version for generated source files.")
     private String targetVersion = "1.6";
     
-    @Parameter(names = { "-dda", "--disable-dynamic-accessors" }, description = "Disable dynamic getter, setter, and builder support on generated types.")
-    private boolean disableDynamicAccessors = false;
+    @Parameter(names = { "-ida", "--include-dynamic-accessors" }, description = "Include dynamic getter, setter, and builder support on generated types.")
+    private boolean includeDynamicAccessors = false;
 
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -343,7 +343,7 @@ public class Arguments implements GenerationConfig {
 
     @Override
     public boolean isIncludeDynamicAccessors() {
-        return !disableDynamicAccessors;
+        return includeDynamicAccessors;
     }
 
     @Override

--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ArgumentsTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ArgumentsTest.java
@@ -23,10 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 
-import org.jsonschema2pojo.util.URLUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +51,7 @@ public class ArgumentsTest {
     public void parseRecognisesValidArguments() {
         ArgsForTest args = (ArgsForTest) new ArgsForTest().parse(new String[] {
                 "--source", "/home/source", "--target", "/home/target", "--package", "mypackage",
-                "--generate-builders", "--use-primitives", "--omit-hashcode-and-equals", "--omit-tostring"
+                "--generate-builders", "--use-primitives", "--omit-hashcode-and-equals", "--omit-tostring", "--include-dynamic-accessors"
         });
 
         assertThat(args.didExit(), is(false));
@@ -65,12 +62,13 @@ public class ArgumentsTest {
         assertThat(args.isUsePrimitives(), is(true));
         assertThat(args.isIncludeHashcodeAndEquals(), is(false));
         assertThat(args.isIncludeToString(), is(false));
+        assertThat(args.isIncludeDynamicAccessors(), is(true));
     }
 
     @Test
     public void parseRecognisesShorthandArguments() {
         ArgsForTest args = (ArgsForTest) new ArgsForTest().parse(new String[] {
-                "-s", "/home/source", "-t", "/home/target", "-p", "mypackage", "-b", "-P", "-E", "-S"
+                "-s", "/home/source", "-t", "/home/target", "-p", "mypackage", "-b", "-P", "-E", "-S", "-ida"
         });
 
         assertThat(args.didExit(), is(false));
@@ -81,6 +79,7 @@ public class ArgumentsTest {
         assertThat(args.isUsePrimitives(), is(true));
         assertThat(args.isIncludeHashcodeAndEquals(), is(false));
         assertThat(args.isIncludeToString(), is(false));
+        assertThat(args.isIncludeDynamicAccessors(), is(true));
     }
 
     @Test
@@ -106,6 +105,7 @@ public class ArgumentsTest {
         assertThat(args.isUsePrimitives(), is(false));
         assertThat(args.isIncludeHashcodeAndEquals(), is(true));
         assertThat(args.isIncludeToString(), is(true));
+        assertThat(args.isIncludeDynamicAccessors(), is(false));
     }
 
     @Test


### PR DESCRIPTION
This is a breaking change.

Removes the `--disable-dynamic-accessors`/`-dda` option and replaces it with an `--include-dynamic-accessors`/`-ida` option instead.