### PR TITLE
Support for @JsonFormat annotation

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -140,6 +140,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private String timeType = null;
 
     private String dateType = null;
+    
+    private boolean formatDateTime = false;
 
 
     /**
@@ -668,6 +670,18 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public void setIncludeDynamicAccessors(boolean includeDynamicAccessors) {
         this.includeDynamicAccessors = includeDynamicAccessors;
     }
+    
+    /**
+     * Sets the 'formatDateTime' property of this class
+     *
+     * @param formatDateTime
+     *            Whether the fields of type `date-type` have the `@JsonFormat` annotation 
+     *            with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` 
+     *            and timezone set to default value of `UTC`
+     */
+    public void setFormatDateTime(boolean formatDateTime) {
+        this.formatDateTime = formatDateTime;
+    }
 
     @Override
     public boolean isGenerateBuilders() {
@@ -899,6 +913,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseBigDecimals() {
         return useBigDecimals;
+    }
+
+    @Override
+    public boolean isFormatDateTime() {
+        return formatDateTime;
     }
 
 }

--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -141,7 +141,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private String dateType = null;
     
-    private boolean formatDateTime = false;
+    private boolean formatDateTimes = false;
 
 
     /**
@@ -672,15 +672,15 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
     
     /**
-     * Sets the 'formatDateTime' property of this class
+     * Sets the 'formatDateTimes' property of this class
      *
-     * @param formatDateTime
-     *            Whether the fields of type `date-type` have the `@JsonFormat` annotation 
-     *            with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` 
+     * @param formatDateTimes
+     *            Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation 
+     *            with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSS</code> 
      *            and timezone set to default value of `UTC`
      */
-    public void setFormatDateTime(boolean formatDateTime) {
-        this.formatDateTime = formatDateTime;
+    public void setFormatDateTime(boolean formatDateTimes) {
+        this.formatDateTimes = formatDateTimes;
     }
 
     @Override
@@ -916,8 +916,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     @Override
-    public boolean isFormatDateTime() {
-        return formatDateTime;
+    public boolean isFormatDateTimes() {
+        return formatDateTimes;
     }
 
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -302,8 +302,8 @@
         <td align="center" valign="top">No</td>
       </tr>
       <tr>
-        <td valign="top">formatDateTime</td>
-        <td valign="top">Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSS</code> and timezone set to default value of <code>UTC</code>
+        <td valign="top">formatDateTimes</td>
+        <td valign="top">Whether the fields of type <code>date-time</code> have the <code>@JsonFormat</code> annotation with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSS</code> and timezone set to default value of <code>UTC</code>
         </td>
         <td align="center" valign="top">No (default <code>false</code>)</td>
       </tr>

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -301,6 +301,12 @@
         </td>
         <td align="center" valign="top">No</td>
       </tr>
+      <tr>
+        <td valign="top">formatDateTime</td>
+        <td valign="top">Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSS</code> and timezone set to default value of <code>UTC</code>
+        </td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+      </tr>
     </table>
 
     <h3>Examples</h3>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -162,8 +162,8 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-ida", "--include-dynamic-accessors" }, description = "Include dynamic getter, setter, and builder support on generated types.")
     private boolean includeDynamicAccessors = false;
     
-    @Parameter(names = { "-fdt", "--format-date-time" }, description = "Whether the fields of type `date-type` have the `@JsonFormat` annotation with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` and timezone set to default value of `UTC`")
-    private boolean formatDateTime = false;
+    @Parameter(names = { "-fdt", "--format-date-times" }, description = "Whether the fields of type `date-time` have the `@JsonFormat` annotation with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` and timezone set to default value of `UTC`")
+    private boolean formatDateTimes = false;
     
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -405,8 +405,8 @@ public class Arguments implements GenerationConfig {
     }
 
     @Override
-    public boolean isFormatDateTime() {
-        return formatDateTime;
+    public boolean isFormatDateTimes() {
+        return formatDateTimes;
     }
 
 }

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -161,7 +161,10 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-ida", "--include-dynamic-accessors" }, description = "Include dynamic getter, setter, and builder support on generated types.")
     private boolean includeDynamicAccessors = false;
-
+    
+    @Parameter(names = { "-fdt", "--format-date-time" }, description = "Whether the fields of type `date-type` have the `@JsonFormat` annotation with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` and timezone set to default value of `UTC`")
+    private boolean formatDateTime = false;
+    
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
 
@@ -399,6 +402,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isUseBigDecimals() {
         return useBigDecimals;
+    }
+
+    @Override
+    public boolean isFormatDateTime() {
+        return formatDateTime;
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
@@ -95,8 +95,8 @@ public abstract class AbstractAnnotator implements Annotator {
         return generationConfig;
     }
 
-	@Override
-	public void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node) {
-	}
+    @Override
+    public void dateField(JFieldVar field, JsonNode node) {
+    }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
@@ -95,4 +95,8 @@ public abstract class AbstractAnnotator implements Annotator {
         return generationConfig;
     }
 
+	@Override
+	public void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node) {
+	}
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
@@ -173,7 +173,7 @@ public interface Annotator {
      * @param propertyNode
      *            the schema node defining this property
      */
-    void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node);
+    void dateField(JFieldVar field, JsonNode node);
 
     void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName);
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
@@ -160,6 +160,20 @@ public interface Annotator {
      *         properties'.
      */
     boolean isAdditionalPropertiesSupported();
+    
+    /**
+     * Add the <code>@JsonFormat</code> annotation to mark a java.util.Date field
+     * 
+     * @param field
+     *            the field that contains data that will be serialized
+     * @param clazz
+     *            the owner of the field (class to which the field belongs)
+     * @param propertyName
+     *            the name of the JSON property that this field represents
+     * @param propertyNode
+     *            the schema node defining this property
+     */
+    void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node);
 
     void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName);
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
@@ -131,9 +131,9 @@ public class CompositeAnnotator implements Annotator {
     }
 
 	@Override
