### PR TITLE
Issue 485 fix

### DIFF
--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/UrlConverterTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/UrlConverterTest.java
@@ -19,12 +19,11 @@ package org.jsonschema2pojo.cli;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.net.URL;
+
 import org.junit.Test;
 
 import com.beust.jcommander.ParameterException;
-import org.jsonschema2pojo.Annotator;
-
-import java.net.URL;
 
 public class UrlConverterTest {
 
@@ -34,7 +33,9 @@ public class UrlConverterTest {
     public void urlIsCreatedFromFilePath() {
         URL url = converter.convert("/path/to/something");
 
-        assertThat(url.getPath(), is("/path/to/something"));
+        // on *ux the path part of the URL is equal to the given path
+        // on Windows C: is prepended, which is expected
+        assertThat(url.getPath(), endsWith("/path/to/something"));
     }
 
     @Test


### PR DESCRIPTION
`UrlConverterTest.urlIsCreatedFromFilePath` uses an absolute *ux stype path. On Windows the Java FileSystem implementation converts it to a valid Windows path, that is, a `C:` is prepended to it. If instead a relative path is used by the test, the returned URL will contain the path to the project as well. This way in both cases we have to check whether the returned URL ends with the expected path, which is done by this commit. It fixes the #485 issue