### PR TITLE
Generate hashCode and equals even without declared fields

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -364,7 +364,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
     }
 
     private void addJsonTypeInfoAnnotation(JDefinedClass jclass, JsonNode node) {
-        if (this.ruleFactory.getGenerationConfig().getAnnotationStyle() == AnnotationStyle.JACKSON2) {
+        if (ruleFactory.getGenerationConfig().getAnnotationStyle() == AnnotationStyle.JACKSON2) {
             String annotationName = node.get("deserializationClassProperty").asText();
             JAnnotationUse jsonTypeInfo = jclass.annotate(JsonTypeInfo.class);
             jsonTypeInfo.param("use", JsonTypeInfo.Id.CLASS);
@@ -388,9 +388,6 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
     private void addHashCode(JDefinedClass jclass) {
         Map<String, JFieldVar> fields = jclass.fields();
-        if (fields.isEmpty()) {
-            return;
-        }
 
         JMethod hashCode = jclass.method(JMod.PUBLIC, int.class, "hashCode");
 
@@ -400,7 +397,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         JClass hashCodeBuilderClass = jclass.owner().ref(hashCodeBuilder);
         JInvocation hashCodeBuilderInvocation = JExpr._new(hashCodeBuilderClass);
 
-        if (!jclass._extends().name().equals("Object")) {
+        if (!jclass._extends().fullName().equals(Object.class.getName())) {
             hashCodeBuilderInvocation = hashCodeBuilderInvocation.invoke("appendSuper").arg(JExpr._super().invoke("hashCode"));
         }
 
@@ -510,9 +507,6 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
     private void addEquals(JDefinedClass jclass) {
         Map<String, JFieldVar> fields = jclass.fields();
-        if (fields.isEmpty()) {
-            return;
-        }
 
         JMethod equals = jclass.method(JMod.PUBLIC, boolean.class, "equals");
         JVar otherObject = equals.param(Object.class, "other");
@@ -528,7 +522,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         JClass equalsBuilderClass = jclass.owner().ref(equalsBuilder);
         JInvocation equalsBuilderInvocation = JExpr._new(equalsBuilderClass);
 
-        if (!jclass._extends().name().equals("Object")) {
+        if (!jclass._extends().fullName().equals(Object.class.getName())) {
             equalsBuilderInvocation = equalsBuilderInvocation.invoke("appendSuper").arg(JExpr._super().invoke("equals").arg(otherObject));
         }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeHashCodeAndEqualsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeHashCodeAndEqualsIT.java
@@ -20,13 +20,26 @@ import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IncludeHashCodeAndEqualsIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @Rule
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @ClassRule
+    public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static ClassLoader resultsClassLoader;
+
+    @BeforeClass
+    public static void generateAndCompileClass() throws ClassNotFoundException {
+        resultsClassLoader = classSchemaRule.generateAndCompile("/schema/hashCodeAndEquals/types.json", "com.example", config("includeAdditionalProperties", false));
+    }
 
     @Test
     public void beansIncludeHashCodeAndEqualsByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
@@ -36,7 +49,7 @@ public class IncludeHashCodeAndEqualsIT {
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
         // throws NoSuchMethodException if method is not found
-        generatedType.getDeclaredMethod("equals", Object.class);
+        generatedType.getDeclaredMethod("equals", java.lang.Object.class);
         generatedType.getDeclaredMethod("hashCode");
 
     }
@@ -48,7 +61,7 @@ public class IncludeHashCodeAndEqualsIT {
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
         try {
-            generatedType.getDeclaredMethod("equals", Object.class);
+            generatedType.getDeclaredMethod("equals", java.lang.Object.class);
             fail(".equals method is present, it should have been omitted");
         } catch (NoSuchMethodException e) {
         }
@@ -58,6 +71,94 @@ public class IncludeHashCodeAndEqualsIT {
             fail(".hashCode method is present, it should have been omitted");
         } catch (NoSuchMethodException e) {
         }
+    }
+
+    @Test
+    public void objectWithoutFields() throws Exception {
+
+        Class genType = resultsClassLoader.loadClass("com.example.Empty");
+        assertEquals(genType.getDeclaredFields().length, 0);
+
+        genType.getDeclaredMethod("equals", java.lang.Object.class);
+        assertEquals("Should not use super.equals()", genType.newInstance(), genType.newInstance());
+        assertEquals(genType.newInstance().hashCode(), genType.newInstance().hashCode());
+    }
+
+    @Test
+    public void objectExtendingJavaType() throws Exception {
+
+        Class genType = resultsClassLoader.loadClass("com.example.ExtendsJavaType");
+        assertEquals(genType.getSuperclass(), Parent.class);
+        assertEquals(genType.getDeclaredFields().length, 0);
+
+        genType.getDeclaredMethod("equals", java.lang.Object.class);
+        assertNotEquals("Should use super.equals() because parent is not Object; parent uses Object.equals()", genType.newInstance(), genType.newInstance());
+    }
+
+    @Test
+    public void objectExtendingJavaTypeWithEquals() throws Exception {
+
+        Class genType = resultsClassLoader.loadClass("com.example.ExtendsJavaTypeWithEquals");
+        assertEquals(genType.getSuperclass(), ParentWithEquals.class);
+        assertEquals(genType.getDeclaredFields().length, 0);
+
+        genType.getDeclaredMethod("equals", java.lang.Object.class);
+        assertEquals("Should use super.equals()", genType.newInstance(), genType.newInstance());
+        assertEquals(genType.newInstance().hashCode(), genType.newInstance().hashCode());
+    }
+
+    @Test
+    public void objectExtendingFalseObject() throws Exception {
+
+        Class genType = resultsClassLoader.loadClass("com.example.ExtendsFalseObject");
+        assertEquals(genType.getSuperclass(), Object.class);
+
+        genType.getDeclaredMethod("equals", java.lang.Object.class);
+        assertNotEquals("Should use super.equals() because parent is not java.lang.Object; parent uses Object.equals()", genType.newInstance(), genType.newInstance());
+    }
+
+    @Test
+    public void objectExtendingEmptyParent() throws Exception {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/hashCodeAndEquals/extendsEmpty.json", "com.example");
+        Class gen1Type = resultsClassLoader.loadClass("com.example.ExtendsEmptyParent");
+        Class gen2Type = resultsClassLoader.loadClass("com.example.ExtendsEmpty");
+
+        gen2Type.getDeclaredMethod("equals", java.lang.Object.class);
+        gen2Type.getDeclaredMethod("hashCode");
+        assertEquals(gen2Type.newInstance(), gen2Type.newInstance());
+        assertEquals(gen2Type.newInstance().hashCode(), gen2Type.newInstance().hashCode());
+
+        gen1Type.getDeclaredMethod("equals", java.lang.Object.class);
+        gen1Type.getDeclaredMethod("hashCode");
+        assertEquals(gen1Type.newInstance(), gen1Type.newInstance());
+        assertEquals(gen1Type.newInstance().hashCode(), gen1Type.newInstance().hashCode());
+    }
+
+    public static class Object extends java.lang.Object {
+    }
+
+    public static class Parent {
+    }
+
+    public static class ParentWithEquals {
+
+        @Override
+        public boolean equals(java.lang.Object other) {
+            if (other == this) {
+                return true;
+            }
+            if ((other instanceof ParentWithEquals) == false) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/hashCodeAndEquals/extendsEmpty.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/hashCodeAndEquals/extendsEmpty.json
@@ -1,0 +1,8 @@
+{
+	"type" : "object",
+	"extends" : {
+		"type" : "object",
+		"additionalProperties" : false
+	},
+	"additionalProperties" : true
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/hashCodeAndEquals/types.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/hashCodeAndEquals/types.json
@@ -1,0 +1,20 @@
+{
+	"type" : "object",
+	"properties" : {
+		"empty" : {
+			"type" : "object"
+		},
+		"extendsJavaType" : {
+			"type" : "object",
+			"extendsJavaClass" : "org.jsonschema2pojo.integration.config.IncludeHashCodeAndEqualsIT.Parent"
+		},
+		"extendsJavaTypeWithEquals" : {
+			"type" : "object",
+			"extendsJavaClass" : "org.jsonschema2pojo.integration.config.IncludeHashCodeAndEqualsIT.ParentWithEquals"
+		},
+		"extendsFalseObject" : {
+			"type" : "object",
+			"extendsJavaClass" : "org.jsonschema2pojo.integration.config.IncludeHashCodeAndEqualsIT.Object"
+		}
+	}
+}


### PR DESCRIPTION
In these generated methods, call the super version only if
the type does not extend java.lang.Object.

Fix #610.