### PR TITLE
Fix for issue 486

### DIFF
--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
@@ -241,7 +241,7 @@ public class Jsonschema2PojoRule implements TestRule {
     static String classNameToPath(String className) {
         return className
                 .replaceAll("\\A(?:.*\\.)?([^\\.]*)\\Z", "$1")
-                .replaceAll("\\$", File.separator);
+                .replaceAll("\\$", Pattern.quote(File.separator));
     }
 
 }


### PR DESCRIPTION
Path separator is now properly escaped in the regular expression used in Jsonschema2PojoRule. This solves the #486 issue.