### PR TITLE
Adds support for mapping BigDecimal as mentioned in issues #161

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -79,6 +79,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean useDoubleNumbers = true;
 
+    private boolean useBigDecimals = false;
+
     private boolean includeHashcodeAndEquals = true;
 
     private boolean includeToString = true;
@@ -120,7 +122,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private boolean includeAdditionalProperties = true;
 
     private boolean includeAccessors = true;
-    
+
     private String targetVersion = "1.6";
 
     private boolean includeDynamicAccessors = false;
@@ -288,6 +290,19 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
      */
     public void setUseDoubleNumbers(boolean useDoubleNumbers) {
         this.useDoubleNumbers = useDoubleNumbers;
+    }
+
+    /**
+     * Sets the 'useBigDecimals' property of this class
+     *
+     * @param useBigDecimals
+     *            Whether to use the java type <code>BigDecimal</code>
+     *            instead of <code>float</code> (or {@link java.lang.Float})
+     *            when representing the JSON Schema type 'number'. Note that
+     *            this overrides <code>useDoubleNumbers</code>.
+     */
+    public void setUseBigDecimals(boolean useBigDecimals) {
+        this.useBigDecimals = useBigDecimals;
     }
 
     /**
@@ -784,5 +799,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public String getTimeType() {
         return timeType;
+    }
+
+    @Override
+    public boolean isUseBigDecimals() {
+        return useBigDecimals;
     }
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -209,6 +209,11 @@
         <td align="center" valign="top">No (default <code>true</code>)</td>
       </tr>
       <tr>
+        <td valign="top">useBigDecimals</td>
+        <td valign="top">Whether to use the java type <code>BigDecimal</code> instead of <code>float</code> (or <code>java.lang.Float</code>) when representing the JSON Schema type 'number'. Note that this overrides <code>useDoubleNumbers</code>.</td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+      </tr>
+      <tr>
         <td valign="top">useJodaDates</td>
         <td valign="top">Whether to use <code>org.joda.time.DateTime</code> instead of <code>java.util.Date</code>  when adding date-time type fields to generated Java types.</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -75,6 +75,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-f", "--float-numbers" }, description = "Use float (or Float) instead of double (or Double) when the JSON Schema type 'number' is encountered")
     private boolean useFloatNumbers = false;
 
+    @Parameter(names = { "-i", "--big-decimals" }, description = "Use BigDecimal instead of double (or Double) when the JSON Schema type 'number' is encountered. Note that this overrides useFloatNumbers/-f/--float-numbers")
+    private boolean useBigDecimals = false;
+
     @Parameter(names = { "-E", "--omit-hashcode-and-equals" }, description = "Omit hashCode and equals methods in the generated Java types")
     private boolean omitHashcodeAndEquals = false;
 
@@ -140,10 +143,10 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-da", "--disable-accessors" }, description = "Whether to omit getter/setter methods and create public fields instead.")
     private boolean disableAccessors = false;
-    
+
     @Parameter(names = { "-tv", "--target-version" }, description = "The target version for generated source files.")
     private String targetVersion = "1.6";
-    
+
     @Parameter(names = { "-ida", "--include-dynamic-accessors" }, description = "Include dynamic getter, setter, and builder support on generated types.")
     private boolean includeDynamicAccessors = false;
 
@@ -361,4 +364,7 @@ public class Arguments implements GenerationConfig {
         return timeType;
     }
 
+    public boolean isUseBigDecimals() {
+        return useBigDecimals;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -224,6 +224,11 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return "";
     }
 
+    @Override
+    public boolean isUseBigDecimals() {
+        return false;
+    }
+
     /**
      * @return <code>false</code>
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -102,6 +102,17 @@ public interface GenerationConfig {
      */
     boolean isUseDoubleNumbers();
 
+
+    /**
+     * Gets the 'useBigDecimals' configuration option.
+     *
+     * @return Whether to use the java type <code>BigDecimal</code>
+     *         instead of <code>float</code> (or {@link java.lang.Float})
+     *         when representing the JSON Schema type 'number'. Note
+     *         that this configuration overrides <code>isUseDoubleNumbers</code>.
+     */
+    boolean isUseBigDecimals();
+
     /**
      * Gets the 'includeHashcodeAndEquals' configuration option.
      *
@@ -305,7 +316,7 @@ public interface GenerationConfig {
 
     /**
      * Gets the 'targetVersion' configuration option.
-     * 
+     *
      *  @return The target version for generated source files.
      */
     String getTargetVersion();

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
@@ -27,6 +27,8 @@ import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JType;
+
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -110,6 +112,9 @@ public class DefaultRule implements Rule<JFieldVar, JFieldVar> {
             return JExpr.lit(Integer.parseInt(node.asText()));
 
         } else if (fieldType.fullName().equals(double.class.getName())) {
+            return JExpr.lit(Double.parseDouble(node.asText()));
+
+        } else if (fieldType.fullName().equals(BigDecimal.class.getName())) {
             return JExpr.lit(Double.parseDouble(node.asText()));
 
         } else if (fieldType.fullName().equals(boolean.class.getName())) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -18,6 +18,7 @@ package org.jsonschema2pojo.rules;
 
 import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
 
+import java.math.BigDecimal;
 import java.util.Iterator;
 
 import org.jsonschema2pojo.GenerationConfig;
