### PR TITLE
Fix javaName breaking required properties

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DynamicPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DynamicPropertiesRule.java
@@ -16,24 +16,6 @@
 
 package org.jsonschema2pojo.rules;
 
-import static com.sun.codemodel.JExpr.FALSE;
-import static com.sun.codemodel.JExpr._new;
-import static com.sun.codemodel.JExpr._super;
-import static com.sun.codemodel.JExpr._this;
-import static com.sun.codemodel.JExpr.cast;
-import static com.sun.codemodel.JExpr.invoke;
-import static com.sun.codemodel.JExpr.lit;
-import static com.sun.codemodel.JMod.FINAL;
-import static com.sun.codemodel.JMod.PROTECTED;
-import static com.sun.codemodel.JMod.PUBLIC;
-import static com.sun.codemodel.JMod.STATIC;
-
-import java.util.Iterator;
-
-import org.jsonschema2pojo.Schema;
-import org.jsonschema2pojo.util.LanguageFeatures;
-import org.jsonschema2pojo.util.Models;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
@@ -49,6 +31,25 @@ import com.sun.codemodel.JSwitch;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JTypeVar;
 import com.sun.codemodel.JVar;
+
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.util.LanguageFeatures;
+import org.jsonschema2pojo.util.Models;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static com.sun.codemodel.JExpr.FALSE;
+import static com.sun.codemodel.JExpr._new;
+import static com.sun.codemodel.JExpr._super;
+import static com.sun.codemodel.JExpr._this;
+import static com.sun.codemodel.JExpr.cast;
+import static com.sun.codemodel.JExpr.invoke;
+import static com.sun.codemodel.JExpr.lit;
+import static com.sun.codemodel.JMod.FINAL;
+import static com.sun.codemodel.JMod.PROTECTED;
+import static com.sun.codemodel.JMod.PUBLIC;
+import static com.sun.codemodel.JMod.STATIC;
 
 /**
  * Adds methods for dynamically getting, setting, and building properties.
@@ -169,12 +170,14 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
         JBlock body = method.body();
         JSwitch propertySwitch = body._switch(nameParam);
         if (propertiesNode != null) {
-            for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
-                String propertyName = properties.next();
-                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName);
+            for (Iterator<Map.Entry<String, JsonNode>> properties = propertiesNode.fields(); properties.hasNext();) {
+                Map.Entry<String, JsonNode> property = properties.next();
+                String propertyName = property.getKey();
+                JsonNode node = property.getValue();
+                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName, node);
                 JType propertyType = jclass.fields().get(fieldName).type();
 
-                addGetPropertyCase(jclass, propertySwitch, propertyName, propertyType);
+                addGetPropertyCase(jclass, propertySwitch, propertyName, propertyType, node);
             }
         }
         JClass extendsType = jclass._extends();
@@ -199,9 +202,11 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
         JBlock body = method.body();
         JConditional propertyConditional = null;
         if (propertiesNode != null) {
-            for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
-                String propertyName = properties.next();
-                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName);
+            for (Iterator<Map.Entry<String, JsonNode>> properties = propertiesNode.fields(); properties.hasNext();) {
+                Map.Entry<String, JsonNode> property = properties.next();
+                String propertyName = property.getKey();
+                JsonNode node = property.getValue();
+                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName, node);
                 JType propertyType = jclass.fields().get(fieldName).type();
 
                 JExpression condition = JExpr.lit(propertyName).invoke("equals").arg(nameParam);
@@ -210,7 +215,7 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
                 } else {
                     propertyConditional = propertyConditional._elseif(condition);
                 }
-                JMethod propertyGetter = jclass.getMethod(getGetterName(propertyName, propertyType), new JType[] {});
+                JMethod propertyGetter = jclass.getMethod(getGetterName(propertyName, propertyType, node), new JType[] {});
                 propertyConditional._then()._return(invoke(propertyGetter));
             }
         }
@@ -228,8 +233,8 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
         return method;
     }
 
-    private void addGetPropertyCase(JDefinedClass jclass, JSwitch propertySwitch, String propertyName, JType propertyType) {
-        JMethod propertyGetter = jclass.getMethod(getGetterName(propertyName, propertyType), new JType[] {});
+    private void addGetPropertyCase(JDefinedClass jclass, JSwitch propertySwitch, String propertyName, JType propertyType, JsonNode node) {
+        JMethod propertyGetter = jclass.getMethod(getGetterName(propertyName, propertyType, node), new JType[] {});
         propertySwitch._case(JExpr.lit(propertyName)).body()
                 ._return(invoke(propertyGetter));
     }
@@ -296,12 +301,14 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
         JBlock body = method.body();
         JSwitch propertySwitch = body._switch(nameParam);
         if (propertiesNode != null) {
-            for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
-                String propertyName = properties.next();
-                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName);
+            for (Iterator<Map.Entry<String, JsonNode>> properties = propertiesNode.fields(); properties.hasNext();) {
+                Map.Entry<String, JsonNode> property = properties.next();
+                String propertyName = property.getKey();
+                JsonNode node = property.getValue();
+                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName, node);
                 JType propertyType = jclass.fields().get(fieldName).type();
 
-                addSetPropertyCase(jclass, propertySwitch, propertyName, propertyType, valueParam);
+                addSetPropertyCase(jclass, propertySwitch, propertyName, propertyType, valueParam, node);
             }
         }
         JBlock defaultBlock = propertySwitch._default().body();
@@ -324,16 +331,18 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
         JBlock body = method.body();
         JConditional propertyConditional = null;
         if (propertiesNode != null) {
-            for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
-                String propertyName = properties.next();
-                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName);
+            for (Iterator<Map.Entry<String, JsonNode>> properties = propertiesNode.fields(); properties.hasNext();) {
+                Map.Entry<String, JsonNode> property = properties.next();
+                String propertyName = property.getKey();
+                JsonNode node = property.getValue();
+                String fieldName = ruleFactory.getNameHelper().getPropertyName(propertyName, node);
                 JType propertyType = jclass.fields().get(fieldName).type();
                 JExpression condition = JExpr.lit(propertyName).invoke("equals").arg(nameParam);
                 propertyConditional = propertyConditional == null ? propertyConditional = body._if(condition)
                         : propertyConditional._elseif(condition);
 
                 JBlock callSite = propertyConditional._then();
-                addSetProperty(jclass, callSite, propertyName, propertyType, valueParam);
+                addSetProperty(jclass, callSite, propertyName, propertyType, valueParam, node);
                 callSite._return(JExpr.TRUE);
             }
         }
@@ -361,14 +370,14 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
                 new JType[] { jclass.owner().ref(String.class), jclass.owner().ref(Object.class) });
     }
 
-    private void addSetPropertyCase(JDefinedClass jclass, JSwitch setterSwitch, String propertyName, JType propertyType, JVar valueVar) {
+    private void addSetPropertyCase(JDefinedClass jclass, JSwitch setterSwitch, String propertyName, JType propertyType, JVar valueVar, JsonNode node) {
         JBlock setterBody = setterSwitch._case(lit(propertyName)).body();
-        addSetProperty(jclass, setterBody, propertyName, propertyType, valueVar);
+        addSetProperty(jclass, setterBody, propertyName, propertyType, valueVar, node);
         setterBody._return(JExpr.TRUE);
     }
 
-    private void addSetProperty(JDefinedClass jclass, JBlock callSite, String propertyName, JType propertyType, JVar valueVar) {
-        JMethod propertySetter = jclass.getMethod(getSetterName(propertyName), new JType[] { propertyType });
+    private void addSetProperty(JDefinedClass jclass, JBlock callSite, String propertyName, JType propertyType, JVar valueVar, JsonNode node) {
+        JMethod propertySetter = jclass.getMethod(getSetterName(propertyName, node), new JType[] { propertyType });
         JConditional isInstance = callSite._if(valueVar._instanceof(propertyType.boxify().erasure()));
         isInstance._then()
                 .invoke(propertySetter).arg(cast(propertyType.boxify(), valueVar));
@@ -387,11 +396,11 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
                         .plus(valueVar.invoke("getClass").invoke("toString")));
     }
 
-    private String getSetterName(String propertyName) {
-        return ruleFactory.getNameHelper().getSetterName(propertyName);
+    private String getSetterName(String propertyName, JsonNode node) {
+        return ruleFactory.getNameHelper().getSetterName(propertyName, node);
     }
 
-    private String getGetterName(String propertyName, JType type) {
-        return ruleFactory.getNameHelper().getGetterName(propertyName, type);
+    private String getGetterName(String propertyName, JType type, JsonNode node) {
+        return ruleFactory.getNameHelper().getGetterName(propertyName, type, node);
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -16,24 +16,6 @@
 
 package org.jsonschema2pojo.rules;
 
-import static java.util.Arrays.*;
-import static org.apache.commons.lang3.StringUtils.*;
-import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
-import static org.jsonschema2pojo.util.TypeUtil.*;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Generated;
-
-import org.jsonschema2pojo.Schema;
-import org.jsonschema2pojo.SchemaMapper;
-import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
-import org.jsonschema2pojo.exception.GenerationException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.ClassType;
 import com.sun.codemodel.JAnnotationUse;
@@ -52,6 +34,30 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
+
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
+import org.jsonschema2pojo.exception.GenerationException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.containsOnly;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.splitByCharacterTypeCamelCase;
+import static org.apache.commons.lang3.StringUtils.upperCase;
+import static org.jsonschema2pojo.rules.PrimitiveTypes.isPrimitive;
+import static org.jsonschema2pojo.util.TypeUtil.resolveType;
 
 /**
  * Applies the "enum" schema rule.
@@ -140,7 +146,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
                 }
             } else {
                 try {
-                    return container._class(modifiers, getEnumName(nodeName, container), ClassType.ENUM);
+                    return container._class(modifiers, getEnumName(nodeName, node, container), ClassType.ENUM);
                 } catch (JClassAlreadyExistsException e) {
                     throw new GenerationException(e);
                 }
@@ -224,11 +230,13 @@ public class EnumRule implements Rule<JClassContainer, JType> {
         generated.param("value", SchemaMapper.class.getPackage().getName());
     }
 
-    private String getEnumName(String nodeName, JClassContainer container) {
-        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(capitalize(nodeName));
+    private String getEnumName(String nodeName, JsonNode node, JClassContainer container) {
+        String fieldName = ruleFactory.getNameHelper().getFieldName(nodeName, node);
+        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(capitalize(fieldName));
         String normalizedName = ruleFactory.getNameHelper().normalizeName(className);
         return makeUnique(normalizedName, container);
     }
+
 
     private String makeUnique(String className, JClassContainer container) {
         boolean found = false;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -16,26 +16,7 @@
 
 package org.jsonschema2pojo.rules;
 
-import static org.apache.commons.lang3.StringUtils.*;
-import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
-import static org.jsonschema2pojo.util.TypeUtil.*;
-
-import java.io.Serializable;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Generated;
-
-import org.jsonschema2pojo.AnnotationStyle;
-import org.jsonschema2pojo.Schema;
-import org.jsonschema2pojo.SchemaMapper;
-import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
-import org.jsonschema2pojo.util.NameHelper;
-import org.jsonschema2pojo.util.ParcelableHelper;
-import org.jsonschema2pojo.util.TypeUtil;
+import android.os.Parcelable;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,7 +35,29 @@ import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
 
-import android.os.Parcelable;
+import org.jsonschema2pojo.AnnotationStyle;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
+import org.jsonschema2pojo.util.NameHelper;
+import org.jsonschema2pojo.util.ParcelableHelper;
+import org.jsonschema2pojo.util.TypeUtil;
+
+import java.io.Serializable;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
+import static org.jsonschema2pojo.rules.PrimitiveTypes.isPrimitive;
+import static org.jsonschema2pojo.rules.PrimitiveTypes.primitiveType;
+import static org.jsonschema2pojo.util.TypeUtil.resolveType;
 
 /**
  * Applies the generation steps required for schemas of type "object".
@@ -186,10 +189,10 @@ public class ObjectRule implements Rule<JPackage, JType> {
             JsonNode propertyObj = property.getValue();
             if (onlyRequired) {
                 if (propertyObj.has("required") && propertyObj.get("required").asBoolean()) {
-                    rtn.add(nameHelper.getPropertyName(property.getKey()));
+                    rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
                 }
             } else {
-                rtn.add((nameHelper.getPropertyName(property.getKey())));
+                rtn.add((nameHelper.getPropertyName(property.getKey(), property.getValue())));
             }
         }
         return rtn;
@@ -246,9 +249,9 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 }
             } else {
                 if (usePolymorphicDeserialization) {
-                    newType = _package._class(JMod.PUBLIC, getClassName(nodeName, _package), ClassType.CLASS);
+                    newType = _package._class(JMod.PUBLIC, getClassName(nodeName, node, _package), ClassType.CLASS);
                 } else {
-                    newType = _package._class(getClassName(nodeName, _package));
+                    newType = _package._class(getClassName(nodeName, node, _package));
                 }
             }
         } catch (JClassAlreadyExistsException e) {
@@ -424,18 +427,19 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
     }
 
-    private String getClassName(String nodeName, JPackage _package) {
+    private String getClassName(String nodeName, JsonNode node, JPackage _package) {
         String prefix = ruleFactory.getGenerationConfig().getClassNamePrefix();
         String suffix = ruleFactory.getGenerationConfig().getClassNameSuffix();
-        String capitalizedNodeName = capitalize(nodeName);
-        String fullNodeName = createFullNodeName(capitalizedNodeName, prefix, suffix);
+        String fieldName = ruleFactory.getNameHelper().getFieldName(nodeName, node);
+        String capitalizedFieldName = capitalize(fieldName);
+        String fullFieldName = createFullFieldName(capitalizedFieldName, prefix, suffix);
 
-        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(fullNodeName);
+        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(fullFieldName);
         String normalizedName = ruleFactory.getNameHelper().normalizeName(className);
         return makeUnique(normalizedName, _package);
     }
 
-    private String createFullNodeName(String nodeName, String prefix, String suffix) {
+    private String createFullFieldName(String nodeName, String prefix, String suffix) {
         String returnString = nodeName;
         if (prefix != null) {
             returnString = prefix + returnString;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -16,14 +16,17 @@
 
 package org.jsonschema2pojo.util;
 
-import static java.lang.Character.*;
-import static javax.lang.model.SourceVersion.*;
-import static org.apache.commons.lang3.StringUtils.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JType;
 
 import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
 
-import com.sun.codemodel.JType;
+import static java.lang.Character.isDigit;
+import static javax.lang.model.SourceVersion.isKeyword;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.containsAny;
+import static org.apache.commons.lang3.StringUtils.remove;
 
 public class NameHelper {
 
@@ -69,9 +72,12 @@ public class NameHelper {
      * illegal characters and normalizing it.
      * 
      * @param jsonFieldName
+     * @param node
      * @return
      */