-	public void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
+	public void dateField(JFieldVar field, JsonNode propertyNode) {
 		for (Annotator annotator : annotators) {
-            annotator.jsonFormat(field, clazz, propertyName, propertyNode);
+            annotator.dateField(field, propertyNode);
         }
 	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
@@ -130,4 +130,10 @@ public class CompositeAnnotator implements Annotator {
         }
     }
 
+	@Override
+	public void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
+		for (Annotator annotator : annotators) {
+            annotator.jsonFormat(field, clazz, propertyName, propertyNode);
+        }
+	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -322,7 +322,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
     }
 
 	@Override
-	public boolean isFormatDateTime() {
+	public boolean isFormatDateTimes() {
 		return false;
 	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -320,4 +320,9 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public String getTimeType() {
         return null;
     }
+
+	@Override
+	public boolean isFormatDateTime() {
+		return false;
+	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -416,9 +416,9 @@ public interface GenerationConfig {
     /**
      * Gets the `formatDateTime` configuration option 
      *
-     * @return Whether the fields of type `date-type` have the `@JsonFormat` annotation 
-     *         with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSSZ` 
+     * @return Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation 
+     *         with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSSZ</code> 
      */
-    boolean isFormatDateTime();
+    boolean isFormatDateTimes();
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -412,5 +412,13 @@ public interface GenerationConfig {
      *         date-time) to generated Java types.
      */
     String getTimeType();
+    
+    /**
+     * Gets the `formatDateTime` configuration option 
+     *
+     * @return Whether the fields of type `date-type` have the `@JsonFormat` annotation 
+     *         with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSSZ` 
+     */
+    boolean isFormatDateTime();
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -46,11 +46,9 @@ import com.sun.codemodel.JMethod;
  *      href="https://github.com/FasterXML/jackson-annotations">https://github.com/FasterXML/jackson-annotations</a>
  */
 public class Jackson2Annotator extends AbstractAnnotator {
-    private GenerationConfig generationConfig;
     
     public Jackson2Annotator(GenerationConfig generationConfig) {
         super(generationConfig);
-        this.generationConfig = generationConfig;
     }
 
     @Override
@@ -129,11 +127,11 @@ public class Jackson2Annotator extends AbstractAnnotator {
     }
 
     @Override
-    public void jsonFormat(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node) {
-        boolean formatDateTime = generationConfig.isFormatDateTime();
+    public void dateField(JFieldVar field, JsonNode node) {
+        boolean formatDateTime = getGenerationConfig().isFormatDateTimes();
         String iso8601DateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-        String customDateTimePattern = node.has("customDateTimePattern") == true ? node.get("customDateTimePattern").asText() : null;
-        String timezone = node.has("customTimezone") == true ? node.get("customTimezone").asText() : "UTC";
+        String customDateTimePattern = node.has("customDateTimePattern") ? node.get("customDateTimePattern").asText() : null;
+        String timezone = node.has("customTimezone") ? node.get("customTimezone").asText() : "UTC";
         
         String pattern = null;
         

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -124,4 +125,18 @@ public class Jackson2Annotator extends AbstractAnnotator {
     public void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName) {
         field.annotate(JsonIgnore.class);
     }
+
+	@Override
+	public void jsonFormat(JFieldVar field, JDefinedClass clazz,
+			String propertyName, JsonNode node) {
+		String customDateTimePattern = node.has("customDateTimePattern") == true ? node.get("customDateTimePattern").asText() : null;
+		String timezone = node.has("timezone") == true ? node.get("timezone").asText() : null;
+		if (customDateTimePattern != null) {
+			if (timezone != null){
+				field.annotate(JsonFormat.class).param("shape", JsonFormat.Shape.STRING).param("pattern", customDateTimePattern).param("timezone", timezone);
+			} else {
+				field.annotate(JsonFormat.class).param("shape", JsonFormat.Shape.STRING).param("pattern", customDateTimePattern);
+			}
+		}
+	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -78,8 +78,11 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
         int accessModifier = ruleFactory.getGenerationConfig().isIncludeAccessors() ? JMod.PRIVATE : JMod.PUBLIC;
         JFieldVar field = jclass.field(accessModifier, propertyType, propertyName);
+        
         propertyAnnotations(nodeName, node, schema, field);
-
+        
+        formatAnnotation(field, jclass, nodeName, node);
+        
         ruleFactory.getAnnotator().propertyField(field, jclass, nodeName, node);
 
         if (ruleFactory.getGenerationConfig().isIncludeAccessors()) {
@@ -133,6 +136,13 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         } else {
             ruleFactory.getNotRequiredRule().apply(nodeName, node.get("required"), generatedJavaConstruct, schema);
         }
+    }
+    
+    private void formatAnnotation(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node) {
+    	String format = node.has("format") == true ? node.get("format").asText() : null;
+    	if ("date-time".equalsIgnoreCase(format)) {
+    		ruleFactory.getAnnotator().jsonFormat(field, clazz, propertyName, node);
+    	}
     }
 
     private JsonNode resolveRefs(JsonNode node, Schema parent) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -139,10 +139,10 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
     }
     
     private void formatAnnotation(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode node) {
-    	String format = node.has("format") == true ? node.get("format").asText() : null;
-    	if ("date-time".equalsIgnoreCase(format)) {
-    		ruleFactory.getAnnotator().jsonFormat(field, clazz, propertyName, node);
-    	}
+        String format = node.path("format").asText();
+        if ("date-time".equalsIgnoreCase(format)) {
+            ruleFactory.getAnnotator().dateField(field, node);
+        }
     }
 
     private JsonNode resolveRefs(JsonNode node, Schema parent) {

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -70,6 +70,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean useBigIntegers
   boolean usePrimitives
   FileFilter fileFilter
+  boolean formatDateTime
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -111,6 +112,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeAccessors = true
     targetVersion = '1.6'
     includeDynamicAccessors = false
+    formatDateTime = false
   }
 
   @Override
@@ -191,6 +193,12 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeAccessors = ${includeAccessors}
        |targetVersion = ${targetVersion}
        |includeDynamicAccessors = ${includeDynamicAccessors}
+       |formatDateTime = ${formatDateTime}
      """.stripMargin()
   }
+  
+  public boolean isFormatDateTime() {
+    return formatDateTime;
+  }
+  
 }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -70,7 +70,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean useBigIntegers
   boolean usePrimitives
   FileFilter fileFilter
-  boolean formatDateTime
+  boolean formatDateTimes
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -112,7 +112,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeAccessors = true
     targetVersion = '1.6'
     includeDynamicAccessors = false
-    formatDateTime = false
+    formatDateTimes = false
   }
 
   @Override
@@ -193,12 +193,12 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeAccessors = ${includeAccessors}
        |targetVersion = ${targetVersion}
        |includeDynamicAccessors = ${includeDynamicAccessors}
-       |formatDateTime = ${formatDateTime}
+       |formatDateTimes = ${formatDateTimes}
      """.stripMargin()
   }
   
-  public boolean isFormatDateTime() {
-    return formatDateTime;
+  public boolean isFormatDateTimes() {
+    return formatDateTimes;
   }
   
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -1,7 +1,6 @@
 package org.jsonschema2pojo.integration;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -9,14 +8,16 @@ import static org.junit.Assert.assertThat;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
 
-import org.joda.time.DateTime;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -26,86 +27,156 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @RunWith(Parameterized.class)
 public class CustomDateTimeFormatIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-
-    private static Class<?> classWithFormattedProperties;
+    
+    private static Class<?> classWhenConfigIsTrue;
+    private static Class<?> classWhenConfigIsFalse;
     
     @Parameters(name="{0}")
-    public static List<Object[]> data() {
+    public static List<Object[]> data() throws ParseException {
+        String defaultFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+        String defaultTZ = "UTC";
+        SimpleDateFormat df1 = new SimpleDateFormat(defaultFormat);
+        df1.setTimeZone(TimeZone.getTimeZone(defaultTZ));
+        
+        SimpleDateFormat df2 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        df2.setTimeZone(TimeZone.getTimeZone(defaultTZ));
+        
+        SimpleDateFormat df3 = new SimpleDateFormat("yyyy-MM-dd");
+        df3.setTimeZone(TimeZone.getTimeZone("PST"));
+        
         return asList(new Object[][] {
-                /* { propertyName, expectedType, jsonValue, timezone, javaValue } */
-                { "stringAsDateTime", Date.class, "2016-11-06", "PST", new Date(new GregorianCalendar(2016, 10, 06, 5, 0, 0).getTimeInMillis()) },
-                { "stringAsDateTime2", DateTime.class, "2016-11-06", "PST", new DateTime(2016, 10, 06, 5, 0, 0) }});
+                /* { propertyName,          config_isFormatDateTime, isAnnotated, format, timezone, jsonValue, javaValue } */
+                { "defaultFormat",          Boolean.TRUE, Boolean.TRUE, defaultFormat,            defaultTZ,  "2016-11-06T00:00:00.000", df1.parse("2016-11-06T00:00:00.000") },
+                { "customFormatDefaultTZ",  Boolean.TRUE, Boolean.TRUE, "yyyy-MM-dd'T'HH:mm:ss",  defaultTZ,  "2016-11-06T00:00:00", df2.parse("2016-11-06T00:00:00") },
+                { "customFormatCustomTZ",   Boolean.TRUE, Boolean.TRUE, "yyyy-MM-dd",             "PST",      "2016-11-06", df3.parse("2016-11-06") },
+                
+                { "defaultFormat",         Boolean.FALSE, Boolean.FALSE, null, null, null, null },
+                { "customFormatDefaultTZ", Boolean.FALSE, Boolean.TRUE, "yyyy-MM-dd'T'HH:mm:ss", defaultTZ, "2016-11-06T00:00:00", df2.parse("2016-11-06T00:00:00") },
+                { "customFormatCustomTZ",  Boolean.FALSE, Boolean.TRUE, "yyyy-MM-dd",            "PST",     "2016-11-06", df3.parse("2016-11-06") }
+        });
     }
 
     private String propertyName;
-    private Class<?> expectedType;
-    private Object jsonValue;
+    private Boolean config_isFormatDateTime;
+    private Boolean isAnnotated;
+    private String format;
     private String timezone;
+    private Object jsonValue;
     private Object javaValue;
 
-    public CustomDateTimeFormatIT(String propertyName, Class<?> expectedType, Object jsonValue, String timezone, Object javaValue) {
+    public CustomDateTimeFormatIT(String propertyName, Boolean config_isFormatDateTime, Boolean isAnnotated, String format, String timezone, Object jsonValue, Object javaValue) {
         this.propertyName = propertyName;
-        this.expectedType = expectedType;
-        this.jsonValue = jsonValue;
+        this.config_isFormatDateTime = config_isFormatDateTime;
+        this.isAnnotated = isAnnotated;
+        this.format = format;
         this.timezone = timezone;
+        this.jsonValue = jsonValue;
         this.javaValue = javaValue;
     }
 
+    /**
+     * We are going to generate the same class twice:
+     * Once with the configuration option formatDateTime set to TRUE
+     * Once with the configuration option formatDateTime set to FALSE
+     * 
+     * @throws ClassNotFoundException
+     * @throws IOException
+     */
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
-
-        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/format/customDateTimeFormat.json", "com.example");
-
-        classWithFormattedProperties = resultsClassLoader.loadClass("com.example.CustomDateTimeFormat");
-
-    }
-
-    @Test
-    public void formatValueProducesExpectedType() throws NoSuchMethodException, IntrospectionException {
-
-        Method getter = new PropertyDescriptor(propertyName, classWithFormattedProperties).getReadMethod();
-
-        assertThat(getter.getReturnType().getName(), is(this.expectedType.getName()));
-
+        Map<String, Object> configValues = new HashMap<String, Object>();
+        
+        configValues.put("formatDateTime", Boolean.TRUE);
+        classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_true", configValues);
+        
+        configValues.put("formatDateTime", Boolean.FALSE);
+        classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_false", configValues);
+        
+        ClassLoader loader = classSchemaRule.compile();
+        
+        // Class generated when formatDateTime is set to TRUE in configuration
+        classWhenConfigIsTrue = loader.loadClass("com.example.config_true.CustomDateTimeFormat");
+        // Class generated when formatDateTime is set to FALSE in configuration
+        classWhenConfigIsFalse = loader.loadClass("com.example.config_false.CustomDateTimeFormat");
     }
     
+    /**
+     * Test whether the annotation is supposed to be generated.
+     * If it is supposed to be generated, test if the pattern and timezone attributes are as expected.
+     * 
+     * @throws NoSuchFieldException
+     * @throws SecurityException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
     @Test
     public void formatValueProducesExpectedAnnotation() throws NoSuchFieldException, SecurityException, InstantiationException, IllegalAccessException {
-
-    	Field field = classWithFormattedProperties.getDeclaredField(propertyName);
-    	
-    	JsonFormat expected = field.getAnnotation(JsonFormat.class);
-    	
-    	assertThat(expected, notNullValue());
-    }
-
-    /*
-     * TODO: Need to fix this test 
-    @Test
-    public void valueCanBeSerializedAndDeserialized() throws NoSuchMethodException, IOException, IntrospectionException, IllegalAccessException, InvocationTargetException {
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        
-        if (timezone != null){
-        	objectMapper.setTimeZone(TimeZone.getTimeZone(timezone));
+        Field field;
+        if (config_isFormatDateTime) {
+            field = classWhenConfigIsTrue.getDeclaredField(propertyName);
+        }
+        else {
+            field = classWhenConfigIsFalse.getDeclaredField(propertyName);
         }
         
-        ObjectNode node = objectMapper.createObjectNode();
-        node.put(propertyName, jsonValue.toString());
-
-        Object pojo = objectMapper.treeToValue(node, classWithFormattedProperties);
+        if (isAnnotated) {
+            JsonFormat annotation = field.getAnnotation(JsonFormat.class);
+            
+            assertThat(annotation, notNullValue());
+            // Assert that the patterns match
+            assertEquals(format, annotation.pattern());
+            // Assert that the timezones match
+            assertEquals(timezone, annotation.timezone());
+        }
+        else {
+            // Verify that no annotation is generated
+            assertEquals(Boolean.FALSE, field.isAnnotationPresent(JsonFormat.class));
+        }
         
-        Method getter = new PropertyDescriptor(propertyName, classWithFormattedProperties).getReadMethod();
-        assertThat(getter.invoke(pojo).toString(), is(equalTo(javaValue.toString())));
-
-        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
-        assertThat(jsonVersion.get(propertyName).asText(), is(equalTo(jsonValue.toString())));
     }
-     */
+
+    @Test
+    public void valueCanBeSerializedAndDeserialized() throws NoSuchMethodException, IOException, IntrospectionException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        @SuppressWarnings("rawtypes")
+        Class generatedClass;
+        if (config_isFormatDateTime) {
+            generatedClass = classWhenConfigIsTrue;
+        }
+        else {
+            generatedClass = classWhenConfigIsFalse;
+        }
+        
+        // Assert only if annotation is generated
+        if (isAnnotated) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            
+            if (timezone != null){
+                objectMapper.setTimeZone(TimeZone.getTimeZone(timezone));
+            }
+            
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put(propertyName, jsonValue.toString());
+
+            @SuppressWarnings("unchecked")
+            Object pojo = objectMapper.treeToValue(node, generatedClass);
+            
+            Method getter = new PropertyDescriptor(propertyName, generatedClass).getReadMethod();
+            
+            // Assert that the Date object in the deserialized class is as expected
+            assertEquals(javaValue.toString(), getter.invoke(pojo).toString());
+            
+            JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+            
+            // Assert that when the class is serialized, the date object is serialized as expected 
+            assertEquals(jsonValue.toString(), jsonVersion.get(propertyName).asText());
+        }
+        
+    }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -1,21 +1,20 @@
 package org.jsonschema2pojo.integration;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.joda.time.DateTime;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
@@ -27,9 +26,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
 
 @RunWith(Parameterized.class)
 public class CustomDateTimeFormatIT {
@@ -40,22 +38,20 @@ public class CustomDateTimeFormatIT {
     @Parameters(name="{0}")
     public static List<Object[]> data() {
         return asList(new Object[][] {
-                /* { propertyName, expectedType, expectedAnnotation, jsonValue, timezone, javaValue } */
-                { "stringAsDateTime", Date.class, JsonFormat.class, "2016-11-06", "PST", new Date(new GregorianCalendar(2016, 10, 06, 5, 0, 0).getTimeInMillis()) },
-                { "stringAsDateTime2", DateTime.class, JsonFormat.class, "2016-11-06", "PST", new DateTime(2016, 10, 06, 5, 0, 0) }});
+                /* { propertyName, expectedType, jsonValue, timezone, javaValue } */
+                { "stringAsDateTime", Date.class, "2016-11-06", "PST", new Date(new GregorianCalendar(2016, 10, 06, 5, 0, 0).getTimeInMillis()) },
+                { "stringAsDateTime2", DateTime.class, "2016-11-06", "PST", new DateTime(2016, 10, 06, 5, 0, 0) }});
     }
 
     private String propertyName;
     private Class<?> expectedType;
-    private Class<?> expectedAnnotation;
     private Object jsonValue;
     private String timezone;
     private Object javaValue;
 
-    public CustomDateTimeFormatIT(String propertyName, Class<?> expectedType, Class<?> expectedAnnotation, Object jsonValue, String timezone, Object javaValue) {
+    public CustomDateTimeFormatIT(String propertyName, Class<?> expectedType, Object jsonValue, String timezone, Object javaValue) {
         this.propertyName = propertyName;
         this.expectedType = expectedType;
-        this.expectedAnnotation = expectedAnnotation;
         this.jsonValue = jsonValue;
         this.timezone = timezone;
         this.javaValue = javaValue;
@@ -80,11 +76,13 @@ public class CustomDateTimeFormatIT {
     }
     
     @Test
-    public void formatValueProducesExpectedAnnotation() throws NoSuchFieldException, SecurityException {
+    public void formatValueProducesExpectedAnnotation() throws NoSuchFieldException, SecurityException, InstantiationException, IllegalAccessException {
 
     	Field field = classWithFormattedProperties.getDeclaredField(propertyName);
     	
-    	assertEquals(expectedAnnotation, field.getDeclaredAnnotation(JsonFormat.class).annotationType());
+    	JsonFormat expected = field.getAnnotation(JsonFormat.class);
+    	
+    	assertThat(expected, notNullValue());
     }
 
     /*

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -1,20 +1,15 @@
 package org.jsonschema2pojo.integration;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -22,161 +17,268 @@ import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-@RunWith(Parameterized.class)
+/**
+ * This test utilizes the json schema customDateTimeFormat.json located in src/test/resources/schema/format/
+ * 
+ * It generates 2 classes located in target/jsonschema2pojo/CustomDateTimeFoormatIT/
+ * 1. com.example.config_true.CustomDateTimeFormat - generated with config option formatDateTimes set to True
+ * 2. com.example.config_false.CustomDateTimeFormat - generated with config option formatDateTimes set to False
+ * 
+ * The data used here is tightly coupled with the schema defined in customDateTimeFormat.json
+ * Any modifications here must be synced up with the json schema and vice versa
+ * 
+ * @author shrpurohit
+ *
+ */
 public class CustomDateTimeFormatIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
     
     private static Class<?> classWhenConfigIsTrue;
     private static Class<?> classWhenConfigIsFalse;
     
-    @Parameters(name="{0}")
-    public static List<Object[]> data() throws ParseException {
-        String defaultFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-        String defaultTZ = "UTC";
-        SimpleDateFormat df1 = new SimpleDateFormat(defaultFormat);
-        df1.setTimeZone(TimeZone.getTimeZone(defaultTZ));
-        
-        SimpleDateFormat df2 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        df2.setTimeZone(TimeZone.getTimeZone(defaultTZ));
-        
-        SimpleDateFormat df3 = new SimpleDateFormat("yyyy-MM-dd");
-        df3.setTimeZone(TimeZone.getTimeZone("PST"));
-        
-        return asList(new Object[][] {
-                /* { propertyName,          config_isFormatDateTime, isAnnotated, format, timezone, jsonValue, javaValue } */
-                { "defaultFormat",          Boolean.TRUE, Boolean.TRUE, defaultFormat,            defaultTZ,  "2016-11-06T00:00:00.000", df1.parse("2016-11-06T00:00:00.000") },
-                { "customFormatDefaultTZ",  Boolean.TRUE, Boolean.TRUE, "yyyy-MM-dd'T'HH:mm:ss",  defaultTZ,  "2016-11-06T00:00:00", df2.parse("2016-11-06T00:00:00") },
-                { "customFormatCustomTZ",   Boolean.TRUE, Boolean.TRUE, "yyyy-MM-dd",             "PST",      "2016-11-06", df3.parse("2016-11-06") },
-                
-                { "defaultFormat",         Boolean.FALSE, Boolean.FALSE, null, null, null, null },
-                { "customFormatDefaultTZ", Boolean.FALSE, Boolean.TRUE, "yyyy-MM-dd'T'HH:mm:ss", defaultTZ, "2016-11-06T00:00:00", df2.parse("2016-11-06T00:00:00") },
-                { "customFormatCustomTZ",  Boolean.FALSE, Boolean.TRUE, "yyyy-MM-dd",            "PST",     "2016-11-06", df3.parse("2016-11-06") }
-        });
-    }
-
-    private String propertyName;
-    private Boolean config_isFormatDateTime;
-    private Boolean isAnnotated;
-    private String format;
-    private String timezone;
-    private Object jsonValue;
-    private Object javaValue;
-
-    public CustomDateTimeFormatIT(String propertyName, Boolean config_isFormatDateTime, Boolean isAnnotated, String format, String timezone, Object jsonValue, Object javaValue) {
-        this.propertyName = propertyName;
-        this.config_isFormatDateTime = config_isFormatDateTime;
-        this.isAnnotated = isAnnotated;
-        this.format = format;
-        this.timezone = timezone;
-        this.jsonValue = jsonValue;
-        this.javaValue = javaValue;
-    }
+    private static SimpleDateFormat dateTimeMilliSecFormatter;
+    private static SimpleDateFormat dateTimeFormatter;
+    private static SimpleDateFormat dateFormatter;
 
     /**
      * We are going to generate the same class twice:
-     * Once with the configuration option formatDateTime set to TRUE
-     * Once with the configuration option formatDateTime set to FALSE
+     * Once with the configuration option formatDateTimes set to TRUE
+     * Once with the configuration option formatDateTimes set to FALSE
      * 
      * @throws ClassNotFoundException
      * @throws IOException
      */
     @BeforeClass
     public static void generateClasses() throws ClassNotFoundException, IOException {
+        // The SimpleDateFormat instances created and configured here are based on the json schema defined in customDateTimeFormat.json
+        dateTimeMilliSecFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        dateTimeMilliSecFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        
+        dateTimeFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        dateTimeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        
+        dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
+        dateFormatter.setTimeZone(TimeZone.getTimeZone("PST"));
+        
         Map<String, Object> configValues = new HashMap<String, Object>();
         
-        configValues.put("formatDateTime", Boolean.TRUE);
+        // Generate class with config option formatDateTimes = TRUE
+        configValues.put("formatDateTimes", Boolean.TRUE);
         classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_true", configValues);
         
-        configValues.put("formatDateTime", Boolean.FALSE);
+        // Generate class with config option formatDateTimes = FALSE
+        configValues.put("formatDateTimes", Boolean.FALSE);
         classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_false", configValues);
         
         ClassLoader loader = classSchemaRule.compile();
         
-        // Class generated when formatDateTime is set to TRUE in configuration
+        // Class generated when formatDateTimes = TRUE in configuration
         classWhenConfigIsTrue = loader.loadClass("com.example.config_true.CustomDateTimeFormat");
-        // Class generated when formatDateTime is set to FALSE in configuration
+        // Class generated when formatDateTimes = FALSE in configuration
         classWhenConfigIsFalse = loader.loadClass("com.example.config_false.CustomDateTimeFormat");
     }
     
     /**
-     * Test whether the annotation is supposed to be generated.
-     * If it is supposed to be generated, test if the pattern and timezone attributes are as expected.
+     * This tests the class generated when formatDateTimes config option is set to TRUE
+     * The field should have @JsonFormat annotation with iso8601 date time pattern and UTC timezone
+     * It also tests the serialization and deserialization process
      * 
-     * @throws NoSuchFieldException
-     * @throws SecurityException
-     * @throws InstantiationException
-     * @throws IllegalAccessException
+     * @throws Exception
      */
     @Test
-    public void formatValueProducesExpectedAnnotation() throws NoSuchFieldException, SecurityException, InstantiationException, IllegalAccessException {
-        Field field;
-        if (config_isFormatDateTime) {
-            field = classWhenConfigIsTrue.getDeclaredField(propertyName);
-        }
-        else {
-            field = classWhenConfigIsFalse.getDeclaredField(propertyName);
-        }
+    public void testDefaultWhenFormatDateTimesConfigIsTrue() throws Exception {
+        Field field = classWhenConfigIsTrue.getDeclaredField("defaultFormat");
+        JsonFormat annotation = field.getAnnotation(JsonFormat.class);
         
-        if (isAnnotated) {
-            JsonFormat annotation = field.getAnnotation(JsonFormat.class);
-            
-            assertThat(annotation, notNullValue());
-            // Assert that the patterns match
-            assertEquals(format, annotation.pattern());
-            // Assert that the timezones match
-            assertEquals(timezone, annotation.timezone());
-        }
-        else {
-            // Verify that no annotation is generated
-            assertEquals(Boolean.FALSE, field.isAnnotationPresent(JsonFormat.class));
-        }
+        assertThat(annotation, notNullValue());
+        // Assert that the patterns match
+        assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSS", annotation.pattern());
+        // Assert that the timezones match
+        assertEquals("UTC", annotation.timezone());
         
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("defaultFormat", "2016-11-06T00:00:00.000");
+
+        Object pojo = objectMapper.treeToValue(node, classWhenConfigIsTrue);
+        
+        Method getter = new PropertyDescriptor("defaultFormat", classWhenConfigIsTrue).getReadMethod();
+        
+        // Assert that the Date object in the deserialized class is as expected
+        assertEquals(dateTimeMilliSecFormatter.parse("2016-11-06T00:00:00.000").toString(), getter.invoke(pojo).toString());
+        
+        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+        
+        // Assert that when the class is serialized, the date object is serialized as expected 
+        assertEquals("2016-11-06T00:00:00.000", jsonVersion.get("defaultFormat").asText());
     }
-
+    
+    /**
+     * This tests the class generated when formatDateTimes config option is set to TRUE
+     * The field should have @JsonFormat annotation with pattern defined in json schema and UTC timezone
+     * It also tests the serialization and deserialization process
+     * 
+     * @throws Exception
+     */
     @Test
-    public void valueCanBeSerializedAndDeserialized() throws NoSuchMethodException, IOException, IntrospectionException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        @SuppressWarnings("rawtypes")
-        Class generatedClass;
-        if (config_isFormatDateTime) {
-            generatedClass = classWhenConfigIsTrue;
-        }
-        else {
-            generatedClass = classWhenConfigIsFalse;
-        }
+    public void testCustomDateTimePatternWithDefaultTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception {
+        Field field = classWhenConfigIsTrue.getDeclaredField("customFormatDefaultTZ");
+        JsonFormat annotation = field.getAnnotation(JsonFormat.class);
         
-        // Assert only if annotation is generated
-        if (isAnnotated) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            
-            if (timezone != null){
-                objectMapper.setTimeZone(TimeZone.getTimeZone(timezone));
-            }
-            
-            ObjectNode node = objectMapper.createObjectNode();
-            node.put(propertyName, jsonValue.toString());
+        assertThat(annotation, notNullValue());
+        // Assert that the patterns match
+        assertEquals("yyyy-MM-dd'T'HH:mm:ss", annotation.pattern());
+        // Assert that the timezones match
+        assertEquals("UTC", annotation.timezone());
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("customFormatDefaultTZ", "2016-11-06T00:00:00");
 
-            @SuppressWarnings("unchecked")
-            Object pojo = objectMapper.treeToValue(node, generatedClass);
-            
-            Method getter = new PropertyDescriptor(propertyName, generatedClass).getReadMethod();
-            
-            // Assert that the Date object in the deserialized class is as expected
-            assertEquals(javaValue.toString(), getter.invoke(pojo).toString());
-            
-            JsonNode jsonVersion = objectMapper.valueToTree(pojo);
-            
-            // Assert that when the class is serialized, the date object is serialized as expected 
-            assertEquals(jsonValue.toString(), jsonVersion.get(propertyName).asText());
-        }
+        Object pojo = objectMapper.treeToValue(node, classWhenConfigIsTrue);
         
+        Method getter = new PropertyDescriptor("customFormatDefaultTZ", classWhenConfigIsTrue).getReadMethod();
+        
+        // Assert that the Date object in the deserialized class is as expected
+        assertEquals(dateTimeFormatter.parse("2016-11-06T00:00:00").toString(), getter.invoke(pojo).toString());
+        
+        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+        
+        // Assert that when the class is serialized, the date object is serialized as expected 
+        assertEquals("2016-11-06T00:00:00", jsonVersion.get("customFormatDefaultTZ").asText());
+    }
+    
+    /**
+     * This tests the class generated when formatDateTimes config option is set to TRUE
+     * The field should have @JsonFormat annotation with pattern and timezone defined in json schema
+     * It also tests the serialization and deserialization process
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCustomDateTimePatternWithCustomTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception{
+        Field field = classWhenConfigIsTrue.getDeclaredField("customFormatCustomTZ");
+        JsonFormat annotation = field.getAnnotation(JsonFormat.class);
+        
+        assertThat(annotation, notNullValue());
+        // Assert that the patterns match
+        assertEquals("yyyy-MM-dd", annotation.pattern());
+        // Assert that the timezones match
+        assertEquals("PST", annotation.timezone());
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setTimeZone(TimeZone.getTimeZone("PST"));
+        
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("customFormatCustomTZ", "2016-11-06");
+
+        Object pojo = objectMapper.treeToValue(node, classWhenConfigIsTrue);
+        
+        Method getter = new PropertyDescriptor("customFormatCustomTZ", classWhenConfigIsTrue).getReadMethod();
+        
+        // Assert that the Date object in the deserialized class is as expected
+        assertEquals(dateFormatter.parse("2016-11-06").toString(), getter.invoke(pojo).toString());
+        
+        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+        
+        // Assert that when the class is serialized, the date object is serialized as expected 
+        assertEquals("2016-11-06", jsonVersion.get("customFormatCustomTZ").asText());
+    }
+    
+    /**
+     * This tests the class generated when formatDateTimes config option is set to FALSE
+     * The field should not have @JsonFormat annotation
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testDefaultWhenFormatDateTimesConfigIsFalse() throws Exception{
+        Field field = classWhenConfigIsFalse.getDeclaredField("defaultFormat");
+        // Verify that no annotation is generated
+        assertEquals(Boolean.FALSE, field.isAnnotationPresent(JsonFormat.class));
+    }
+    
+    /**
+     * This tests the class generated when formatDateTimes config option is set to FALSE
+     * The field should have @JsonFormat annotation with pattern defined in json schema and UTC timezone
+     * It also tests the serialization and deserialization process
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCustomDateTimePatternWithDefaultTimezoneWhenFormatDateTimesConfigIsFalse() throws Exception {
+        Field field = classWhenConfigIsFalse.getDeclaredField("customFormatDefaultTZ");
+        JsonFormat annotation = field.getAnnotation(JsonFormat.class);
+        
+        assertThat(annotation, notNullValue());
+        // Assert that the patterns match
+        assertEquals("yyyy-MM-dd'T'HH:mm:ss", annotation.pattern());
+        // Assert that the timezones match
+        assertEquals("UTC", annotation.timezone());
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("customFormatDefaultTZ", "2016-11-06T00:00:00");
+
+        Object pojo = objectMapper.treeToValue(node, classWhenConfigIsFalse);
+        
+        Method getter = new PropertyDescriptor("customFormatDefaultTZ", classWhenConfigIsFalse).getReadMethod();
+        
+        // Assert that the Date object in the deserialized class is as expected
+        assertEquals(dateTimeFormatter.parse("2016-11-06T00:00:00").toString(), getter.invoke(pojo).toString());
+        
+        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+        
+        // Assert that when the class is serialized, the date object is serialized as expected 
+        assertEquals("2016-11-06T00:00:00", jsonVersion.get("customFormatDefaultTZ").asText());
+    }
+    
+    /**
+     * This tests the class generated when formatDateTimes config option is set to FALSE
+     * The field should have @JsonFormat annotation with pattern and timezone defined in json schema
+     * It also tests the serialization and deserialization process
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCustomDateTimePatternWithCustomTimezoneWhenFormatDateTimesConfigIsFalse() throws Exception {
+        Field field = classWhenConfigIsFalse.getDeclaredField("customFormatCustomTZ");
+        JsonFormat annotation = field.getAnnotation(JsonFormat.class);
+        
+        assertThat(annotation, notNullValue());
+        // Assert that the patterns match
+        assertEquals("yyyy-MM-dd", annotation.pattern());
+        // Assert that the timezones match
+        assertEquals("PST", annotation.timezone());
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setTimeZone(TimeZone.getTimeZone("PST"));
+        
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("customFormatCustomTZ", "2016-11-06");
+
+        Object pojo = objectMapper.treeToValue(node, classWhenConfigIsFalse);
+        
+        Method getter = new PropertyDescriptor("customFormatCustomTZ", classWhenConfigIsFalse).getReadMethod();
+        
+        // Assert that the Date object in the deserialized class is as expected
+        assertEquals(dateFormatter.parse("2016-11-06").toString(), getter.invoke(pojo).toString());
+        
+        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+        
+        // Assert that when the class is serialized, the date object is serialized as expected 
+        assertEquals("2016-11-06", jsonVersion.get("customFormatCustomTZ").asText());
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -1,0 +1,113 @@
+package org.jsonschema2pojo.integration;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.joda.time.DateTime;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@RunWith(Parameterized.class)
+public class CustomDateTimeFormatIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static Class<?> classWithFormattedProperties;
+    
+    @Parameters(name="{0}")
+    public static List<Object[]> data() {
+        return asList(new Object[][] {
+                /* { propertyName, expectedType, expectedAnnotation, jsonValue, timezone, javaValue } */
+                { "stringAsDateTime", Date.class, JsonFormat.class, "2016-11-06", "PST", new Date(new GregorianCalendar(2016, 10, 06, 5, 0, 0).getTimeInMillis()) },
+                { "stringAsDateTime2", DateTime.class, JsonFormat.class, "2016-11-06", "PST", new DateTime(2016, 10, 06, 5, 0, 0) }});
+    }
+
+    private String propertyName;
+    private Class<?> expectedType;
+    private Class<?> expectedAnnotation;
+    private Object jsonValue;
+    private String timezone;
+    private Object javaValue;
+
+    public CustomDateTimeFormatIT(String propertyName, Class<?> expectedType, Class<?> expectedAnnotation, Object jsonValue, String timezone, Object javaValue) {
+        this.propertyName = propertyName;
+        this.expectedType = expectedType;
+        this.expectedAnnotation = expectedAnnotation;
+        this.jsonValue = jsonValue;
+        this.timezone = timezone;
+        this.javaValue = javaValue;
+    }
+
+    @BeforeClass
+    public static void generateClasses() throws ClassNotFoundException, IOException {
+
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/format/customDateTimeFormat.json", "com.example");
+
+        classWithFormattedProperties = resultsClassLoader.loadClass("com.example.CustomDateTimeFormat");
+
+    }
+
+    @Test
+    public void formatValueProducesExpectedType() throws NoSuchMethodException, IntrospectionException {
+
+        Method getter = new PropertyDescriptor(propertyName, classWithFormattedProperties).getReadMethod();
+
+        assertThat(getter.getReturnType().getName(), is(this.expectedType.getName()));
+
+    }
+    
+    @Test
+    public void formatValueProducesExpectedAnnotation() throws NoSuchFieldException, SecurityException {
+
+    	Field field = classWithFormattedProperties.getDeclaredField(propertyName);
+    	
+    	assertEquals(expectedAnnotation, field.getDeclaredAnnotation(JsonFormat.class).annotationType());
+    }
+
+    /*
+     * TODO: Need to fix this test 
+    @Test
+    public void valueCanBeSerializedAndDeserialized() throws NoSuchMethodException, IOException, IntrospectionException, IllegalAccessException, InvocationTargetException {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        if (timezone != null){
+        	objectMapper.setTimeZone(TimeZone.getTimeZone(timezone));
+        }
+        
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put(propertyName, jsonValue.toString());
+
+        Object pojo = objectMapper.treeToValue(node, classWithFormattedProperties);
+        
+        Method getter = new PropertyDescriptor(propertyName, classWithFormattedProperties).getReadMethod();
+        assertThat(getter.invoke(pojo).toString(), is(equalTo(javaValue.toString())));
+
+        JsonNode jsonVersion = objectMapper.valueToTree(pojo);
+        assertThat(jsonVersion.get(propertyName).asText(), is(equalTo(jsonValue.toString())));
+    }
+     */
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -172,6 +172,12 @@ public class CustomAnnotatorIT {
 
         }
 
+		@Override
+		public void jsonFormat(JFieldVar field, JDefinedClass clazz,
+				String propertyName, JsonNode propertyNode) {
+			field.annotate(Deprecated.class);
+		}
+
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -173,8 +173,7 @@ public class CustomAnnotatorIT {
         }
 
 		@Override
-		public void jsonFormat(JFieldVar field, JDefinedClass clazz,
-				String propertyName, JsonNode propertyNode) {
+		public void dateField(JFieldVar field, JsonNode propertyNode) {
 			field.annotate(Deprecated.class);
 		}
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
@@ -1,0 +1,17 @@
+{
+    "type" : "object",
+    "properties" : {
+        "stringAsDateTime" : {
+            "type" : "string",
+            "format" : "date-time",
+            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            "timezone" : "PST"
+        },
+        "stringAsDateTime2" : {
+            "javaType" : "org.joda.time.DateTime",
+            "format" : "date-time",
+            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            "timezone" : "PST"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
@@ -1,17 +1,20 @@
 {
     "type" : "object",
     "properties" : {
-        "stringAsDateTime" : {
+        "defaultFormat" : {
+            "type" : "string",
+            "format" : "date-time"
+        },
+        "customFormatDefaultTZ" : {
             "type" : "string",
             "format" : "date-time",
-            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
-            "timezone" : "PST"
+            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss"
         },
-        "stringAsDateTime2" : {
-            "javaType" : "org.joda.time.DateTime",
+        "customFormatCustomTZ" : {
+            "type" : "string",
             "format" : "date-time",
-            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
-            "timezone" : "PST"
+            "customDateTimePattern" : "yyyy-MM-dd",
+            "customTimezone" : "PST"
         }
     }
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -544,15 +544,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private MavenProject project;
     
     /**
-     * Whether the fields of type `date-type` have the `@JsonFormat` annotation 
+     * Whether the fields of type `date-time` have the `@JsonFormat` annotation 
      * with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS`
      * and timezone set to default value of `UTC`
      *
-     * @parameter expression="${jsonschema2pojo.formatDateTime}"
+     * @parameter expression="${jsonschema2pojo.formatDateTimes}"
      *            default-value="false"
      * @since 0.4.29
      */
-    private boolean formatDateTime = false;
+    private boolean formatDateTimes = false;
 
     private FileFilter fileFilter = new AllFileFilter();
 
@@ -882,8 +882,8 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     }
 
 	@Override
-	public boolean isFormatDateTime() {
-		return formatDateTime;
+	public boolean isFormatDateTimes() {
+		return formatDateTimes;
 	}
 
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -542,6 +542,17 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @readonly
      */
     private MavenProject project;
+    
+    /**
+     * Whether the fields of type `date-type` have the `@JsonFormat` annotation 
+     * with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS`
+     * and timezone set to default value of `UTC`
+     *
+     * @parameter expression="${jsonschema2pojo.formatDateTime}"
+     *            default-value="false"
+     * @since 0.4.29
+     */
+    private boolean formatDateTime = false;
 
     private FileFilter fileFilter = new AllFileFilter();
 
@@ -869,5 +880,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     public boolean isUseBigDecimals() {
         return useBigDecimals;
     }
+
+	@Override
+	public boolean isFormatDateTime() {
+		return formatDateTime;
+	}
 
 }


### PR DESCRIPTION
Adds @JsonFormat annotation to specified property. An example of the jsonschema is:

```
{
    "type" : "object",
    "properties" : {
        "stringAsJavaDate" : {
            "type" : "string",
            "format" : "date-time",
            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
            "timezone" : "PST"
        },
        "stringAsJodaDateTime" : {
            "javaType" : "org.joda.time.DateTime",
            "format" : "date-time",
            "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
            "timezone" : "PST"
        }
    }
}
```

This PR is not ready to be merged. I created this to get feedback. I am still trying to get the integration tests to work.