### PR TITLE
Allow setting custom annotator and custom rule factory fields directly in Gradle

### DIFF
--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -134,8 +134,16 @@ public class JsonSchemaExtension implements GenerationConfig {
     customAnnotator = Class.forName(clazz, true, this.class.classLoader)
   }
 
+  public void setCustomAnnotator(Class clazz) {
+    customAnnotator = clazz
+  }
+
   public void setCustomRuleFactory(String clazz) {
     customRuleFactory = Class.forName(clazz, true, this.class.classLoader)
+  }
+
+  public void setCustomRuleFactory(Class clazz) {
+    customRuleFactory = clazz
   }
 
   public void setSourceType(String s) {


### PR DESCRIPTION
This allows me to pass in an annotator implementation defined in the gradle file, which otherwise was throwing ClassNotFoundException.