### PR TITLE
Android gradle plugin fixes

### DIFF
--- a/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
@@ -12,13 +12,13 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "jsonschema2pojo.joelittlejohn.github.com.androidexample"
         minSdkVersion 17
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -29,11 +29,26 @@ android {
         }
     }
 
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+    }
+
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+
+    // Required for @Generated annotation
+    compile 'org.glassfish:javax.annotation:10.0-b28'
+    // Required if generating Gson annotations
+    compile 'com.google.code.gson:gson:2.4'
+    // Required if generating equals, hashCode, or toString methods
+    compile 'commons-lang:commons-lang:2.6'
+    // Required if generating JSR-303 annotations
+    compile 'javax.validation:validation-api:1.1.0.CR2'
+    // Required if generating Jackson 2 annotations
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.1.4'
 
 }
 
@@ -51,9 +66,9 @@ jsonSchema2Pojo {
     //source = files("${sourceSets.main.output.resourcesDir}/json")
     source = files("${project.rootDir}/schema")
 
-    // Target directory for generated Java source files. The plugin will add this directory to the
+    // Target directory for generated Java source files. The plugin will ignore this value for Android projects and will generate the classes into a generated source folder for each build variant and add this directory to the
     // java source set so the compiler will find and compile the newly generated source files.
-    targetDirectory = file("${project.rootDir}/build/generated-sources/js2p")
+    // targetDirectory = file("${project.rootDir}/build/generated-sources/js2p")
 
     // Package name used for generated Java classes (for types where a fully qualified name has not
     // been supplied in the schema using the 'javaType' property).

--- a/jsonschema2pojo-gradle-plugin/example/android/app/src/main/java/jsonschema2pojo/joelittlejohn/github/com/androidexample/MainActivity.java
+++ b/jsonschema2pojo-gradle-plugin/example/android/app/src/main/java/jsonschema2pojo/joelittlejohn/github/com/androidexample/MainActivity.java
@@ -21,15 +21,25 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.oosocial.clarityn.rest.clarityn.model.Entry_schema;
+import com.oosocial.clarityn.rest.clarityn.model.Storage;
+
 
 public class MainActivity extends ActionBarActivity
 {
+
+    Entry_schema schema;
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        schema = new Entry_schema();
+        schema.setReadonly(false);
+        schema.setFstype(Entry_schema.Fstype.EXT_4);
+        schema.setStorage(new Storage());
     }
 
 

--- a/jsonschema2pojo-gradle-plugin/example/android/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/jsonschema2pojo-gradle-plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/jsonschema2pojo-gradle-plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/jsonschema2pojo-gradle-plugin/example/android/lib/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/lib/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -27,11 +27,27 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+    }
+
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+
+    // Required for @Generated annotation
+    compile 'org.glassfish:javax.annotation:10.0-b28'
+    // Required if generating Gson annotations
+    compile 'com.google.code.gson:gson:2.5'
+    // Required if generating equals, hashCode, or toString methods
+    compile 'commons-lang:commons-lang:2.6'
+    // Required if generating JSR-303 annotations
+    compile 'javax.validation:validation-api:1.1.0.CR2'
+    // Required if generating Jackson 2 annotations
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.1.4'
 }
 
 // Each configuration is set to the default value
