### PR TITLE
[Issue #626] Enable GenerateJsonSchemaJavaTask to set custom configuration with closure; not just single jsonSchema2Pojo object.

### DIFF
--- a/jsonschema2pojo-gradle-plugin/example/java/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/java/build.gradle
@@ -1,3 +1,7 @@
+import org.jsonschema2pojo.SourceType
+import org.jsonschema2pojo.gradle.GenerateJsonSchemaJavaTask
+import org.jsonschema2pojo.gradle.JsonSchemaExtension
+
 apply plugin: 'java'
 apply plugin: 'jsonschema2pojo'
 
@@ -32,4 +36,13 @@ jsonSchema2Pojo {
   targetPackage = 'example'
   includeJsr303Annotations = true
   propertyWordDelimiters = ['_'] as char[]
+}
+
+task generateJsonSchema2PojoTwo(type: GenerateJsonSchemaJavaTask) {
+  configuration {
+    source = files("${project.sourceSets.main.output.resourcesDir}/json2")
+    targetPackage = 'example.json2'
+    propertyWordDelimiters = ['_', ' ', '-'] as char[]
+    sourceType = SourceType.JSON
+  }
 }

--- a/jsonschema2pojo-gradle-plugin/example/java/src/main/resources/json2/simple.json
+++ b/jsonschema2pojo-gradle-plugin/example/java/src/main/resources/json2/simple.json
@@ -1,0 +1,5 @@
+{
+  "@type": "Simple",
+  "num" : 5,
+  "name": "MyName"
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaJavaTask.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaJavaTask.groovy
@@ -35,7 +35,7 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
     outputs.upToDateWhen { false }
 
     project.afterEvaluate {
-      configuration = project.jsonSchema2Pojo
+      configuration = configuration ?: project.jsonSchema2Pojo
       configuration.targetDirectory = configuration.targetDirectory ?:
         project.file("${project.buildDir}/generated-sources/js2p")
 
@@ -46,6 +46,13 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
       }
       outputs.dir configuration.targetDirectory
     }
+  }
+
+  def configuration(Closure closure) {
+    configuration = new JsonSchemaExtension()
+    closure.delegate = configuration
+    closure.call()
+    configuration
   }
 
   def configureJava() {


### PR DESCRIPTION
Fixes #626

This change enables adding extra tasks that inherit from GenerateJsonSchemaJavaTask and extend a configuration with a closure rather than only being able to use the global and singleton `jsonSchema2Pojo`:

```
task generateJsonSchema2PojoTwo(type: GenerateJsonSchemaJavaTask) {
  configuration {
     source = files("${project.sourceSets.main.output.resourcesDir}/json2")
     targetPackage = 'example.json2'
     propertyWordDelimiters = ['_', ' ', '-'] as char[]
     sourceType = SourceType.JSON
   }
}
```
