### PR TITLE
support "required" keyword draft4 array-style when generating constru…

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -24,10 +24,12 @@ import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -182,13 +184,17 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         LinkedHashSet<String> rtn = new LinkedHashSet<String>();
-        LinkedHashSet<String> draft4RequiredProperties = new LinkedHashSet<String>();
+        Set<String> draft4RequiredProperties = new HashSet<String>();
 
         // setup the set of required properties for draft4 style "required"
-        if (onlyRequired && node.has("required") && node.get("required").isArray()) {
-            for (Iterator<JsonNode> ri = node.get("required").elements(); ri.hasNext();) {
-                JsonNode required = ri.next();
-                draft4RequiredProperties.add(required.asText());
+        if (onlyRequired && node.has("required")) {
+            JsonNode requiredArray =  node.get("required");
+            if (requiredArray.isArray()) {
+                for (JsonNode requiredEntry: requiredArray) {
+                    if (requiredEntry.isTextual()) {
+                        draft4RequiredProperties.add(requiredEntry.asText());
+                    }
+                }
             }
         }
 
@@ -208,7 +214,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
                     rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
                 }
             } else {
-                rtn.add((nameHelper.getPropertyName(property.getKey(), property.getValue())));
+                rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
             }
         }
         return rtn;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -182,6 +182,15 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         LinkedHashSet<String> rtn = new LinkedHashSet<String>();
+        LinkedHashSet<String> draft4RequiredProperties = new LinkedHashSet<String>();
+
+        // setup the set of required properties for draft4 style "required"
+        if (onlyRequired && node.has("required") && node.get("required").isArray()) {
+            for (Iterator<JsonNode> ri = node.get("required").elements(); ri.hasNext();) {
+                JsonNode required = ri.next();
+                draft4RequiredProperties.add(required.asText());
+            }
+        }
 
         NameHelper nameHelper = ruleFactory.getNameHelper();
         for (Iterator<Map.Entry<String, JsonNode>> properties = node.get("properties").fields(); properties.hasNext();) {
@@ -189,7 +198,13 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
             JsonNode propertyObj = property.getValue();
             if (onlyRequired) {
+                // draft3 style
                 if (propertyObj.has("required") && propertyObj.get("required").asBoolean()) {
+                    rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
+                }
+
+                // draft4 style
+                if (draft4RequiredProperties.contains(property.getKey())) {
                     rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
                 }
             } else {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
@@ -51,11 +51,11 @@ public class ConstructorsIT {
     }
 
     public static class AllPropertiesIT {
-        
         @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
         protected static Class<?> typeWithRequired;
         private static Class<?> typeWithoutProperties;
+        protected static Class<?> typeWithRequiredArray;
 
         //xxx there's a bit of duplication here in the name of performance; if we did this step as a Before method,
         //we could factor out a super class between AllPropertiesIT and RequiredOnlyIT... but it makes the tests run
@@ -76,18 +76,29 @@ public class ConstructorsIT {
                     "com.example",
                     config);
 
+            classSchemaRule.generate(
+                    "/schema/constructors/requiredArrayPropertyConstructors.json",
+                    "com.example",
+                    config);
+
             ClassLoader loader = classSchemaRule.compile();
             typeWithRequired = loader.loadClass("com.example.RequiredPropertyConstructors");
             typeWithoutProperties = loader.loadClass("com.example.NoPropertiesConstructor");
+            typeWithRequiredArray = loader.loadClass("com.example.RequiredArrayPropertyConstructors");
         }
 
         @Test
         public void testGeneratesConstructorWithAllProperties() throws Exception {
-            assertHasModifier(JMod.PUBLIC, getArgsConstructor().getModifiers(), "public");
-
+            assertHasModifier(JMod.PUBLIC, getArgsConstructor(typeWithRequired).getModifiers(), "public");
         }
-        public Constructor<?> getArgsConstructor() throws NoSuchMethodException {
-            return typeWithRequired.getConstructor(String.class, Integer.class, Boolean.class, String.class, String.class);
+
+        @Test
+            public void testGeneratesCosntructorWithAllPropertiesArrayStyle() throws Exception {
+            assertHasModifier(JMod.PUBLIC, getArgsConstructor(typeWithRequiredArray).getModifiers(), "public");
+        }
+
+        public Constructor<?> getArgsConstructor(Class<?> clazz) throws NoSuchMethodException {
+            return clazz.getConstructor(String.class, Integer.class, Boolean.class, String.class, String.class);
         }
 
         @Test
@@ -106,6 +117,7 @@ public class ConstructorsIT {
 
         protected static Class<?> typeWithRequired;
         protected static Class<?> typeWithoutRequired;
+        protected static Class<?> typeWithRequiredArray;
 
         @BeforeClass
         public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
@@ -124,9 +136,15 @@ public class ConstructorsIT {
                     "com.example",
                     config);
 
+            classSchemaRule.generate(
+                    "/schema/constructors/requiredArrayPropertyConstructors.json",
+                    "com.example",
+                    config);
+
             ClassLoader classLoader = classSchemaRule.compile();
             typeWithRequired = classLoader.loadClass("com.example.RequiredPropertyConstructors");
             typeWithoutRequired = classLoader.loadClass("com.example.NoRequiredPropertiesConstructor");
+            typeWithRequiredArray = classLoader.loadClass("com.example.RequiredArrayPropertyConstructors");
         }
 
         @Test
@@ -138,18 +156,25 @@ public class ConstructorsIT {
 
         @Test
         public void testCreatesConstructorWithRequiredParams() throws Exception {
-            Constructor<?> constructor = getArgsConstructor();
+            Constructor<?> constructor = getArgsConstructor(typeWithRequired);
 
             assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
         }
 
-        public Constructor<?> getArgsConstructor() throws NoSuchMethodException {
-            return typeWithRequired.getConstructor(String.class, Integer.class, Boolean.class);
+        @Test
+        public void testCreatesConstructorWithRequiredParamsArrayStyle() throws Exception {
+            Constructor<?> constructor = getArgsConstructor(typeWithRequiredArray);
+
+            assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+        }
+
+        public Constructor<?> getArgsConstructor(Class<?> clazz) throws NoSuchMethodException {
+            return clazz.getConstructor(String.class, Integer.class, Boolean.class);
         }
 
         @Test
         public void testConstructorAssignsFields() throws Exception {
-            Object instance = getArgsConstructor().newInstance("type", 5, true);
+            Object instance = getArgsConstructor(typeWithRequired).newInstance("type", 5, true);
 
             assertEquals("type", typeWithRequired.getMethod("getType").invoke(instance));
             assertEquals(5, typeWithRequired.getMethod("getId").invoke(instance));

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/requiredArrayPropertyConstructors.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/requiredArrayPropertyConstructors.json
@@ -1,0 +1,22 @@
+{
+    "type" : "object",
+    "properties" : {
+        "type" : {
+            "type" : "string",
+            "default" : "event"
+        },
+        "id" : {
+            "type" : "integer"
+        },
+        "has_tickets" : {
+            "type" : "boolean"
+        },
+        "provider" : {
+            "type" : "string"
+        },
+        "starttime" : {
+            "type" : "string"
+        }
+    },
+    "required": [ "type", "id", "has_tickets" ]
+}


### PR DESCRIPTION
Hello,
I noticed that the "required" keyword only considers the draft3 style (boolean on a property) style when used with isConstructorsRequiredPropertiesOnly() == true.

This pull-request adds support for the draft4 style ("requires" as an array of property names in object) when generating constructors with only required properties.

Thanks again for this great library.

Enjoy,
Jon