### PR TITLE
Issue 484 fix

### DIFF
--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ArgumentsTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ArgumentsTest.java
@@ -58,7 +58,7 @@ public class ArgumentsTest {
         });
 
         assertThat(args.didExit(), is(false));
-        assertThat(args.getSource().next().getFile(), is("/home/source"));
+        assertThat(args.getSource().next().getFile(), endsWith("/home/source"));
         assertThat(args.getTargetDirectory(), is(theFile("/home/target")));
         assertThat(args.getTargetPackage(), is("mypackage"));
         assertThat(args.isGenerateBuilders(), is(true));
@@ -74,7 +74,7 @@ public class ArgumentsTest {
         });
 
         assertThat(args.didExit(), is(false));
-        assertThat(args.getSource().next().getFile(), is("/home/source"));
+        assertThat(args.getSource().next().getFile(), endsWith("/home/source"));
         assertThat(args.getTargetDirectory(), is(theFile("/home/target")));
         assertThat(args.getTargetPackage(), is("mypackage"));
         assertThat(args.isGenerateBuilders(), is(true));
@@ -99,7 +99,7 @@ public class ArgumentsTest {
         });
 
         assertThat(args.didExit(), is(false));
-        assertThat(args.getSource().next().getFile(), is("/home/source"));
+        assertThat(args.getSource().next().getFile(), endsWith("/home/source"));
         assertThat(args.getTargetDirectory(), is(theFile("/home/target")));
         assertThat(args.getTargetPackage(), is(nullValue()));
         assertThat(args.isGenerateBuilders(), is(false));


### PR DESCRIPTION
ArgumentsTest test use an absolute *ux stype path. On Windows the Java FileSystem implementation converts it to a valid Windows path, that is, a C: is prepended to it. If instead a relative path is used by the test, the returned URL will contain the path to the project as well. This way in both cases we have to check whether the returned URL ends with the expected path, which is done by this commit. It fixes the #484 issue.
Actually the reason for the issue is absolutely the same as for the issue #485.