### PR TITLE
Add plugin infos

### DIFF
--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -9,6 +9,7 @@ describes the rules and their effect on generated Java types.
 This plugin is hosted on the Maven Central Repository. All actions are logged at the `info` level.
 
 ```groovy
+apply plugin: 'java' // Not needed in Android Projects
 apply plugin: 'jsonschema2pojo'
 
 buildscript {

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -9,7 +9,11 @@ describes the rules and their effect on generated Java types.
 This plugin is hosted on the Maven Central Repository. All actions are logged at the `info` level.
 
 ```groovy
-apply plugin: 'java' // Not needed in Android Projects
+// Use the java plugin 
+apply plugin: 'java' 
+// In Android Projects use 
+apply plugin: 'com.android.application'
+
 apply plugin: 'jsonschema2pojo'
 
 buildscript {


### PR DESCRIPTION
I've just created a "plain old" gradle project. 
Only for creating the json files to objects. Don't want to import it in my android project. 
So it ended up with:
```java
* What went wrong:
A problem occurred evaluating root project 'pojoGen'.
> Failed to apply plugin [id 'jsonschema2pojo']
   > generateJsonSchema: Java or Android plugin required
```

For further readers it would be great to know that info ;)