-    public String getPropertyName(String jsonFieldName) {
+    public String getPropertyName(String jsonFieldName, JsonNode node) {
+        jsonFieldName = getFieldName(jsonFieldName, node);
+
         jsonFieldName = replaceIllegalCharacters(jsonFieldName);
         jsonFieldName = normalizeName(jsonFieldName);
 
@@ -90,9 +96,12 @@ public class NameHelper {
      * Generate setter method name for property.
      * 
      * @param propertyName
+     * @param node
      * @return
      */
-    public String getSetterName(String propertyName) {
+    public String getSetterName(String propertyName, JsonNode node) {
+        propertyName = getFieldName(propertyName, node);
+
         propertyName = replaceIllegalCharacters(propertyName);
         String setterName = "set" + capitalize(capitalizeTrailingWords(propertyName));
 
@@ -104,13 +113,32 @@ public class NameHelper {
     }
 
     /**
+     * Get name of the field generated from property.
+     *
+     * @param propertyName
+     * @param node
+     * @return
+     */
+    public String getFieldName(String propertyName, JsonNode node) {
+        
+        if (node != null && node.has("javaName")) {
+            propertyName = node.get("javaName").textValue();
+        }
+
+        return propertyName;
+    }
+
+    /**
      * Generate getter method name for property.
      * 
      * @param propertyName
      * @param type
+     * @param node
      * @return
      */
-    public String getGetterName(String propertyName, JType type) {
+    public String getGetterName(String propertyName, JType type, JsonNode node) {
+        propertyName = getFieldName(propertyName, node);
+
         String prefix = type.equals(type.owner()._ref(boolean.class)) ? "is" : "get";
         propertyName = replaceIllegalCharacters(propertyName);
         String getterName = prefix + capitalize(capitalizeTrailingWords(propertyName));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -16,12 +16,14 @@
 
 package org.jsonschema2pojo.rules;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
+
 import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
@@ -32,6 +34,7 @@ import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -55,6 +58,7 @@ public class EnumRuleTest {
     public void applyGeneratesUniqueEnumNamesForMultipleEnumNodesWithSameName() {
 
         Answer<String> firstArgAnswer = new FirstArgAnswer<String>();
+        when(nameHelper.getFieldName(anyString(), any(JsonNode.class))).thenAnswer(firstArgAnswer);
         when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
         when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
@@ -18,12 +18,20 @@ package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.sun.codemodel.*;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JDocComment;
+import com.sun.codemodel.JMod;
+
 import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.Schema;
 import org.junit.Test;
 
-import javax.validation.constraints.NotNull;
 import java.util.Collection;
+
+import javax.validation.constraints.NotNull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -46,7 +54,7 @@ public class RequiredArrayRuleTest {
         ObjectMapper mapper = new ObjectMapper();
         ArrayNode requiredNode = mapper.createArrayNode().add("fooBar");
 
-        rule.apply("Class", requiredNode, jclass, null);
+        rule.apply("Class", requiredNode, jclass, new Schema(null, requiredNode, requiredNode));
 
         JDocComment fooBarJavaDoc = jclass.fields().get("fooBar").javadoc();
         JDocComment fooJavaDoc = jclass.fields().get("foo").javadoc();
@@ -71,7 +79,7 @@ public class RequiredArrayRuleTest {
         ObjectMapper mapper = new ObjectMapper();
         ArrayNode requiredNode = mapper.createArrayNode().add("foo_bar");
 
-        rule.apply("Class", requiredNode, jclass, null);
+        rule.apply("Class", requiredNode, jclass, new Schema(null, requiredNode, requiredNode));
 
         Collection<JAnnotationUse> fooBarAnnotations = jclass.fields().get("fooBar").annotations();
         Collection<JAnnotationUse> fooAnnotations = jclass.fields().get("foo").annotations();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -24,7 +24,7 @@ import com.thoughtworks.qdox.model.JavaField;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.beans.IntrospectionException;
@@ -44,25 +44,21 @@ import static org.junit.Assert.assertThat;
  */
 public class JavaNameIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();
 
-    private static Class<?> classWithJavaNames;
-    private static ClassLoader resultsClassLoader;
-
     @BeforeClass
-    public static void generateAndCompileClass() throws ClassNotFoundException {
+    public static void generateAndCompileClass() throws ClassNotFoundException, IOException {
 
-        resultsClassLoader = classSchemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example");
-
-        classWithJavaNames = resultsClassLoader.loadClass("com.example.JavaName");
 
     }
 
     @Test
-    public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException {
+    public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
 
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
         Object instance = classWithJavaNames.newInstance();
 
         assertThat(instance, hasProperty("javaProperty"));
@@ -77,15 +73,22 @@ public class JavaNameIT {
     @Test
     public void propertiesHaveCorrectTypes() throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchFieldException, IntrospectionException {
 
-        assertThat(classWithJavaNames.getDeclaredField("javaEnum").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.JavaName$JavaEnum")));
-        assertThat(classWithJavaNames.getDeclaredField("enumWithoutJavaName").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.JavaName$EnumWithoutJavaName")));
-        assertThat(classWithJavaNames.getDeclaredField("javaObject").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.JavaObject")));
-        assertThat(classWithJavaNames.getDeclaredField("objectWithoutJavaName").getType(), typeCompatibleWith(resultsClassLoader.loadClass("com.example.ObjectWithoutJavaName")));
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
+        Object instance = classWithJavaNames.newInstance();
+
+        assertThat(classWithJavaNames.getDeclaredField("javaEnum").getType(), typeCompatibleWith(javaNameClassLoader.loadClass("com.example.javaname.JavaName$JavaEnum")));
+        assertThat(classWithJavaNames.getDeclaredField("enumWithoutJavaName").getType(), typeCompatibleWith(javaNameClassLoader.loadClass("com.example.javaname.JavaName$EnumWithoutJavaName")));
+        assertThat(classWithJavaNames.getDeclaredField("javaObject").getType(), typeCompatibleWith(javaNameClassLoader.loadClass("com.example.javaname.JavaObject")));
+        assertThat(classWithJavaNames.getDeclaredField("objectWithoutJavaName").getType(), typeCompatibleWith(javaNameClassLoader.loadClass("com.example.javaname.ObjectWithoutJavaName")));
 
     }
 
     @Test
-    public void gettersHaveCorrectNames() throws NoSuchMethodException {
+    public void gettersHaveCorrectNames() throws NoSuchMethodException, IllegalAccessException, InstantiationException, ClassNotFoundException {
+
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
 
         classWithJavaNames.getMethod("getJavaProperty");
         classWithJavaNames.getMethod("getPropertyWithoutJavaName");
@@ -97,22 +100,27 @@ public class JavaNameIT {
     }
 
     @Test
-    public void settersHaveCorrectNamesAndArgumentTypes() throws NoSuchMethodException, ClassNotFoundException {
+    public void settersHaveCorrectNamesAndArgumentTypes() throws NoSuchMethodException, ClassNotFoundException, IllegalAccessException, InstantiationException {
+
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
 
         classWithJavaNames.getMethod("setJavaProperty", String.class);
         classWithJavaNames.getMethod("setPropertyWithoutJavaName", String.class);
 
-        classWithJavaNames.getMethod("setJavaEnum", resultsClassLoader.loadClass("com.example.JavaName$JavaEnum"));
-        classWithJavaNames.getMethod("setEnumWithoutJavaName", resultsClassLoader.loadClass("com.example.JavaName$EnumWithoutJavaName"));
+        classWithJavaNames.getMethod("setJavaEnum", javaNameClassLoader.loadClass("com.example.javaname.JavaName$JavaEnum"));
+        classWithJavaNames.getMethod("setEnumWithoutJavaName", javaNameClassLoader.loadClass("com.example.javaname.JavaName$EnumWithoutJavaName"));
 
-        classWithJavaNames.getMethod("setJavaObject", resultsClassLoader.loadClass("com.example.JavaObject"));
-        classWithJavaNames.getMethod("setObjectWithoutJavaName", resultsClassLoader.loadClass("com.example.ObjectWithoutJavaName"));
+        classWithJavaNames.getMethod("setJavaObject", javaNameClassLoader.loadClass("com.example.javaname.JavaObject"));
+        classWithJavaNames.getMethod("setObjectWithoutJavaName", javaNameClassLoader.loadClass("com.example.javaname.ObjectWithoutJavaName"));
 
     }
 
     @Test
-    public void serializedPropertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+    public void serializedPropertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException, ClassNotFoundException {
 
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
         Object instance = classWithJavaNames.newInstance();
 
         new PropertyDescriptor("javaProperty", classWithJavaNames).getWriteMethod().invoke(instance, "abc");
@@ -128,12 +136,13 @@ public class JavaNameIT {
     @Test
     public void originalPropertyNamesAppearInJavaDoc() throws NoSuchFieldException, IOException {
 
-        File generatedJavaFile = classSchemaRule.generated("com/example/JavaName.java");
+        schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        File generatedJavaFile = schemaRule.generated("com/example/javaname/JavaName.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
-        JavaClass classWithDescription = javaDocBuilder.getClassByName("com.example.JavaName");
+        JavaClass classWithDescription = javaDocBuilder.getClassByName("com.example.javaname.JavaName");
 
         JavaField javaPropertyField = classWithDescription.getFieldByName("javaProperty");
         assertThat(javaPropertyField.getComment(), containsString("Corresponds to the \"propertyWithJavaName\" property."));
@@ -149,15 +158,51 @@ public class JavaNameIT {
     @Test(expected = IllegalArgumentException.class)
     public void doesNotAllowDuplicateNames() {
 
-        classSchemaRule.generateAndCompile("/schema/javaName/duplicateName.json", "com.example");
+        schemaRule.generateAndCompile("/schema/javaName/duplicateName.json", "com.example");
 
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void doesNotAllowDuplicateDefaultNames() {
 
-        classSchemaRule.generateAndCompile("/schema/javaName/duplicateDefaultName.json", "com.example");
+        schemaRule.generateAndCompile("/schema/javaName/duplicateDefaultName.json", "com.example");
 
+    }
+
+    @Test
+    public void arrayRequiredAppearsInFieldJavadoc() throws IOException {
+
+        schemaRule.generateAndCompile("/schema/javaName/javaNameWithRequiredProperties.json", "com.example.required");
+        File generatedJavaFileWithRequiredProperties = schemaRule.generated("com/example/required/JavaNameWithRequiredProperties.java");
+
+        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        javaDocBuilder.addSource(generatedJavaFileWithRequiredProperties);
+
+        JavaClass classWithRequiredProperties = javaDocBuilder.getClassByName("com.example.required.JavaNameWithRequiredProperties");
+
+        JavaField javaFieldWithoutJavaName = classWithRequiredProperties.getFieldByName("requiredPropertyWithoutJavaName");
+        JavaField javaFieldWithJavaName = classWithRequiredProperties.getFieldByName("requiredPropertyWithoutJavaName");
+
+        assertThat(javaFieldWithoutJavaName.getComment(), containsString("(Required)"));
+        assertThat(javaFieldWithJavaName.getComment(), containsString("(Required)"));
+    }
+
+    @Test
+    public void inlineRequiredAppearsInFieldJavadoc() throws IOException {
+
+        schemaRule.generateAndCompile("/schema/javaName/javaNameWithRequiredProperties.json", "com.example.required");
+        File generatedJavaFileWithRequiredProperties = schemaRule.generated("com/example/required/JavaNameWithRequiredProperties.java");
+
+        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        javaDocBuilder.addSource(generatedJavaFileWithRequiredProperties);
+
+        JavaClass classWithRequiredProperties = javaDocBuilder.getClassByName("com.example.required.JavaNameWithRequiredProperties");
+
+        JavaField javaFieldWithoutJavaName = classWithRequiredProperties.getFieldByName("inlineRequiredPropertyWithoutJavaName");
+        JavaField javaFieldWithJavaName = classWithRequiredProperties.getFieldByName("inlineRequiredPropertyWithoutJavaName");
+
+        assertThat(javaFieldWithoutJavaName.getComment(), containsString("(Required)"));
+        assertThat(javaFieldWithJavaName.getComment(), containsString("(Required)"));
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/javaNameWithRequiredProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/javaNameWithRequiredProperties.json
@@ -1,0 +1,29 @@
+{
+  "type" : "object",
+  "required" : [ "requiredPropertyWithJavaName", "requiredPropertyWithoutJavaName" ],
+  "properties" : {
+    "notRequiredPropertyWithJavaName" : {
+      "javaName" : "notRequiredJavaProperty",
+      "type" : "string"
+    },
+    "notRequiredPropertyWithoutJavaName" : {
+      "type" : "string"
+    },
+    "requiredPropertyWithJavaName" : {
+      "javaName" : "requiredJavaProperty",
+      "type" : "string"
+    },
+    "requiredPropertyWithoutJavaName" : {
+      "type" : "string"
+    },
+    "inlineRequiredPropertyWithJavaName" : {
+      "javaName" : "inlineRequiredJavaProperty",
+      "type" : "string",
+      "required" : true
+    },
+    "inlineRequiredPropertyWithoutJavaName" : {
+      "type" : "string",
+      "required" : true
+    }
+  }
+}


### PR DESCRIPTION
The previous implementation of `javaName` rule was causing required properties to not be annotated properly (and probably breaking other things). This PR is intended to fix that by better integrating the feature into the project's structure.

`javaName` is applied now within the `NameHelper` class so that the other modules can take it into account while resolving generated Java fields. This requires passing the `JsonNode` of the relevant property to the helper method alongside the property's name. Some of the other modules have been altered to reflect that.