### PR TITLE
Override parent builders even if the child schema has no properties

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -121,9 +121,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
             ruleFactory.getDescriptionRule().apply(nodeName, node.get("description"), jclass, schema);
         }
 
-        if (node.has("properties")) {
-            ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), jclass, schema);
-        }
+        ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), jclass, schema);
 
         if (ruleFactory.getGenerationConfig().isIncludeToString()) {
             addToString(jclass);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
@@ -17,6 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.sun.codemodel.*;
 import org.jsonschema2pojo.Schema;
 
@@ -53,6 +54,9 @@ public class PropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
      */
     @Override
     public JDefinedClass apply(String nodeName, JsonNode node, JDefinedClass jclass, Schema schema) {
+        if (node == null) {
+            node = JsonNodeFactory.instance.objectNode();
+        }
 
         for (Iterator<String> properties = node.fieldNames(); properties.hasNext(); ) {
             String property = properties.next();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -107,19 +107,49 @@ public class ExtendsIT {
     }
 
     @Test
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings("rawtypes")
     public void extendsBuilderMethods() throws Exception {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfAParent");
 
-        Method builderMethod = supertype.getDeclaredMethod("withParent", String.class);
-        assertNotNull("no withParent method", builderMethod);
+        checkBuilderMethod(subtype, supertype, "withParent");
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void builderMethodsOnChildWithProperties() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfB.json", "com.example", config("generateBuilders", true));
+
+        Class type = resultsClassLoader.loadClass("com.example.SubtypeOfB");
+        Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfBParent");
+
+        checkBuilderMethod(type, supertype, "withParentProperty");
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void builderMethodsOnChildWithNoProperties() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfBWithNoProperties.json", "com.example", config("generateBuilders", true));
+
+        Class type = resultsClassLoader.loadClass("com.example.SubtypeOfBWithNoProperties");
+        Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfBWithNoPropertiesParent");
+
+        checkBuilderMethod(type, supertype, "withParentProperty");
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static void checkBuilderMethod(Class type, Class supertype, String builderMethodName) throws Exception {
+        assertThat(type.getSuperclass(), is(equalTo(supertype)));
+
+        Method builderMethod = supertype.getDeclaredMethod(builderMethodName, String.class);
+        assertNotNull("Builder method not found on super type: " + builderMethodName, builderMethod);
         assertThat(builderMethod.getReturnType(), is(equalTo(supertype)));
 
-        Method builderMethodOverride = subtype.getDeclaredMethod("withParent", String.class);
-        assertNotNull("no withParent method", builderMethodOverride);
-        assertThat(builderMethodOverride.getReturnType(), is(equalTo(subtype)));
+        Method builderMethodOverride = type.getDeclaredMethod(builderMethodName, String.class);
+        assertNotNull("Builder method not overridden on type: " + builderMethodName, builderMethodOverride);
+        assertThat(builderMethodOverride.getReturnType(), is(equalTo(type)));
     }
+
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/b.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/b.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "parentProperty": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfB.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfB.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "b.json"
+    },
+    "properties": {
+        "childProperty": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfBWithNoProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfBWithNoProperties.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "b.json"
+    }
+}


### PR DESCRIPTION
Fix #538.