### PR TITLE
Jsonschema2pojoRule report problems to STDERR

### DIFF
--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -108,6 +108,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
@@ -58,7 +58,7 @@ import static org.hamcrest.MatcherAssert.*;
  */
 @RunWith(Parameterized.class)
 public class CompilerWarningIT {
-  @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+  @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule().captureDiagnostics();
   
   @Parameters(name="{0}")
   public static Collection<Object[]> parameters() {

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,12 @@
                 <version>2.2.0</version>
             </dependency>
             <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>1.16.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.google.android</groupId>
                 <artifactId>android</artifactId>
                 <version>4.1.1.4</version>


### PR DESCRIPTION
Capturing diagnostics in the Jsonschema2pojoRule was removing output from STDERR.  This makes that feature optional and adds a test to make sure STDERR output is generated when there are compilation problems.