### PR TITLE
Add javaName schema property

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/JavaNameRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/JavaNameRule.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JDocComment;
+import com.sun.codemodel.JDocCommentable;
+
+import org.jsonschema2pojo.Schema;
+
+public class JavaNameRule implements Rule<JDocCommentable, JDocComment> {
+
+    public final String CORRESPONDING_PROPERTY_TEXT = "\nCorresponds to the \"%s\" property.";
+
+    @Override
+    public JDocComment apply(String nodeName, JsonNode node, JDocCommentable generatableType, Schema currentSchema) {
+        JDocComment javaDoc = generatableType.javadoc();
+
+        javaDoc.append(String.format(CORRESPONDING_PROPERTY_TEXT, nodeName));
+
+        return javaDoc;
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -16,14 +16,6 @@
 
 package org.jsonschema2pojo.rules;
 
-import org.jsonschema2pojo.Annotator;
-import org.jsonschema2pojo.DefaultGenerationConfig;
-import org.jsonschema2pojo.GenerationConfig;
-import org.jsonschema2pojo.Jackson2Annotator;
-import org.jsonschema2pojo.SchemaStore;
-import org.jsonschema2pojo.util.NameHelper;
-import org.jsonschema2pojo.util.ParcelableHelper;
-
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassContainer;
 import com.sun.codemodel.JDefinedClass;
@@ -32,6 +24,14 @@ import com.sun.codemodel.JDocCommentable;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
+
+import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.DefaultGenerationConfig;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.Jackson2Annotator;
+import org.jsonschema2pojo.SchemaStore;
+import org.jsonschema2pojo.util.NameHelper;
+import org.jsonschema2pojo.util.ParcelableHelper;
 
 /**
  * Provides factory/creation methods for the code generation rules.
@@ -363,6 +363,10 @@ public class RuleFactory {
      */
     public Rule<JDefinedClass, JDefinedClass> getDynamicPropertiesRule() {
         return new DynamicPropertiesRule(this);
+    }
+
+    public Rule<JDocCommentable, JDocComment> getJavaNameRule() {
+        return new JavaNameRule();
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaField;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.typeCompatibleWith;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by cmb on 31.01.16.
+ */
+public class JavaNameIT {
+
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static Class<?> classWithJavaNames;
+    private static ClassLoader resultsClassLoader;
+
+    @BeforeClass
+    public static void generateAndCompileClass() throws ClassNotFoundException {
+
+        resultsClassLoader = classSchemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example");
+
+        classWithJavaNames = resultsClassLoader.loadClass("com.example.JavaName");
+
+    }
+
+    @Test
+    public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException {
+
+        Object instance = classWithJavaNames.newInstance();
+
+        assertThat(instance, hasProperty("javaProperty"));
+        assertThat(instance, hasProperty("propertyWithoutJavaName"));
+        assertThat(instance, hasProperty("javaEnum"));
+        assertThat(instance, hasProperty("enumWithoutJavaName"));
+        assertThat(instance, hasProperty("javaObject"));
+        assertThat(instance, hasProperty("objectWithoutJavaName"));
+
+    }
+
+    @Test
+    public void propertiesHaveCorrectTypes() throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchFieldException, IntrospectionException {
+
+        assertThat(classWithJavaNames.getDeclaredField("javaEnum").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.JavaName$JavaEnum")));
+        assertThat(classWithJavaNames.getDeclaredField("enumWithoutJavaName").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.JavaName$EnumWithoutJavaName")));
+        assertThat(classWithJavaNames.getDeclaredField("javaObject").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.JavaObject")));
+        assertThat(classWithJavaNames.getDeclaredField("objectWithoutJavaName").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.ObjectWithoutJavaName")));
+
+    }
+
+    @Test
+    public void gettersHaveCorrectNames() throws NoSuchMethodException {
+
+        classWithJavaNames.getMethod("getJavaProperty");
+        classWithJavaNames.getMethod("getPropertyWithoutJavaName");
+        classWithJavaNames.getMethod("getJavaEnum");
+        classWithJavaNames.getMethod("getEnumWithoutJavaName");
+        classWithJavaNames.getMethod("getJavaObject");
+        classWithJavaNames.getMethod("getObjectWithoutJavaName");
+
+    }
+
+    @Test
+    public void settersHaveCorrectNamesAndArgumentTypes() throws NoSuchMethodException, ClassNotFoundException {
+
+        classWithJavaNames.getMethod("setJavaProperty", String.class);
+        classWithJavaNames.getMethod("setPropertyWithoutJavaName", String.class);
+
+        classWithJavaNames.getMethod("setJavaEnum", resultsClassLoader.loadClass("com.example.JavaName$JavaEnum"));
+        classWithJavaNames.getMethod("setEnumWithoutJavaName", resultsClassLoader.loadClass("com.example.JavaName$EnumWithoutJavaName"));
+
+        classWithJavaNames.getMethod("setJavaObject", resultsClassLoader.loadClass("com.example.JavaObject"));
+        classWithJavaNames.getMethod("setObjectWithoutJavaName", resultsClassLoader.loadClass("com.example.ObjectWithoutJavaName"));
+
+    }
+
+    @Test
+    public void serializedPropertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+
+        Object instance = classWithJavaNames.newInstance();
+
+        new PropertyDescriptor("javaProperty", classWithJavaNames).getWriteMethod().invoke(instance, "abc");
+        new PropertyDescriptor("propertyWithoutJavaName", classWithJavaNames).getWriteMethod().invoke(instance, "abc");
+
+        JsonNode serialized = mapper.valueToTree(instance);
+
+        assertThat(serialized.has("propertyWithJavaName"), is(true));
+        assertThat(serialized.has("propertyWithoutJavaName"), is(true));
+
+    }
+
+    @Test
+    public void originalPropertyNamesAppearInJavaDoc() throws NoSuchFieldException, IOException {
+
+        File generatedJavaFile = classSchemaRule.generated("com/example/JavaName.java");
+
+        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        javaDocBuilder.addSource(generatedJavaFile);
+
+        JavaClass classWithDescription = javaDocBuilder.getClassByName("com.example.JavaName");
+
+        JavaField javaPropertyField = classWithDescription.getFieldByName("javaProperty");
+        assertThat(javaPropertyField.getComment(), containsString("Corresponds to the \"propertyWithJavaName\" property."));
+
+        JavaField javaEnumField = classWithDescription.getFieldByName("javaEnum");
+        assertThat(javaEnumField.getComment(), containsString("Corresponds to the \"enumWithJavaName\" property."));
+
+        JavaField javaObjectField = classWithDescription.getFieldByName("javaObject");
+        assertThat(javaObjectField.getComment(), containsString("Corresponds to the \"objectWithJavaName\" property."));
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesNotAllowDuplicateNames() {
+
+        classSchemaRule.generateAndCompile("/schema/javaName/duplicateName.json", "com.example");
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesNotAllowDuplicateDefaultNames() {
+
+        classSchemaRule.generateAndCompile("/schema/javaName/duplicateDefaultName.json", "com.example");
+
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/duplicateDefaultName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/duplicateDefaultName.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "one": {
+      "type": "string"
+    },
+    "two": {
+      "type": "string",
+      "javaName": "one"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/duplicateName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/duplicateName.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "one": {
+      "type": "string",
+      "javaName": "three"
+    },
+    "two": {
+      "type": "string",
+      "javaName": "three"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/javaName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/javaName.json
@@ -1,0 +1,26 @@
+{
+  "type" : "object",
+  "properties" : {
+    "propertyWithJavaName" : {
+      "javaName" : "javaProperty",
+      "type" : "string"
+    },
+    "propertyWithoutJavaName" : {
+      "type" : "string"
+    },
+    "enumWithJavaName" : {
+      "javaName" : "javaEnum",
+      "enum" : [ "a", "b" ]
+    },
+    "enumWithoutJavaName" : {
+      "enum" : [ "c", "d" ]
+    },
+    "objectWithJavaName" : {
+      "javaName" : "javaObject",
+      "type" : "object"
+    },
+    "objectWithoutJavaName" : {
+      "type" : "object"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an option for defining custom field names instead of the ones inferred from property names. For example, this:
```json
{
  "type": "object",
  "properties": {
    "a": {
      "javaName": "b",
      "type": "string"
    }
  }
}
```
will generate this:
```java
@JsonInclude(JsonInclude.Include.NON_NULL)
@Generated("org.jsonschema2pojo")
@JsonPropertyOrder({
    "a"
})
public class SimpleTest {

    /**
     * 
     * Corresponds to the "a" property.
     * 
     */
    @JsonProperty("a")
    private String b;

    /**
     * 
     * Corresponds to the "a" property.
     * 
     * @return
     *     The b
     */
    @JsonProperty("a")
    public String getB() {
        return b;
    }

    /**
     * 
     * Corresponds to the "a" property.
     * 
     * @param b
     *     The b
     */
    @JsonProperty("a")
    public void setB(String b) {
        this.b = b;
    }
    /* ... */
}
```