### PR TITLE
Fix for extends with constructor

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -449,15 +449,27 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
     }
 
+    private static JDefinedClass definedClassOrNullFromType(JType type)
+    {
+        if (type == null || type.isPrimitive())
+        {
+            return null;
+        }
+        JClass fieldClass = type.boxify();
+        JPackage jPackage = fieldClass._package();
+        return jPackage._getClass(fieldClass.name());
+    }
+
     /**
      * This is recursive with searchClassAndSuperClassesForField
      */
     private JFieldVar searchSuperClassesForField(String property, JDefinedClass jclass) {
         JClass superClass = jclass._extends();
-        if (superClass == null || !(superClass instanceof JDefinedClass)) {
+        JDefinedClass definedSuperClass = definedClassOrNullFromType(superClass);
+        if (definedSuperClass == null) {
             return null;
         }
-        return searchClassAndSuperClassesForField(property, (JDefinedClass)superClass);
+        return searchClassAndSuperClassesForField(property, definedSuperClass);
     }
 
     private JFieldVar searchClassAndSuperClassesForField(String property, JDefinedClass jclass) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -108,6 +108,36 @@ public class ExtendsIT {
 
     @Test
     @SuppressWarnings("rawtypes")
+    public void constructorHasParentsProperties() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfB.json", "com.example", config("includeConstructors", true));
+
+        Class type = resultsClassLoader.loadClass("com.example.SubtypeOfB");
+        Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfBParent");
+
+        assertThat(type.getSuperclass(), is(equalTo(supertype)));
+
+        assertNotNull("Parent constructor is missing", supertype.getConstructor(String.class));
+        assertNotNull("Constructor is missing", type.getConstructor(String.class, String.class));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void constructorHasParentsParentProperties() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfB.json", "com.example", config("includeConstructors", true));
+
+        Class type = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfB");
+        Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfBParent");
+        Class superSupertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfBParentParent");
+
+        assertThat(type.getSuperclass(), is(equalTo(supertype)));
+
+        assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class));
+        assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class));
+        assertNotNull("Constructor is missing", type.getDeclaredConstructor(String.class, String.class, String.class));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
     public void extendsBuilderMethods() throws Exception {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -14,6 +14,7 @@ package org.jsonschema2pojo.integration;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.hamcrest.Matchers.*;
@@ -118,6 +119,18 @@ public class ExtendsIT {
 
         assertNotNull("Parent constructor is missing", supertype.getConstructor(String.class));
         assertNotNull("Constructor is missing", type.getConstructor(String.class, String.class));
+
+        Object typeInstance = type.getConstructor(String.class, String.class).newInstance("String1", "String2");
+
+        Field chieldField = type.getDeclaredField("childProperty");
+        chieldField.setAccessible(true);
+        String childProp = (String)chieldField.get(typeInstance);
+        Field parentField = supertype.getDeclaredField("parentProperty");
+        parentField.setAccessible(true);
+        String parentProp = (String)parentField.get(typeInstance);
+
+        assertThat(childProp, is(equalTo("String1")));
+        assertThat(parentProp, is(equalTo("String2")));
     }
 
     @Test
@@ -134,6 +147,22 @@ public class ExtendsIT {
         assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class));
         assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class));
         assertNotNull("Constructor is missing", type.getDeclaredConstructor(String.class, String.class, String.class));
+
+        Object typeInstance = type.getConstructor(String.class, String.class, String.class).newInstance("String1", "String2", "String3");
+
+        Field chieldChildField = type.getDeclaredField("childChildProperty");
+        chieldChildField.setAccessible(true);
+        String childChildProp = (String)chieldChildField.get(typeInstance);
+        Field chieldField = supertype.getDeclaredField("childProperty");
+        chieldField.setAccessible(true);
+        String childProp = (String)chieldField.get(typeInstance);
+        Field parentField = superSupertype.getDeclaredField("parentProperty");
+        parentField.setAccessible(true);
+        String parentProp = (String)parentField.get(typeInstance);
+
+        assertThat(childChildProp, is(equalTo("String1")));
+        assertThat(childProp, is(equalTo("String2")));
+        assertThat(parentProp, is(equalTo("String3")));
     }
 
     @Test
@@ -150,6 +179,22 @@ public class ExtendsIT {
         assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class));
         assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class));
         assertNotNull("Constructor is missing", type.getDeclaredConstructor(Integer.class, String.class, String.class));
+
+        Object typeInstance = type.getConstructor(Integer.class, String.class, String.class).newInstance(5, "String2", "String3");
+
+        Field chieldChildField = type.getDeclaredField("childChildProperty");
+        chieldChildField.setAccessible(true);
+        int childChildProp = (int)chieldChildField.get(typeInstance);
+        Field chieldField = supertype.getDeclaredField("childProperty");
+        chieldField.setAccessible(true);
+        String childProp = (String)chieldField.get(typeInstance);
+        Field parentField = superSupertype.getDeclaredField("parentProperty");
+        parentField.setAccessible(true);
+        String parentProp = (String)parentField.get(typeInstance);
+
+        assertThat(childChildProp, is(equalTo(5)));
+        assertThat(childProp, is(equalTo("String2")));
+        assertThat(parentProp, is(equalTo("String3")));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -138,6 +138,22 @@ public class ExtendsIT {
 
     @Test
     @SuppressWarnings("rawtypes")
+    public void constructorHasParentsParentPropertiesInCorrectOrder() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfBDifferentType.json", "com.example", config("includeConstructors", true));
+
+        Class type = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfBDifferentType");
+        Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfBDifferentTypeParent");
+        Class superSupertype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfBDifferentTypeParentParent");
+
+        assertThat(type.getSuperclass(), is(equalTo(supertype)));
+
+        assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class));
+        assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class));
+        assertNotNull("Constructor is missing", type.getDeclaredConstructor(Integer.class, String.class, String.class));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
     public void extendsBuilderMethods() throws Exception {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/c.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/c.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "properties": {
+        "duplicatedProp": {
+            "type": "string"
+        },
+        "cProp": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfC.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfC.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "c.json"
+    },
+    "properties": {
+        "duplicatedProp": {
+            "type": "string"
+        },
+        "cSubtypeProp": {
+            "type": "boolean"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfSubtypeOfB.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfSubtypeOfB.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "subtypeOfB.json"
+    },
+    "properties": {
+        "childChildProperty": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfSubtypeOfBDifferentType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfSubtypeOfBDifferentType.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "subtypeOfB.json"
+    },
+    "properties": {
+        "childChildProperty": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfSubtypeOfC.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfSubtypeOfC.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "subtypeOfC.json"
+    },
+    "properties": {
+        "duplicatedProp": {
+            "type": "string"
+        },
+        "cSubtypeSubtypeProp": {
+            "type": "integer"
+        }
+    }
+}


### PR DESCRIPTION
So this isn't the prettiest, but it might do for now.

There's at least 2 new recursive methods and I had to make use of 'instanceof' :(

what do you think to storing classes JFieldVar's on the schema object? It would remove the need for the `instanceof` call...?