@@ -163,7 +164,9 @@ public class TypeRule implements Rule<JClassContainer, JType> {
      */
     private JType getNumberType(JCodeModel owner, JsonNode node, GenerationConfig config) {
 
-        if (config.isUseDoubleNumbers()) {
+        if (config.isUseBigDecimals()) {
+            return unboxIfNecessary(owner.ref(BigDecimal.class), config);
+        } else if (config.isUseDoubleNumbers()) {
             return unboxIfNecessary(owner.ref(Double.class), config);
         } else {
             return unboxIfNecessary(owner.ref(Float.class), config);

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -38,6 +38,8 @@ import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 
+import java.math.BigDecimal;
+
 public class TypeRuleTest {
 
     private GenerationConfig config = mock(GenerationConfig.class);
@@ -127,6 +129,39 @@ public class TypeRuleTest {
 
         assertThat(result.fullName(), is("int"));
     }
+
+    @Test
+    public void applyGeneratesBigDecimal_1() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "number");
+
+        when(config.isUseBigDecimals()).thenReturn(true);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is(BigDecimal.class.getName()));
+    }
+
+    @Test
+    public void applyGeneratesBigDecimal_2() {
+
+        JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());
+
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("type", "number");
+
+        //this shows that isUseBigDecimals overrides isUseDoubleNumbers
+        when(config.isUseDoubleNumbers()).thenReturn(true);
+        when(config.isUseBigDecimals()).thenReturn(true);
+
+        JType result = rule.apply("fooBar", objectNode, jpackage, null);
+
+        assertThat(result.fullName(), is(BigDecimal.class.getName()));
+    }
+
 
     @Test
     public void applyGeneratesIntegerUsingJavaTypeInteger() {

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -71,6 +71,10 @@ jsonSchema2Pojo {
   // Whether to use the java type double (or Double) instead of float (or Float) when representing
   // the JSON Schema type 'number'.
   useDoubleNumbers = true
+  
+  // Whether to use the java type BigDecimal when representing the JSON Schema type 'number'. Note
+  // that this configuration overrides useDoubleNumbers
+  useBigDecimals = false
 
   // Whether to include hashCode and equals methods in generated Java types.
   includeHashcodeAndEquals = true

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -56,6 +56,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   String targetVersion
   boolean useCommonsLang3
   boolean useDoubleNumbers
+  boolean useBigDecimals
   boolean useJodaDates
   boolean useJodaLocalDates
   boolean useJodaLocalTimes
@@ -75,6 +76,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     propertyWordDelimiters = [] as char[]
     useLongIntegers = false
     useDoubleNumbers = true
+    useBigDecimals = false
     includeHashcodeAndEquals = true
     includeConstructors = false
     constructorsRequiredPropertiesOnly = false
@@ -144,6 +146,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |propertyWordDelimiters = ${Arrays.toString(propertyWordDelimiters)}
        |useLongIntegers = ${useLongIntegers}
        |useDoubleNumbers = ${useDoubleNumbers}
+       |useBigDecimals = ${useBigDecimals}
        |includeHashcodeAndEquals = ${includeHashcodeAndEquals}
        |includeConstructors = ${includeConstructors}
        |includeToString = ${includeToString}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/JsonTypesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/JsonTypesIT.java
@@ -19,10 +19,12 @@ package org.jsonschema2pojo.integration.json;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.generateAndCompile;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
@@ -32,7 +34,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonTypesIT {
-    
+
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -54,6 +56,21 @@ public class JsonTypesIT {
         assertThat(generatedType.getMethod("getE").invoke(deserialisedValue), is(nullValue()));
 
     }
+
+    @Test
+    public void bigDecimalInExampleIsMappedToCorrectJavaType() throws Exception {
+
+        ClassLoader resultsClassLoader = generateAndCompile("/json/simpleTypes.json", "com.example",
+          config("sourceType", "json", "useBigDecimals", true));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.SimpleTypes");
+
+        Object deserialisedValue = OBJECT_MAPPER.readValue(this.getClass().getResourceAsStream("/json/simpleTypes.json"), generatedType);
+
+        assertThat((BigDecimal) generatedType.getMethod("getC").invoke(deserialisedValue), is(new BigDecimal("12999999999999999999999.99")));
+    }
+
+
 
     @Test(expected = ClassNotFoundException.class)
     public void simpleTypeAtRootProducesNoJavaTypes() throws ClassNotFoundException {

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -172,6 +172,18 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean useDoubleNumbers = true;
 
     /**
+     * Whether to use the java type <code>BigDecimal</code> instead of
+     * <code>float</code> (or {@link java.lang.Float})  when representing
+     * the JSON Schema type 'number'. Note that this configuration overrides
+     * <code>useDoubleNumbers</code>.
+     *
+     * @parameter expression="${jsonschema2pojo.useBigDecimals}"
+     *            default-value="false"
+     * @since TODO
+     */
+    private boolean useBigDecimals = false;
+
+    /**
      * Whether to include <code>hashCode</code> and <code>equals</code> methods
      * in generated Java types.
      *
@@ -438,10 +450,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.4.15
      */
     private boolean includeAccessors = true;
-    
+
     /**
      * The target version for generated source files.
-     * 
+     *
      * @parameter expression="${maven.compiler.target}"
      *            default-value="1.6"
      * @since 0.4.17
@@ -768,4 +780,8 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         return timeType;
     }
 
+    @Override
+    public boolean isUseBigDecimals() {
+        return useBigDecimals;
+    }
 }


### PR DESCRIPTION
I stumbled upon issue #161 and took the commit mentioned there (c182b93bda6) and re-applied it to master. 

This PR adds a config property that allows mapping of number types to BigDecimal instead of Floats