### PR TITLE
Issue 481 fix

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -25,7 +25,9 @@ import java.net.URL;
 import java.net.URLDecoder;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.util.URLUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JBlock;
@@ -127,28 +129,26 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
             if (reference.startsWith("#/")) {
                 // self reference with type definition
                 // use the name of the type
+                
+                // TODO: what about nested references? How to handle them: e.g: "$ref": "#/definitions/level/sublevel/actual_element"
+                // with type information available only on actual_element and level/sublevel used as namespaces to avoid type conflicts
+                // e.g. level could also contain an actual_element definition which differs from the sublevel/actual_element.
+                // Maybe it is worth to generate java subpackages for such cases. 
                 return reference.substring(reference.lastIndexOf('/') + 1);
             } else {
                 // global reference (other file, url whatever)
                 final URI uri = schema == null || schema.getId() == null ? URI.create(reference) : schema.getId().resolve(reference);
-
-                try {
-                    return getNodeName(uri.toURL());
-                } catch (final MalformedURLException e) {
-                    throw new IllegalArgumentException(String.format("The referenced URL %s for %s is invalid", uri, nodeName), e);
-                }
+                
+                // TODO: actually this fix is incomplete. The uri may by any valid URL (file, classpath, java, http, etc)
+                // Also same problem exists here. The url may point to a schema with a type name already defined e.g.
+                // in the document referencing it, but with different contents. How to handle this?
+                // Maybe it is worth to require the usage of the "id" element of the json schema and generate package
+                // names based on it. In addition one could introduce configuration options to map these ids to 
+                // java packages.
+                return FilenameUtils.getBaseName(uri.getPath());
             }
         } else {
             return nodeName;
-        }
-
-    }
-
-    private String getNodeName(URL url) {
-        try {
-            return FilenameUtils.getBaseName(URLDecoder.decode(url.toString(), "UTF-8"));
-        } catch (final UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(String.format("Unable to generate node name from URL: %s", url.toString()), e);
         }
 
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
@@ -44,7 +44,7 @@ public class ClasspathRefIT {
 
         Class<?> aClass = classpathRefsClass.getMethod("getPropertyClasspathRef").getReturnType();
 
-        assertThat(aClass.getName(), is("com.example.PropertyClasspathRef"));
+        assertThat(aClass.getName(), is("com.example.A"));
         assertThat(aClass.getMethods(), hasItemInArray(hasProperty("name", equalTo("getPropertyOfA"))));
     }
 
@@ -53,7 +53,7 @@ public class ClasspathRefIT {
 
         Class<?> aClass = classpathRefsClass.getMethod("getPropertyResourceRef").getReturnType();
 
-        assertThat(aClass.getName(), is("com.example.PropertyResourceRef"));
+        assertThat(aClass.getName(), is("com.example.Title"));
         assertThat(aClass.getMethods(), hasItemInArray(hasProperty("name", equalTo("getTitle"))));
     }
 
@@ -62,7 +62,7 @@ public class ClasspathRefIT {
 
         Class<?> aClass = classpathRefsClass.getMethod("getPropertyJavaRef").getReturnType();
 
-        assertThat(aClass.getName(), is("com.example.PropertyJavaRef"));
+        assertThat(aClass.getName(), is("com.example.Description"));
         assertThat(aClass.getMethods(), hasItemInArray(hasProperty("name", equalTo("getDescription"))));
     }
 
@@ -71,12 +71,12 @@ public class ClasspathRefIT {
 
         Class<?> aClass = classpathRefsClass.getMethod("getTransitiveRelativeClasspathRef").getReturnType();
 
-        assertThat(aClass.getName(), is("com.example.TransitiveRelativeClasspathRef"));
+        assertThat(aClass.getName(), is("com.example.ClasspathRefs2"));
         assertThat(aClass.getMethods(), hasItemInArray(hasProperty("name", equalTo("getPropertyRelativeRef"))));
 
         Class<?> bClass = aClass.getMethod("getPropertyRelativeRef").getReturnType();
 
-        assertThat(bClass.getName(), is("com.example.PropertyRelativeRef"));
+        assertThat(bClass.getName(), is("com.example.ClasspathRefs3"));
         assertThat(bClass.getMethods(), hasItemInArray(hasProperty("name", equalTo("getTransitive"))));
 
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ExtRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ExtRefIT.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.ref;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.integration.util.CodeGenerationHelper;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.sun.codemodel.JCodeModel;
+
+public class ExtRefIT {
+    @Rule
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    
+    @Test
+    public void multipleExternalReferencesToDifferentTypes()  throws NoSuchMethodException, ClassNotFoundException, IOException {
+        URL schemaUrl = CodeGenerationHelper.class.getResource("/schema/ref/refsToExt.jsonschema");
+        JCodeModel codeModel = new JCodeModel();
+        
+        // NOTE: using generate with last argument being the loaded json schema contents (String) will make this test fail!!!!
+        new SchemaMapper().generate(codeModel, "RefsToExt", "com.example", schemaUrl);
+
+        codeModel.build(schemaRule.getGenerateDir());
+
+        ClassLoader classLoader = schemaRule.compile();
+
+        Class<?> topClass = classLoader.loadClass("com.example.RefsToExt");
+        assertThat(topClass.getMethod("getFirstExtRef").getReturnType().getSimpleName(), equalTo("FirstRef"));
+        assertThat(topClass.getMethod("getSecondExtRef").getReturnType().getSimpleName(), equalTo("SecondRef"));
+        assertThat(topClass.getMethod("getThirdExtRef").getReturnType().getSimpleName(), equalTo("FirstRef"));
+        assertThat(topClass.getMethod("getFourthExtRef").getReturnType().getSimpleName(), equalTo("SecondRef"));
+
+        Class<?> firstExtClass = classLoader.loadClass("com.example.FirstRef");
+        assertThat(firstExtClass.getMethod("getVal").getReturnType().getSimpleName(), equalTo("String"));
+
+        Class<?> secondExtClass = classLoader.loadClass("com.example.SecondRef");
+        assertThat(secondExtClass.getMethod("getVal").getReturnType().getSimpleName(), equalTo("String"));
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRef2IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRef2IT.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.ref;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.integration.util.CodeGenerationHelper;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.sun.codemodel.JCodeModel;
+
+public class SelfRef2IT {
+
+    @Rule
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void multipleNestedSelfReferencesToSameTypeDefinitions() throws NoSuchMethodException, ClassNotFoundException, IOException {
+
+        URL schemaUrl = CodeGenerationHelper.class.getResource("/schema/ref/selfRefs2.jsonschema");
+        JCodeModel codeModel = new JCodeModel();
+        
+        // NOTE: using generate with last argument being the loaded json schema contents (String) will make this test fail!!!!
+        new SchemaMapper().generate(codeModel, "SelfRefs2", "com.example", schemaUrl);
+
+        codeModel.build(schemaRule.getGenerateDir());
+
+        ClassLoader classLoader = schemaRule.compile();
+
+        Class<?> topClass = classLoader.loadClass("com.example.SelfRefs2");
+        assertThat(topClass.getMethod("getFirstRef").getReturnType().getSimpleName(), equalTo("AType"));
+        assertThat(topClass.getMethod("getSecondRef").getReturnType().getSimpleName(), equalTo("AType"));
+
+        Class<?> firstLevelClass = classLoader.loadClass("com.example.AType");
+        assertThat(firstLevelClass.getMethod("getFirstProp").getReturnType().getSimpleName(), equalTo("BType"));
+        assertThat(firstLevelClass.getMethod("getSecondProp").getReturnType().getSimpleName(), equalTo("BType"));
+
+        Class<?> secondLevelClass = classLoader.loadClass("com.example.BType");
+        assertThat(secondLevelClass.getMethod("getFirstProp").getReturnType().getSimpleName(), equalTo("String"));
+        assertThat(secondLevelClass.getMethod("getSecondProp").getReturnType().getSimpleName(), equalTo("String"));
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
@@ -92,9 +92,9 @@ public class SelfRefIT {
         assertThat(nestedSelfRefs.getMethod("getThings").getReturnType().getSimpleName(), equalTo("List"));
         
         Class<?> listEntryType = (Class<?>) ((ParameterizedType)nestedSelfRefs.getMethod("getThings").getGenericReturnType()).getActualTypeArguments()[0];
-        assertThat(listEntryType.getName(), equalTo("com.example.Thing"));
+        assertThat(listEntryType.getName(), equalTo("com.example.ThingList"));
         
-        Class<?> thingClass = classLoader.loadClass("com.example.Thing");
+        Class<?> thingClass = classLoader.loadClass("com.example.ThingList");
         assertThat(thingClass.getMethod("getNamespace").getReturnType().getSimpleName(), equalTo("String"));
         assertThat(thingClass.getMethod("getName").getReturnType().getSimpleName(), equalTo("String"));
         assertThat(thingClass.getMethod("getVersion").getReturnType().getSimpleName(), equalTo("String"));

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/firstRef.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/firstRef.json
@@ -1,0 +1,7 @@
+{
+	"type": "object",
+    
+    "properties": {
+    	"val": { "type": "string" }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/refsToExt.jsonschema
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/refsToExt.jsonschema
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    
+    "properties": {
+    	"first_ext_ref": { "$ref": "firstRef.json" },
+    	"second_ext_ref": { "$ref": "secondRef.json" },
+    	
+    	"third_ext_ref": { "$ref": "firstRef.json" },
+    	"fourth_ext_ref": { "$ref": "secondRef.json" }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/secondRef.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/secondRef.json
@@ -1,0 +1,7 @@
+{
+	"type": "object",
+    
+    "properties": {
+    	"val": { "type": "string" }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/selfRefs2.jsonschema
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/selfRefs2.jsonschema
@@ -1,0 +1,28 @@
+{
+	"id": "http://test.com",
+	"$schema": "http://json-schema.org/schema#",
+	
+	"definitions": {
+		"a_type": {
+		    "type": "object",
+		    "properties": {
+		        "first_prop": { "$ref": "#/definitions/b_type" },
+		        "second_prop": { "$ref": "#/definitions/b_type" }
+		    }
+	    },
+	    "b_type": {
+		    "type": "object",
+		    "properties": {
+		        "first_prop": { "type": "string" },
+		        "second_prop": { "type": "string" }
+		    }
+	    }
+    },
+    
+    "type": "object",
+    
+    "properties": {
+    	"first_ref": { "$ref": "#/definitions/a_type" },
+    	"second_ref": { "$ref": "#/definitions/a_type" }
+    }
+}


### PR DESCRIPTION
This fix solves the #464 and #481 issues. The implementation of the fix is done entirely in the PropertyRule class.

**IMPORTANT:** It will break the so far implemented naming convention of types. Instead of deriving the typename from the name of the first using property, or file name, the type name is now always based on its name from the reference (for internal references) or the actual file name for external references. Please see also my comments on #481 for more information.

**PLEASE SEE ALSO:** _TODO_s in the implementation of the `getPropertyTypeName` function (see diff view below).

Regards,
Dimitrij
