### PR TITLE
add failing test for embedded refs to schema root

### DIFF
--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
@@ -76,6 +76,20 @@ public class SchemaStoreTest {
     }
 
     @Test
+    public void createWithEmbeddedSelfRef() throws URISyntaxException {
+
+        URI schemaUri = getClass().getResource("/schema/embeddedRef.json").toURI();
+
+        SchemaStore schemaStore = new SchemaStore();
+        Schema topSchema = schemaStore.create(schemaUri);
+        Schema embeddedSchema = schemaStore.create(topSchema, "#/definitions/embedded");
+        Schema selfRefSchema = schemaStore.create(embeddedSchema, "#");
+
+        assertThat(topSchema, is(sameInstance(selfRefSchema)));
+
+    }
+
+    @Test
     public void createWithFragmentResolution() throws URISyntaxException {
 
         URI addressSchemaUri = getClass().getResource("/schema/address.json").toURI();

--- a/jsonschema2pojo-core/src/test/resources/schema/embeddedRef.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/embeddedRef.json
@@ -1,0 +1,9 @@
+{
+    "type" : "object",
+    "definitions" : {
+        "embedded" : {
+            "type" : "object"
+        }
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
@@ -59,6 +59,22 @@ public class SelfRefIT {
     }
 
     @Test
+    public void selfEmbeddedRefUsedInAPropertyIsReadSuccessfully() throws NoSuchMethodException {
+
+        Class<?> aClass = selfRefsClass.getMethod("getEmbeddedInSelf").getReturnType();
+
+        assertThat(aClass.getName(), is("com.example.EmbeddedInSelf"));
+
+        Class<?> embedded2Class = aClass.getMethod("getEmbeddedProp").getReturnType();
+
+        assertThat(embedded2Class.getName(), is("com.example.EmbeddedProp"));
+
+        Class<?> otherEmbeddedClass = embedded2Class.getMethod("getEmbeddedProp2").getReturnType();
+
+        assertThat(otherEmbeddedClass.getName(), is("com.example.SelfRefs"));
+    }
+
+    @Test
     public void selfRefUsedAsArrayItemsIsReadSuccessfully() throws NoSuchMethodException {
 
         Type listOfAType = selfRefsClass.getMethod("getArrayOfSelf").getGenericReturnType();

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/selfRefs.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/selfRefs.json
@@ -9,9 +9,31 @@
             "items" : {
                 "$ref" : "#"
             }
+        },
+        "embeddedInSelf" : {
+            "$ref" : "#/definitions/embedded"
         }
     },
     "additionalProperties" : {
         "$ref" : "#"
+    },
+    "definitions" : {
+        "embedded" : {
+            "type" : "object",
+            "properties" : {
+                "embeddedProp" : {
+                    "$ref" : "#/definitions/embedded2"
+                }
+            }
+        },
+        "embedded2" : {
+            "type" : "object",
+            "properties" : {
+                "embeddedProp2" : {
+                    "$ref" : "#"
+                }
+            }
+        }
     }
+
 }


### PR DESCRIPTION
I will be working on a fix for this. I think that the library currently makes some incorrect assumptions about the way that refs should work and that's currently causing issue in other work im trying to do (on basic allOf support). Have a look at this really small test case and see if you agree.