### PR TITLE
fix issue #509 in gradle plugin for Java projects

### DIFF
--- a/jsonschema2pojo-gradle-plugin/example/java/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/java/build.gradle
@@ -1,5 +1,5 @@
-apply plugin: 'jsonschema2pojo'
 apply plugin: 'java'
+apply plugin: 'jsonschema2pojo'
 
 buildscript {
   repositories {

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaPlugin.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaPlugin.groovy
@@ -32,7 +32,7 @@ class JsonSchemaPlugin implements Plugin<Project> {
 
     if (project.plugins.hasPlugin('java')) {
       project.tasks.create('generateJsonSchema2Pojo', GenerateJsonSchemaJavaTask)
-    } else if (project.android) {
+    } else if (project.plugins.hasPlugin('com.android.application') || project.plugins.hasPlugin('com.android.library')) {
       def config = project.jsonSchema2Pojo
       def variants = null
       if (project.android.hasProperty('applicationVariants')) {

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaPlugin.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaPlugin.groovy
@@ -30,32 +30,30 @@ class JsonSchemaPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.extensions.create('jsonSchema2Pojo', JsonSchemaExtension)
 
-    project.afterEvaluate {
-      if (project.plugins.hasPlugin('java')) {
-        project.tasks.create('generateJsonSchema2Pojo', GenerateJsonSchemaJavaTask)
-      } else if (project.android) {
-        def config = project.jsonSchema2Pojo
-        def variants = null
-        if (project.android.hasProperty('applicationVariants')) {
-          variants = project.android.applicationVariants
-        } else if (project.android.hasProperty('libraryVariants')) {
-          variants = project.android.libraryVariants
-        } else {
-          throw new IllegalStateException('Android project must have applicationVariants or libraryVariants!')
-        }
-
-        variants.all { variant ->
-
-          GenerateJsonSchemaAndroidTask task = (GenerateJsonSchemaAndroidTask) project.task(type: GenerateJsonSchemaAndroidTask, "generateJsonSchema2PojoFor${variant.name.capitalize()}") {
-            source = config.source.collect { it }
-            outputDir = project.file("$project.buildDir/generated/source/js2p/$variant.flavorName/$variant.buildType.name/")
-          }
-
-          variant.registerJavaGeneratingTask(task, (File) task.outputDir)
-        }
+    if (project.plugins.hasPlugin('java')) {
+      project.tasks.create('generateJsonSchema2Pojo', GenerateJsonSchemaJavaTask)
+    } else if (project.android) {
+      def config = project.jsonSchema2Pojo
+      def variants = null
+      if (project.android.hasProperty('applicationVariants')) {
+        variants = project.android.applicationVariants
+      } else if (project.android.hasProperty('libraryVariants')) {
+        variants = project.android.libraryVariants
       } else {
-        throw new GradleException('generateJsonSchema: Java or Android plugin required')
+        throw new IllegalStateException('Android project must have applicationVariants or libraryVariants!')
       }
+
+      variants.all { variant ->
+
+        GenerateJsonSchemaAndroidTask task = (GenerateJsonSchemaAndroidTask) project.task(type: GenerateJsonSchemaAndroidTask, "generateJsonSchema2PojoFor${variant.name.capitalize()}") {
+          source = config.source.collect { it }
+          outputDir = project.file("$project.buildDir/generated/source/js2p/$variant.flavorName/$variant.buildType.name/")
+        }
+
+        variant.registerJavaGeneratingTask(task, (File) task.outputDir)
+      }
+    } else {
+      throw new GradleException('generateJsonSchema: Java or Android plugin required')
     }
   }
 }


### PR DESCRIPTION
fix gradle plugin for Java projects.
Previous code change has caused a bug in the creation of the java task,
The task was not able to access gradle extension which contains the JsonSchema2Pojo configuration.
The missing configuration resulted in a NullPointerException when calling JsonSchema2Pojo.generate on a null configuration.

Fix: Java task will be created by the gradle plugin immediately when the plugin is applied on the project instead of after project evaluation.
Note: I only removed "project.afterEvaluate {" that surrounds the task creation code.