@@ -48,9 +64,9 @@ jsonSchema2Pojo {
     //source = files("${sourceSets.main.output.resourcesDir}/json")
     source = files("${project.rootDir}/schema")
 
-    // Target directory for generated Java source files. The plugin will add this directory to the
+    // Target directory for generated Java source files. The plugin will ignore this value for Android projects and will generate the classes into a generated source folder for each build variant and add this directory to the
     // java source set so the compiler will find and compile the newly generated source files.
-    targetDirectory = file("${project.rootDir}/build/generated-sources/js2p")
+    // targetDirectory = file("${project.rootDir}/build/generated-sources/js2p")
 
     // Package name used for generated Java classes (for types where a fully qualified name has not
     // been supplied in the schema using the 'javaType' property).

--- a/jsonschema2pojo-gradle-plugin/example/android/lib/src/main/java/jsonschema2pojo/joelittlejohn/github/com/androidlibexample/AndroidLibExample.java
+++ b/jsonschema2pojo-gradle-plugin/example/android/lib/src/main/java/jsonschema2pojo/joelittlejohn/github/com/androidlibexample/AndroidLibExample.java
@@ -1,12 +1,12 @@
 /**
  * Copyright © 2010-2014 Nokia
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,5 +16,15 @@
 
 package jsonschema2pojo.joelittlejohn.github.com.androidlibexample;
 
+import com.oosocial.clarityn.rest.clarityn.model.Entry_schema;
+import com.oosocial.clarityn.rest.clarityn.model.Storage;
+
 public final class AndroidLibExample {
+
+    public static void example() {
+        Entry_schema schema = new Entry_schema();
+        schema.setReadonly(false);
+        schema.setFstype(Entry_schema.Fstype.EXT_4);
+        schema.setStorage(new Storage());
+    }
 }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaAndroidTask.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaAndroidTask.groovy
@@ -1,0 +1,55 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jsonschema2pojo.gradle
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+import org.jsonschema2pojo.Jsonschema2Pojo
+
+/**
+ * Task that generates java source files for an Android project
+ */
+class GenerateJsonSchemaAndroidTask extends SourceTask {
+
+  /**
+   * The output directory.
+   */
+  @OutputDirectory
+  File outputDir
+
+  @TaskAction
+  def generate(IncrementalTaskInputs inputs) {
+
+    // If the whole thing isn't incremental, delete the build folder (if it exists)
+    if (!inputs.isIncremental() && outputDir.exists()) {
+      logger.debug("JsonSchema2Pojo generation is not incremental; deleting build folder and starting fresh!")
+      outputDir.deleteDir()
+    }
+
+    if (!outputDir.exists()) {
+      outputDir.mkdirs()
+    }
+
+    def configuration = project.jsonSchema2Pojo
+    configuration.targetDirectory = outputDir
+
+    logger.info 'Using this configuration:\n{}', configuration
+    Jsonschema2Pojo.generate(configuration)
+  }
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaPlugin.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package org.jsonschema2pojo.gradle
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -28,6 +29,33 @@ class JsonSchemaPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     project.extensions.create('jsonSchema2Pojo', JsonSchemaExtension)
-    project.tasks.create('generateJsonSchema2Pojo', GenerateJsonSchemaTask)
+
+    project.afterEvaluate {
+      if (project.plugins.hasPlugin('java')) {
+        project.tasks.create('generateJsonSchema2Pojo', GenerateJsonSchemaJavaTask)
+      } else if (project.android) {
+        def config = project.jsonSchema2Pojo
+        def variants = null
+        if (project.android.hasProperty('applicationVariants')) {
+          variants = project.android.applicationVariants
+        } else if (project.android.hasProperty('libraryVariants')) {
+          variants = project.android.libraryVariants
+        } else {
+          throw new IllegalStateException('Android project must have applicationVariants or libraryVariants!')
+        }
+
+        variants.all { variant ->
+
+          GenerateJsonSchemaAndroidTask task = (GenerateJsonSchemaAndroidTask) project.task(type: GenerateJsonSchemaAndroidTask, "generateJsonSchema2PojoFor${variant.name.capitalize()}") {
+            source = config.source.collect { it }
+            outputDir = project.file("$project.buildDir/generated/source/js2p/$variant.flavorName/$variant.buildType.name/")
+          }
+
+          variant.registerJavaGeneratingTask(task, (File) task.outputDir)
+        }
+      } else {
+        throw new GradleException('generateJsonSchema: Java or Android plugin required')
+      }
+    }
   }
 }


### PR DESCRIPTION
Hi,
I'm an Android developer,
I use this project on a daily basis by utilizing the cli during our project's build process.
I tried to use the gradle plugin but unfortunately it didn't compile correctly, although the source code was generated correctly, it seems that the generated code isn't added to the source set of the project correctly.
I'm using several kinds of build variants which are essentially different build setups, when using this advanced configuration, the generated code must be added to each build variant's source set.
Although the gradle plugin's code does something like that, it doesn't actually compile when the project's code depends on the generated code.
I've reproduced compilation errors on the android example code projects in the gradle plugin's source code.

In this pull request, I offer a solution that works, I've reimplemented how the generated code is being added to the build variant's source set. I've based my implementation on other gradle plugins for Android.
Such as: 
https://github.com/Flipboard/psync/blob/master/psync/src/main/groovy/com/flipboard/psync/PSyncPlugin.groovy

Commit notes:
Added Support for code generation for different build variants of Android project.
Fixed : adding the generated code to each build variant source set correctly, so it can be picked up by the compiler.
Added example usage of a generated class into the Android app and library classes.
Added correct compile time dependencies to the example projects such that the generated code could compile successfully.
Updated Android SDK and gradle versions.