### PR TITLE
Add support for "contextual class names and sub-packages"

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -71,6 +71,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private String targetPackage;
 
+    private boolean useContextualSubPackages = false;
+
     private boolean skip;
 
     private char[] propertyWordDelimiters = new char[] { '-', ' ', '_' };
@@ -122,6 +124,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private String classNamePrefix = "";
 
     private String classNameSuffix = "";
+
+    private boolean useContextualClassNames = false;
+
+    private String contextualClassNameDelimiter = "";
 
     private String[] fileExtensions = new String[] {};
 
@@ -695,6 +701,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     @Override
+    public boolean isUseContextualSubPackages() {
+        return useContextualSubPackages;
+    }
+
+    @Override
     public char[] getPropertyWordDelimiters() {
         return propertyWordDelimiters.clone();
     }
@@ -839,6 +850,16 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public String getClassNameSuffix() {
         return classNameSuffix;
+    }
+
+    @Override
+    public boolean isUseContextualClassNames() {
+        return useContextualClassNames;
+    }
+
+    @Override
+    public String getContextualClassNameDelimiter() {
+        return contextualClassNameDelimiter;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -55,6 +55,16 @@
         <td align="center" valign="top">No (default <code>""</code>)</td>
       </tr>
       <tr>
+        <td valign="top">useContextualClassNames</td>
+        <td valign="top">Whether to use contextual class names for nested properties.</td>
+        <td align="center" valign="top">No (default (<code>false</code>)</td>
+      </tr>
+      <tr>
+        <td valign="top">contextualClassNameDelimiter</td>
+        <td valign="top">Defines the delimiter for the contextual part of class names.</td>
+        <td align="center" valign="top"><code>No (default <code>""</code>)</code></td>
+      </tr>
+      <tr>
         <td valign="top">fileExtensions</td>
         <td valign="top">A string containing file extensions that should be considered full extensions and therefore ignored when generating classnames.</td>
         <td align="center" valign="top">No (default <code>""</code> (none))</td>
@@ -220,6 +230,11 @@
         <td valign="top">targetPackage</td>
         <td valign="top">Package name used for generated Java classes (for types where a fully qualified name has not been supplied in the schema using the 'javaType' property).</td>
         <td align="center" valign="top">No</td>
+      </tr>
+      <tr>
+        <td valign="top">useContextualSubPackages</td>
+        <td valign="top">Whether to use contextual package names for nested properties.</td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
       </tr>
       <tr>
         <td valign="top">useCommonsLang3</td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -48,6 +48,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-p", "--package" }, description = "A java package used for generated types")
     private String targetPackage;
 
+    @Parameter(names = { "-cp", "--contextual-sub-packages" }, description = "Use contextual package names for sub-property classes.")
+    private boolean useContextualSubPackages = false;
+
     @Parameter(names = { "-t", "--target" }, description = "The target directory into which generated types will be written", required = true)
     private File targetDirectory;
 
@@ -147,6 +150,12 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-x", "--class-suffix" }, description = "Suffix for generated class.")
     private String classNameSuffix = "";
 
+    @Parameter(names = { "-cc", "--contextual-class-names" }, description = "Use contextual names for sub-property classes.")
+    private boolean useContextualClassNames = false;
+
+    @Parameter(names = { "-ccd", "--contextual-class-name-delimiter" }, description = "Defines the delimiter for the contextual part of class names.")
+    private String contextualClassNameDelimiter = "";
+
     @Parameter(names = { "-fe", "--file-extensions" }, description = "The extensions that should be considered as standard filename extensions when creating java class names.")
     private String fileExtensions = "";
 
@@ -210,6 +219,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public String getTargetPackage() {
         return targetPackage;
+    }
+
+    @Override
+    public boolean isUseContextualSubPackages() {
+        return useContextualSubPackages;
     }
 
     @Override
@@ -339,6 +353,16 @@ public class Arguments implements GenerationConfig {
     @Override
     public String getClassNameSuffix() {
         return classNameSuffix;
+    }
+
+    @Override
+    public boolean isUseContextualClassNames() {
+        return useContextualClassNames;
+    }
+
+    @Override
+    public String getContextualClassNameDelimiter() {
+        return contextualClassNameDelimiter;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -69,6 +69,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
     }
 
     /**
+     * @return <code>false</code>
+     */
+    @Override
+    public boolean isUseContextualSubPackages() {
+        return false;
+    }
+
+    /**
      * @return an empty array (i.e. no word delimiters)
      */
     @Override
@@ -234,6 +242,22 @@ public class DefaultGenerationConfig implements GenerationConfig {
 
     @Override
     public String getClassNameSuffix() {
+        return "";
+    }
+
+    /**
+     * @return <code>false</code>
+     */
+    @Override
+    public boolean isUseContextualClassNames() {
+        return false;
+    }
+
+    /**
+     * @return <code>""</code>
+     */
+    @Override
+    public String getContextualClassNameDelimiter() {
         return "";
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -75,6 +75,13 @@ public interface GenerationConfig {
     String getTargetPackage();
 
     /**
+     * Gets the 'useContextualSubPackages' configuration option.
+     *
+     * @return Whether to use contextual sub-packages or not.
+     */
+    boolean isUseContextualSubPackages();
+
+    /**
      * Gets the 'propertyWordDelimiters' configuration option.
      *
      * @return an array of characters that should act as word delimiters when
@@ -311,6 +318,20 @@ public interface GenerationConfig {
      * @return Whether to add a suffix to generated classes.
      */
     String getClassNameSuffix();
+
+    /**
+     * Gets the 'useContextualClassNames' configuration option.
+     *
+     * @return Whethet to use contextual class names or not.
+     */
+    boolean isUseContextualClassNames();
+
+    /**
+     * Gets the 'contextualClassNameDelimiter' configuration options.
+     *
+     * @return The delimiter separating the contextual parts of class names.
+     */
+    String getContextualClassNameDelimiter();
 
     /**
      * Gets the 'fileExtensions' configuration option.

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -29,14 +29,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
 import org.jsonschema2pojo.util.NameHelper;
 import org.jsonschema2pojo.util.ParcelableHelper;
 import org.jsonschema2pojo.util.SerializableHelper;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.ClassType;
@@ -53,7 +51,6 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
-
 import android.os.Parcelable;
 
 /**
@@ -248,8 +245,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
      *             current map of classes to be generated.
      */
     private JDefinedClass createClass(String nodeName, JsonNode node, JPackage _package) throws ClassAlreadyExistsException {
-
         JDefinedClass newType;
+
+        if (ruleFactory.getGenerationConfig().isUseContextualSubPackages() && ruleFactory.getNameHelper().getContextualSubPackage().length() > 0) {
+            _package = _package.subPackage(ruleFactory.getNameHelper().getContextualSubPackage());
+        }
 
         try {
             boolean usePolymorphicDeserialization = usesPolymorphicDeserialization(node);
@@ -540,8 +540,13 @@ public class ObjectRule implements Rule<JPackage, JType> {
         String suffix = ruleFactory.getGenerationConfig().getClassNameSuffix();
         String fieldName = ruleFactory.getNameHelper().getFieldName(nodeName, node);
         String capitalizedFieldName = capitalize(fieldName);
+        if (ruleFactory.getGenerationConfig().isUseContextualClassNames()) {
+            prefix = ruleFactory.getNameHelper().getContextualClassPrefix(
+                    prefix,
+                    ruleFactory.getGenerationConfig().getContextualClassNameDelimiter()
+            );
+        }
         String fullFieldName = createFullFieldName(capitalizedFieldName, prefix, suffix);
-
         String className = ruleFactory.getNameHelper().replaceIllegalCharacters(fullFieldName);
         String normalizedName = ruleFactory.getNameHelper().normalizeName(className);
         return makeUnique(normalizedName, _package);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
@@ -54,6 +54,8 @@ public class PropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
      */
     @Override
     public JDefinedClass apply(String nodeName, JsonNode node, JDefinedClass jclass, Schema schema) {
+        ruleFactory.getNameHelper().pushToNodeContext(nodeName);
+
         if (node == null) {
             node = JsonNodeFactory.instance.objectNode();
         }
@@ -71,7 +73,7 @@ public class PropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
         }
 
         ruleFactory.getAnnotator().propertyOrder(jclass, node);
-
+        ruleFactory.getNameHelper().popFromNodeContext();
         return jclass;
     }
 
@@ -101,4 +103,5 @@ public class PropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
     
         }
     }
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -18,21 +18,24 @@ package org.jsonschema2pojo.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JType;
-
 import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
+import java.util.Stack;
 
 import static java.lang.Character.isDigit;
 import static javax.lang.model.SourceVersion.isKeyword;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.containsAny;
 import static org.apache.commons.lang3.StringUtils.remove;
+import static org.apache.commons.lang3.StringUtils.join;
 
 public class NameHelper {
 
     public static final String ILLEGAL_CHARACTER_REGEX = "[^0-9a-zA-Z_$]";
 
     private final GenerationConfig generationConfig;
+
+    private final Stack<String> nodeContext = new Stack<String>();
 
     public NameHelper(GenerationConfig generationConfig) {
         this.generationConfig = generationConfig;
@@ -153,5 +156,47 @@ public class NameHelper {
         }
 
         return getterName;
+    }
+
+    /**
+     * Generates a class name prefix based on the current nodeContext
+     *
+     * @param prefix Any already defined class name prefix
+     * @param delimiter A delimiter separating the contextual parts of the class name prefix
+     *
+     * @return The class name prefix
+     */
+    public String getContextualClassPrefix(String prefix, String delimiter) {
+        if (nodeContext.size() > 0) {
+            prefix += (prefix.length() > 0 ? delimiter : "") + join(nodeContext, delimiter) + delimiter;
+        }
+        return prefix;
+    }
+
+    /**
+     * Generates a sub-package name based on the current nodeContext
+     *
+     * @return The sub-package name
+     */
+    public String getContextualSubPackage() {
+        return nodeContext.size() > 0 ? nodeContext.get(nodeContext.size() - 1).toLowerCase() : "";
+    }
+
+    /**
+     * Pushes a node to the nodeContext.
+     *
+     * @param nodeName The name of the node
+     */
+    public void pushToNodeContext(String nodeName) {
+        nodeContext.push(capitalize(capitalizeTrailingWords(nodeName)));
+    }
+
+    /**
+     * Gets and removes the lastly pushed node from the nodeContext.
+     *
+     * @return The name of the removed node
+     */
+    public String popFromNodeContext() {
+        return nodeContext.pop();
     }
 }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -33,9 +33,12 @@ public class JsonSchemaExtension implements GenerationConfig {
   Iterable<File> sourceFiles
   File targetDirectory
   String targetPackage
+  boolean useContextualSubPackages
   AnnotationStyle annotationStyle
   String classNamePrefix
   String classNameSuffix
+  boolean useContextualClassNames
+  String contextualClassNameDelimiter
   String[] fileExtensions
   Class<? extends Annotator> customAnnotator
   Class<? extends RuleFactory> customRuleFactory

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ObjectIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ObjectIT.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class ObjectIT {
+
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void objectsWithSimpleClassNames() {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
+                "/schema/object/objectWithNonUniqueNestedProperty.json",
+                "com.example",
+                config(
+                        "useContextualClassNames", false,
+                        "useContextualSubPackages", false
+                )
+        );
+
+        try {
+            Class firstClass = resultsClassLoader.loadClass("com.example.FirstProperty");
+            assertEquals("FirstProperty", firstClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("First class has not been generated with name 'FirstProperty'");
+        }
+        try {
+            Class secondClass = resultsClassLoader.loadClass("com.example.FirstProperty_");
+            assertEquals("FirstProperty_", secondClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("Second class has not been generated with name 'FirstProperty_'");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void objectsWithContextualClassNames() {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
+                "/schema/object/objectWithNonUniqueNestedProperty.json",
+                "com.example",
+                config(
+                        "useContextualClassNames", true,
+                        "useContextualSubPackages", false
+                )
+        );
+
+        try {
+            Class firstClass = resultsClassLoader.loadClass("com.example.ObjectWithNonUniqueNestedPropertyFirstProperty");
+            assertEquals("ObjectWithNonUniqueNestedPropertyFirstProperty", firstClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("First class has not been generated with name 'ObjectWithNonUniqueNestedPropertyFirstProperty'");
+        }
+        try {
+            Class secondClass = resultsClassLoader.loadClass("com.example.ObjectWithNonUniqueNestedPropertySecondPropertyFirstProperty");
+            assertEquals("ObjectWithNonUniqueNestedPropertySecondPropertyFirstProperty", secondClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("Second class has not been generated with name 'ObjectWithNonUniqueNestedPropertySecondPropertyFirstProperty'");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void objectsWithContextualPackageNames() {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
+                "/schema/object/objectWithNonUniqueNestedProperty.json",
+                "com.example",
+                config(
+                        "useContextualClassNames", false,
+                        "useContextualSubPackages", true
+                )
+        );
+
+        try {
+            Class firstClass = resultsClassLoader.loadClass("com.example.objectwithnonuniquenestedproperty.FirstProperty");
+            assertEquals("FirstProperty", firstClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("First class has not been generated with name 'FirstProperty'");
+        }
+        try {
+            Class secondClass = resultsClassLoader.loadClass("com.example.objectwithnonuniquenestedproperty.secondproperty.FirstProperty");
+            assertEquals("FirstProperty", secondClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("Second class has not been generated with name 'FirstProperty'");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void objectsWithContextualPackageAndClassNames() {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
+                "/schema/object/objectWithNonUniqueNestedProperty.json",
+                "com.example",
+                config(
+                        "useContextualClassNames", true,
+                        "useContextualSubPackages", true
+                )
+        );
+
+        try {
+            Class firstClass = resultsClassLoader.loadClass("com.example.objectwithnonuniquenestedproperty.ObjectWithNonUniqueNestedPropertyFirstProperty");
+            assertEquals("ObjectWithNonUniqueNestedPropertyFirstProperty", firstClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("First class has not been generated with name 'ObjectWithNonUniqueNestedPropertyFirstProperty'");
+        }
+        try {
+            Class secondClass = resultsClassLoader.loadClass("com.example.objectwithnonuniquenestedproperty.secondproperty.ObjectWithNonUniqueNestedPropertySecondPropertyFirstProperty");
+            assertEquals("ObjectWithNonUniqueNestedPropertySecondPropertyFirstProperty", secondClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("Second class has not been generated with name 'ObjectWithNonUniqueNestedPropertySecondPropertyFirstProperty'");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void objectsWithContextualClassNamesAndDelimiter() {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
+                "/schema/object/objectWithNonUniqueNestedProperty.json",
+                "com.example",
+                config(
+                        "useContextualClassNames", true,
+                        "contextualClassNameDelimiter", "Sub"
+                )
+        );
+
+        try {
+            Class firstClass = resultsClassLoader.loadClass("com.example.ObjectWithNonUniqueNestedPropertySubFirstProperty");
+            assertEquals("ObjectWithNonUniqueNestedPropertySubFirstProperty", firstClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("First class has not been generated with name 'ObjectWithNonUniqueNestedPropertySubFirstProperty'");
+        }
+        try {
+            Class secondClass = resultsClassLoader.loadClass("com.example.ObjectWithNonUniqueNestedPropertySubSecondPropertySubFirstProperty");
+            assertEquals("ObjectWithNonUniqueNestedPropertySubSecondPropertySubFirstProperty", secondClass.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            fail("Second class has not been generated with name 'ObjectWithNonUniqueNestedPropertySubSecondPropertySubFirstProperty'");
+        }
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/object/objectWithNonUniqueNestedProperty.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/object/objectWithNonUniqueNestedProperty.json
@@ -1,0 +1,26 @@
+{
+  "type" : "object",
+  "properties" : {
+    "firstProperty" : {
+      "type" : "object",
+      "properties": {
+        "someProperty" : {
+          "type" : "string"
+        }
+      }
+    },
+    "secondProperty" : {
+      "type" : "object",
+      "properties" : {
+        "firstProperty" : {
+          "type" : "object",
+          "properties" : {
+            "someProperty" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -96,6 +96,14 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String targetPackage = "";
 
     /**
+     * Whether to use contextual sub-packages or not.
+     *
+     * @parameter expression="${jsonschema2pojo.useContextualSubPackages}"
+     * @since 0.4.27
+     */
+    private boolean useContextualSubPackages = false;
+
+    /**
      * Whether to generate builder-style methods of the form
      * <code>withXxx(value)</code> (that return <code>this</code>), alongside
      * the standard, void-return setters.
@@ -466,6 +474,22 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String classNameSuffix = "";
 
     /**
+     * Whether to use contextual class names or not.
+     *
+     * @parameter expression="${jsonschema2pojo.useContextualClassNames}"
+     * @since 0.4.27
+     */
+    private boolean useContextualClassNames = false;
+
+    /**
+     * Defines the delimiter for the contextual part of class names.
+     *
+     * @parameter expression="${jsonschema2pojo.contextualClassNameDelimiter}"
+     * @since 0.4.27
+     */
+    private String contextualClassNameDelimiter = "";
+
+    /**
      * The file extenations that should be considered as file name extensions,
      * and therefore ignored, when creating Java class names.
      *
@@ -665,6 +689,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     }
 
     @Override
+    public boolean isUseContextualSubPackages() {
+        return useContextualSubPackages;
+    }
+
+    @Override
     public char[] getPropertyWordDelimiters() {
         return propertyWordDelimiters.toCharArray();
     }
@@ -808,6 +837,16 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public String getClassNameSuffix() {
         return classNameSuffix;
+    }
+
+    @Override
+    public boolean isUseContextualClassNames() {
+        return useContextualClassNames;
+    }
+
+    @Override
+    public String getContextualClassNameDelimiter() {
+        return contextualClassNameDelimiter;
     }
 
     @Override


### PR DESCRIPTION
We have a lot of complex schemas consisting of many objects and sub-objects. There are many sub-objects which are very similar and therefore have properties which are named the same. 

See also the following example (dummy schema):

``` json
{
  "type": "object",
  "properties": {
    "someProperty": {
      "type": "object",
      "properties": {
        "someSubProperty": {
          "type": "string"
        }
      },
      "format": "translatable"
    },
    "anotherProperty": {
      "type": "object",
      "properties": {
        "someProperty": {
          "type": "object",
          "properties": {
            "anotherSubProperty": {
              "type": "string"
            }
          }
        }
      }
    }
  }
}
```

At the moment, `jsonschema2pojo` will generate the classes `com.example.TheClass` (root object), `com.example.SomeProperty`, `com.example.SomeProperty_` and `com.example.AnotherProperty`.

With this PR the ugly `_` can be avoided as follows:
- By setting the configuration option `useContextualClassNames` to `true` the classes `com.example.TheClassSomeProperty` and `com.example.TheClassAnotherPropertySomeProperty` will be generated.
- By setting the configuration option `useContextualSubPackages` to `true` the classes `com.example.theclass.SomeProperty`and `com.example.theclass.anotherproperty.SomeProperty`will be generated.
- Of course, both configuration options can be set to `true`. However, this will lead to redundant information in class name and package name.
