### PR TITLE
 #655 @JsonPropertyDescription fix

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -77,7 +77,7 @@ public class Jackson2Annotator extends AbstractAnnotator {
         }
 
         if (propertyNode.has("description")) {
-            field.annotate(JsonPropertyDescription.class).param("value", propertyNode.asText());
+            field.annotate(JsonPropertyDescription.class).param("value", propertyNode.get("description").asText());
         }
     }
 


### PR DESCRIPTION
Fixes #655 so that the description from the schema is now properly set in the @JsonPropertyDescription annotation.