### PR TITLE
Schema contract changes

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -32,6 +32,14 @@ public class SchemaStore {
     protected FragmentResolver fragmentResolver = new FragmentResolver();
     protected ContentResolver contentResolver = new ContentResolver();
 
+    public SchemaStore() {
+
+    }
+
+    public SchemaStore(ContentResolver contentResolver) {
+        this.contentResolver = contentResolver;
+    }
+
     /**
      * Create or look up a new schema which has the given ID and read the
      * contents of the given ID as a URL. If a schema with the given ID is

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -100,7 +100,13 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
 
         JType propertyType;
         if (node != null && node.size() != 0) {
-            propertyType = ruleFactory.getSchemaRule().apply(nodeName + "Property", node, jclass, schema);
+            String pathToAdditionalProperties;
+            if (schema.getId().getFragment() == null) {
+                pathToAdditionalProperties = "#additionalProperties";
+            } else {
+                pathToAdditionalProperties = "#" + schema.getId().getFragment() + "/additionalProperties";
+            }
+            propertyType = ruleFactory.getSchemaRule().apply(nodeName + "Property", node, jclass, ruleFactory.getSchemaStore().create(schema, pathToAdditionalProperties));
         } else {
             propertyType = jclass.owner().ref(Object.class);
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
@@ -78,7 +78,13 @@ public class ArrayRule implements Rule<JPackage, JClass> {
 
         JType itemType;
         if (node.has("items")) {
-            itemType = ruleFactory.getSchemaRule().apply(makeSingular(nodeName), node.get("items"), jpackage, schema);
+            String pathToItems;
+            if (schema.getId().getFragment() == null) {
+                pathToItems = "#items";
+            } else {
+                pathToItems = "#" + schema.getId().getFragment() + "/items";
+            }
+            itemType = ruleFactory.getSchemaRule().apply(makeSingular(nodeName), node.get("items"), jpackage, ruleFactory.getSchemaStore().create(schema, pathToItems));
         } else {
             itemType = jpackage.owner().ref(Object.class);
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
@@ -79,7 +79,7 @@ public class ArrayRule implements Rule<JPackage, JClass> {
         JType itemType;
         if (node.has("items")) {
             String pathToItems;
-            if (schema.getId().getFragment() == null) {
+            if (schema.getId() == null || schema.getId().getFragment() == null) {
                 pathToItems = "#items";
             } else {
                 pathToItems = "#" + schema.getId().getFragment() + "/items";

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -74,6 +74,37 @@ public class ObjectRule implements Rule<JPackage, JType> {
     private final RuleFactory ruleFactory;
     private final ParcelableHelper parcelableHelper;
 
+    private static class SchemaClassInfo {
+        private final Schema superSchema;
+        private final Schema classDefinitionSchema;
+        private final Schema classHierarchySchema;
+        private final JType superType;
+        private final String nodeName;
+
+        private JType getSuperType() {
+            if (this.superSchema != null) {
+                return this.superSchema.getJavaType();
+            }
+            return this.superType;
+        }
+
+        private SchemaClassInfo(Schema classHierarchySchema, Schema classDefinitionSchema, Schema superSchema, String nodeName) {
+            this.superSchema = superSchema;
+            this.classHierarchySchema = superSchema;
+            this.classDefinitionSchema = classDefinitionSchema;
+            this.superType = null;
+            this.nodeName = nodeName;
+        }
+
+        private SchemaClassInfo(Schema classHierarchySchema, Schema classDefinitionSchema, JType superType, String nodeName) {
+            this.superSchema = null;
+            this.classHierarchySchema = classHierarchySchema;
+            this.classDefinitionSchema = classDefinitionSchema;
+            this.superType = superType;
+            this.nodeName = nodeName;
+        }
+    }
+
     protected ObjectRule(RuleFactory ruleFactory, ParcelableHelper parcelableHelper) {
         this.ruleFactory = ruleFactory;
         this.parcelableHelper = parcelableHelper;
@@ -94,7 +125,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
     @Override
     public JType apply(String nodeName, JsonNode node, JPackage _package, Schema schema) {
 
-        JType superType = getSuperType(nodeName, node, _package, schema);
+        SchemaClassInfo schemaClassInfo = getSchemaClassInfo(nodeName, schema, _package);
+        Schema classDefinitionSchema = schemaClassInfo.classDefinitionSchema;
+        node = classDefinitionSchema.getContent();
+        JType superType = schemaClassInfo.getSuperType();
+
 
         if (superType.isPrimitive() || isFinal(superType)) {
             return superType;
@@ -117,14 +152,14 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         if (node.has("title")) {
-            ruleFactory.getTitleRule().apply(nodeName, node.get("title"), jclass, schema);
+            ruleFactory.getTitleRule().apply(nodeName, node.get("title"), jclass, classDefinitionSchema);
         }
 
         if (node.has("description")) {
-            ruleFactory.getDescriptionRule().apply(nodeName, node.get("description"), jclass, schema);
+            ruleFactory.getDescriptionRule().apply(nodeName, node.get("description"), jclass, classDefinitionSchema);
         }
 
-        ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), jclass, schema);
+        ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), jclass, classDefinitionSchema);
 
         if (ruleFactory.getGenerationConfig().isIncludeToString()) {
             addToString(jclass);
@@ -134,12 +169,12 @@ public class ObjectRule implements Rule<JPackage, JType> {
             addInterfaces(jclass, node.get("javaInterfaces"));
         }
 
-        ruleFactory.getAdditionalPropertiesRule().apply(nodeName, node.get("additionalProperties"), jclass, schema);
+        ruleFactory.getAdditionalPropertiesRule().apply(nodeName, node.get("additionalProperties"), jclass, classDefinitionSchema);
 
-        ruleFactory.getDynamicPropertiesRule().apply(nodeName, node.get("properties"), jclass, schema);
+        ruleFactory.getDynamicPropertiesRule().apply(nodeName, node.get("properties"), jclass, classDefinitionSchema);
 
         if (node.has("required")) {
-            ruleFactory.getRequiredArrayRule().apply(nodeName, node.get("required"), jclass, schema);
+            ruleFactory.getRequiredArrayRule().apply(nodeName, node.get("required"), jclass, classDefinitionSchema);
         }
 
         if (ruleFactory.getGenerationConfig().isIncludeHashcodeAndEquals()) {
@@ -152,7 +187,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
         
         if (ruleFactory.getGenerationConfig().isIncludeConstructors()) {
-            addConstructors(jclass, node, schema, ruleFactory.getGenerationConfig().isConstructorsRequiredPropertiesOnly());
+            addConstructors(nodeName, jclass, schemaClassInfo, ruleFactory.getGenerationConfig().isConstructorsRequiredPropertiesOnly(), _package);
         }
 
         if (ruleFactory.getGenerationConfig().isSerializable()) {
@@ -206,17 +241,17 @@ public class ObjectRule implements Rule<JPackage, JType> {
     /**
      * Recursive, walks the schema tree and assembles a list of all properties of this schema's super schemas
      */
-    private LinkedHashSet<String> getSuperTypeConstructorPropertiesRecursive(JsonNode node, Schema schema, boolean onlyRequired) {
-        Schema superTypeSchema = getSuperSchema(node, schema, true);
+    private LinkedHashSet<String> getSuperTypeConstructorPropertiesRecursive(SchemaClassInfo classInfo, boolean onlyRequired, JPackage jPackage) {
+        SchemaClassInfo superClassInfo = getSuperSchemaClassInfo(classInfo, jPackage);
 
-        if (superTypeSchema == null) {
+        if (superClassInfo == null) {
             return new LinkedHashSet<String>();
         }
 
-        JsonNode superSchemaNode = superTypeSchema.getContent();
+        JsonNode superSchemaNode = superClassInfo.classDefinitionSchema.getContent();
 
-        LinkedHashSet<String> rtn = getConstructorProperties(superSchemaNode, superTypeSchema, onlyRequired);
-        rtn.addAll(getSuperTypeConstructorPropertiesRecursive(superSchemaNode, superTypeSchema, onlyRequired));
+        LinkedHashSet<String> rtn = getConstructorProperties(superSchemaNode, superClassInfo.classDefinitionSchema, onlyRequired);
+        rtn.addAll(getSuperTypeConstructorPropertiesRecursive(superClassInfo, onlyRequired, jPackage));
 
         return rtn;
     }
@@ -296,23 +331,25 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
     }
 
-    private JType getSuperType(String nodeName, JsonNode node, JPackage jPackage, Schema schema) {
+    private SchemaClassInfo getSuperSchemaClassInfo(SchemaClassInfo schemaClassInfo, JPackage jPackage) {
+        Schema superTypeSchema = schemaClassInfo.superSchema;
+        if (superTypeSchema == null) {
+            return null;
+        }
+
+        return getSchemaClassInfo(schemaClassInfo.nodeName + "Parent", superTypeSchema, jPackage);
+    }
+
+    private SchemaClassInfo getSchemaClassInfo(String nodeName, Schema schema, JPackage jPackage) {
+        JsonNode node = schema.getContent();
+
         if (node.has("extends") && node.has("extendsJavaClass")) {
             throw new IllegalStateException("'extends' and 'extendsJavaClass' defined simultaneously");
         }
 
+        String parentNodeName = nodeName + "Parent";
+
         JType superType = jPackage.owner().ref(Object.class);
-        Schema superTypeSchema = getSuperSchema(node, schema, false);
-        if (superTypeSchema != null) {
-            superType = ruleFactory.getSchemaRule().apply(nodeName + "Parent", node.get("extends"), jPackage, superTypeSchema);
-        } else if (node.has("extendsJavaClass")) {
-            superType = resolveType(jPackage, node.get("extendsJavaClass").asText());
-        }
-
-        return superType;
-    }
-
-    private Schema getSuperSchema(JsonNode node, Schema schema, boolean followRefs) {
         if (node.has("extends")) {
             String path;
             if (schema.getId().getFragment() == null) {
@@ -323,13 +360,16 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
             Schema superSchema = ruleFactory.getSchemaStore().create(schema, path);
 
-            if (followRefs) {
-                superSchema = resolveSchemaRefsRecursive(superSchema);
-            }
 
-            return superSchema;
+            //schema rule follows refs, so we do the same in order to get hold of a super schema that has a type associated, schemarule really ought to return this information
+            ruleFactory.getSchemaRule().apply(parentNodeName, node.get("extends"), jPackage, superSchema);
+            superSchema = resolveSchemaRefsRecursive(superSchema);
+
+            return new SchemaClassInfo(schema, schema, superSchema, nodeName);
+        } else if (node.has("extendsJavaClass")) {
+            superType = resolveType(jPackage, node.get("extendsJavaClass").asText());
         }
-        return null;
+        return new SchemaClassInfo(schema, schema, superType, nodeName);
     }
 
     private Schema resolveSchemaRefsRecursive(Schema schema) {
@@ -397,11 +437,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
         hashCode.annotate(Override.class);
     }
 
-    private void addConstructors(JDefinedClass jclass, JsonNode node, Schema schema, boolean onlyRequired) {
-
-        LinkedHashSet<String> classProperties = getConstructorProperties(node, schema, onlyRequired);
-        LinkedHashSet<String> combinedSuperProperties = getSuperTypeConstructorPropertiesRecursive(node, schema, onlyRequired);
-
+    private void addConstructors(String nodeName, JDefinedClass jclass, SchemaClassInfo schemaClassInfo, boolean onlyRequired, JPackage jPackage) {
+        Schema classDefinitionSchema = schemaClassInfo.classDefinitionSchema;
+        LinkedHashSet<String> classProperties = getConstructorProperties(classDefinitionSchema.getContent(), classDefinitionSchema, onlyRequired);
+        LinkedHashSet<String> combinedSuperProperties = getSuperTypeConstructorPropertiesRecursive(schemaClassInfo, onlyRequired, jPackage);
+        
         // no properties to put in the constructor => default constructor is good enough.
         if (classProperties.isEmpty() && combinedSuperProperties.isEmpty()) {
             return;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -72,7 +72,13 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
     public JDefinedClass apply(String nodeName, JsonNode node, JDefinedClass jclass, Schema schema) {
         String propertyName = ruleFactory.getNameHelper().getPropertyName(nodeName, node);
 
-        JType propertyType = ruleFactory.getSchemaRule().apply(nodeName, node, jclass, schema);
+        String pathToProperty;
+        if (schema.getId() == null || schema.getId().getFragment() == null) {
+            pathToProperty = "#properties/" + nodeName;
+        } else {
+            pathToProperty = "#" + schema.getId().getFragment() + "/properties/" + nodeName;
+        }
+        JType propertyType = ruleFactory.getSchemaRule().apply(nodeName, node, jclass, ruleFactory.getSchemaStore().create(schema, pathToProperty));
 
         node = resolveRefs(node, schema);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
@@ -32,6 +32,7 @@ import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
+import org.jsonschema2pojo.ContentResolver;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JPackage;
@@ -39,7 +40,8 @@ import com.sun.codemodel.JPackage;
 public class ArrayRuleTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
-    private final ArrayRule rule = new ArrayRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private final ContentResolver contentResolver = mock(ContentResolver.class);
+    private final ArrayRule rule = new ArrayRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore(contentResolver)));
 
     @Test
     public void arrayWithUniqueItemsProducesSet() {
@@ -55,7 +57,11 @@ public class ArrayRuleTest {
         propertyNode.put("uniqueItems", true);
         propertyNode.put("items", itemsNode);
 
-        JClass propertyType = rule.apply("fooBars", propertyNode, jpackage, mock(Schema.class));
+        Schema schema = mock(Schema.class);
+        when(schema.getId()).thenReturn(URI.create("http://example/uniqueArray"));
+        when(contentResolver.resolve(URI.create("http://example/uniqueArray"))).thenReturn(propertyNode);
+
+        JClass propertyType = rule.apply("fooBars", propertyNode, jpackage, schema);
 
         assertThat(propertyType, notNullValue());
         assertThat(propertyType.erasure(), is(codeModel.ref(Set.class)));
@@ -79,6 +85,7 @@ public class ArrayRuleTest {
         Schema schema = mock(Schema.class);
         when(schema.getId()).thenReturn(URI.create("http://example/nonUniqueArray"));
         when(config.isUseDoubleNumbers()).thenReturn(true);
+        when(contentResolver.resolve(URI.create("http://example/nonUniqueArray"))).thenReturn(propertyNode);
 
         JClass propertyType = rule.apply("fooBars", propertyNode, jpackage, schema);
 
@@ -105,6 +112,7 @@ public class ArrayRuleTest {
         when(schema.getId()).thenReturn(URI.create("http://example/nonUniqueArray"));
         when(config.isUsePrimitives()).thenReturn(true);
         when(config.isUseDoubleNumbers()).thenReturn(true);
+        when(contentResolver.resolve(URI.create("http://example/nonUniqueArray"))).thenReturn(propertyNode);
 
         JClass propertyType = rule.apply("fooBars", propertyNode, jpackage, schema);
 
@@ -129,6 +137,7 @@ public class ArrayRuleTest {
 
         Schema schema = mock(Schema.class);
         when(schema.getId()).thenReturn(URI.create("http://example/defaultArray"));
+        when(contentResolver.resolve(URI.create("http://example/defaultArray"))).thenReturn(propertyNode);
 
         JClass propertyType = rule.apply("fooBars", propertyNode, jpackage, schema);
 


### PR DESCRIPTION
~~This is a very large PR as it includes changes from #560 and #558. The diff should therefore decrease if those changes are accepted~~

This is a change to the way the schemastore is used, essentially it's used more, for every potential object schema we come across.

There is also the beginnings of a context-like object in ObjectRule, call `SchemaClassInfo`. It may look a bit confusing having both the `classHierarchySchema` and `classDefinitionSchema` in as separate instance, but this allows a layer of indirection between the two which allows me to support `allOf` in a very simple way (only where it is exactly equivalent to extends) - see this https://github.com/samskiter/jsonschema2pojo/commit/94d9f1083a23df245b93de493717c9c053026a5d

I appreciated that you might not want to add allOf support and there is a lot of debate, so I tried to separate the two. So this is a bit of a speculative PR - it's really useful for me but maybe not so much for you! If it is ok, let me know if you would also like the allOf in there too.

Cheers,

Sam
