### PR TITLE
Allow pattern, required, and minimum/maximum to declare message arguments

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinimumMaximumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinimumMaximumRule.java
@@ -21,8 +21,8 @@ import javax.validation.constraints.DecimalMin;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.jsonschema2pojo.Schema;
-import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JFieldVar;
+import org.jsonschema2pojo.util.AnnotationHelper;
 
 public class MinimumMaximumRule implements Rule<JFieldVar, JFieldVar> {
 
@@ -38,13 +38,11 @@ public class MinimumMaximumRule implements Rule<JFieldVar, JFieldVar> {
         if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
 
             if (node.has("minimum")) {
-                JAnnotationUse annotation = field.annotate(DecimalMin.class);
-                annotation.param("value", node.get("minimum").asText());
+                AnnotationHelper.annotateField(DecimalMin.class, node.get("minimum"), field, "value");
             }
 
             if (node.has("maximum")) {
-                JAnnotationUse annotation = field.annotate(DecimalMax.class);
-                annotation.param("value", node.get("maximum").asText());
+                AnnotationHelper.annotateField(DecimalMax.class, node.get("maximum"), field, "value");
             }
 
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -103,6 +103,11 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
             ruleFactory.getPatternRule().apply(nodeName, node.get("pattern"), field, schema);
         }
 
+        if (node.has("size")) {
+            ruleFactory.getSizeRule().apply(nodeName, node.get("size"), field, schema);
+        }
+
+
         ruleFactory.getDefaultRule().apply(nodeName, node.get("default"), field, schema);
 
         ruleFactory.getMinimumMaximumRule().apply(nodeName, node, field, schema);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredRule.java
@@ -25,6 +25,7 @@ import org.jsonschema2pojo.Schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JDocCommentable;
 import com.sun.codemodel.JFieldVar;
+import org.jsonschema2pojo.util.AnnotationHelper;
 
 /**
  * Applies the "required" schema rule.
@@ -61,12 +62,12 @@ public class RequiredRule implements Rule<JDocCommentable, JDocCommentable> {
     @Override
     public JDocCommentable apply(String nodeName, JsonNode node, JDocCommentable generatableType, Schema schema) {
 
-        if (node.asBoolean()) {
+        if (node.asBoolean() || node.isObject() || node.isTextual()) {
             generatableType.javadoc().append("\n(Required)");
 
             if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()
                     && generatableType instanceof JFieldVar) {
-                ((JFieldVar) generatableType).annotate(NotNull.class);
+                AnnotationHelper.annotateField(NotNull.class, node, (JFieldVar) generatableType, "message");
             }
 
             if (ruleFactory.getGenerationConfig().isIncludeJsr305Annotations()

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -155,6 +155,7 @@ public class RuleFactory {
      * Provides a rule instance that should be applied when a "required"
      * declaration is found in the schema.
      *
+     * @see javax.validation.constraints.NotNull
      * @return a schema rule that can handle the "required" declaration.
      */
     public Rule<JDocCommentable, JDocCommentable> getRequiredRule() {
@@ -230,10 +231,22 @@ public class RuleFactory {
      * declaration is found in the schema, to assign any minimum/maximum
      * validation on that property
      *
-     * @return a schema rule that can handle the "default" declaration.
+     * @see javax.validation.constraints.DecimalMax
+     * @see javax.validation.constraints.DecimalMin
+     * @return a schema rule that can handle the "minimum/maximum" declaration.
      */
     public Rule<JFieldVar, JFieldVar> getMinimumMaximumRule() {
         return new MinimumMaximumRule(this);
+    }
+
+    /**
+     * Provides a rule instance that should be applied when a "size"
+     * declaration is found in the schema for a property.
+     * @see javax.validation.constraints.Size
+     * @return a schema rule that can handle the "size" declaration
+     */
+    public Rule<JFieldVar, JFieldVar> getSizeRule() {
+        return new SizeRule(this);
     }
 
     /**
@@ -241,7 +254,7 @@ public class RuleFactory {
      * declaration is found in the schema, to assign any size validation
      * (minItems/maxItems) on that property
      *
-     * @return a schema rule that can handle the "default" declaration.
+     * @return a schema rule that can handle the "minItems/maxItems" declaration.
      */
     public Rule<JFieldVar, JFieldVar> getMinItemsMaxItemsRule() {
         return new MinItemsMaxItemsRule(this);
@@ -252,7 +265,7 @@ public class RuleFactory {
      * declaration is found in the schema, to assign any size validation
      * (minLength/maxLength) on that property
      *
-     * @return a schema rule that can handle the "default" declaration.
+     * @return a schema rule that can handle the "minLength/maxLength" declaration.
      */
     public Rule<JFieldVar, JFieldVar> getMinLengthMaxLengthRule() {
         return new MinLengthMaxLengthRule(this);
@@ -262,6 +275,7 @@ public class RuleFactory {
      * Provides a rule instance that should be applied when a "pattern"
      * declaration is found in the schema for a property.
      *
+     * @see javax.validation.constraints.Pattern
      * @return a schema rule that can handle the "pattern" declaration.
      */
     public Rule<JFieldVar, JFieldVar> getPatternRule() {
@@ -273,7 +287,8 @@ public class RuleFactory {
      * declaration is found in the schema which itself contains properties, to
      * assign validation of the properties within that property
      *
-     * @return a schema rule that can handle the "default" declaration.
+     * @see javax.validation.Valid
+     * @return a schema rule that can handle the "property" declaration.
      */
     public Rule<JFieldVar, JFieldVar> getValidRule() {
         return new ValidRule(this);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SizeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SizeRule.java
@@ -16,29 +16,28 @@
 
 package org.jsonschema2pojo.rules;
 
-import javax.validation.constraints.Pattern;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import org.jsonschema2pojo.Schema;
 import com.sun.codemodel.JFieldVar;
+import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.AnnotationHelper;
 
-public class PatternRule implements Rule<JFieldVar, JFieldVar> {
+import javax.validation.constraints.Size;
 
-    private RuleFactory ruleFactory;
+public class SizeRule implements Rule<JFieldVar, JFieldVar> {
 
-    public PatternRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
-    }
+	private final RuleFactory ruleFactory;
 
-    @Override
-    public JFieldVar apply(String nodeName, JsonNode node, JFieldVar field, Schema currentSchema) {
+	protected SizeRule(RuleFactory ruleFactory) {
+		this.ruleFactory = ruleFactory;
+	}
 
-        if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
-            AnnotationHelper.annotateField(Pattern.class, node, field, "regexp");
-        }
+	@Override
+	public JFieldVar apply(String nodeName, JsonNode node, JFieldVar field, Schema currentSchema) {
 
-        return field;
-    }
+		if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
+			AnnotationHelper.annotateField(Size.class, node, field, null);
+		}
 
+		return field;
+	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/AnnotationHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/AnnotationHelper.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JFieldVar;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+public class AnnotationHelper {
+
+	private static void addParameter(Method method, String param, JAnnotationUse jAnnotationUse, JsonNode node) {
+		Class returnType = method.getReturnType();
+
+		if (returnType == String.class) {
+			jAnnotationUse.param(param, node.asText());
+
+		} else if (returnType == int.class) {
+			jAnnotationUse.param(param, node.asInt());
+
+		} else if (returnType == long.class) {
+			jAnnotationUse.param(param, node.asLong());
+		}
+	}
+
+	public static JAnnotationUse annotateField(Class<? extends Annotation> annotation, JsonNode node, JFieldVar field, String optParamName) {
+		JAnnotationUse jAnnotationUse = field.annotate(annotation);
+
+	 	if (node != null && node.isObject()) {
+			for (Method next : annotation.getDeclaredMethods()) {
+				String param = next.getName();
+				if (node.has(param)) {
+					addParameter(next, param, jAnnotationUse, node.get(param));
+				}
+			}
+		} else if (optParamName != null){
+			try {
+				addParameter(annotation.getMethod(optParamName), optParamName, jAnnotationUse, node);
+			} catch (NoSuchMethodException e) {}
+
+		}
+		return jAnnotationUse;
+	}
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredRuleTest.java
@@ -19,6 +19,7 @@ package org.jsonschema2pojo.rules;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,6 +42,22 @@ public class RequiredRuleTest {
 
         ObjectMapper mapper = new ObjectMapper();
         BooleanNode descriptionNode = mapper.createObjectNode().booleanNode(true);
+
+        JDocCommentable result = rule.apply("fooBar", descriptionNode, jclass, null);
+
+        assertThat(result.javadoc(), sameInstance(jclass.javadoc()));
+        assertThat(result.javadoc().size(), is(1));
+        assertThat((String) result.javadoc().get(0), is("\n(Required)"));
+
+    }
+
+    @Test
+    public void applyAddsTextWhenRequiredIsObject() throws JClassAlreadyExistsException {
+
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode descriptionNode = mapper.createObjectNode();
 
         JDocCommentable result = rule.apply("fooBar", descriptionNode, jclass, null);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/AnnotationHelperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/AnnotationHelperTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.codemodel.*;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.io.StringWriter;
+import java.lang.annotation.Annotation;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AnnotationHelperTest {
+
+
+	private JFieldVar jFieldVar;
+	private Random random;
+
+	@Before
+	public void setup() throws Exception {
+		JDefinedClass jDefinedClass = new JCodeModel()._class(this.getClass().getName());
+		jFieldVar = jDefinedClass.field(JMod.PRIVATE, jDefinedClass.owner().ref(String.class), "fooBar");
+
+		random = new Random();
+	}
+
+	private void assertMatches(Class<? extends Annotation> clazz, Map<String, ?> params, JAnnotationUse jAnnotationUse) {
+		StringWriter actualSw = new StringWriter();
+		JFormatter formatter = new JFormatter(actualSw);
+		jAnnotationUse.generate(formatter);
+
+		String actual = actualSw.toString();
+
+		if (params.isEmpty()) {
+			assertEquals(String.format("@%s", clazz.getName()), actual);
+			return;
+		}
+
+		for (String key : params.keySet()) {
+			StringWriter expectedSw = new StringWriter();
+			Object value = params.get(key);
+
+			if (!StringUtils.equals(key, "value")) {
+				expectedSw.append(key);
+				expectedSw.append(" = ");
+			}
+
+			if (value instanceof String) {
+				expectedSw.append('"');
+				expectedSw.append((String)value);
+				expectedSw.append('"');
+
+			} else {
+				expectedSw.write(value.toString());
+
+				if (value instanceof Long || value.getClass() == long.class) {
+					expectedSw.append('L');
+				}
+			}
+
+			String expected = expectedSw.toString();
+
+			assertThat("Expecting " + expected, actual, containsString(expected));
+		}
+
+	}
+
+	private void testClass(Class<? extends Annotation> clazz, Map<String, ?> expected, Object params, String optParamName) {
+		Collection<JAnnotationUse> annotations = jFieldVar.annotations();
+		assertThat(annotations.size(), is(0));
+
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode actualParams = mapper.valueToTree(params);
+
+		AnnotationHelper.annotateField(clazz, actualParams, jFieldVar, optParamName);
+
+		annotations = jFieldVar.annotations();
+
+		assertNotNull(annotations);
+		assertThat(annotations.size(), is(1));
+		for (JAnnotationUse next : annotations) {
+			assertMatches(clazz, expected, next);
+		}
+	}
+
+	@Test
+	public void noParameters() {
+
+		Class<? extends Annotation> clazz = NotNull.class;
+		testClass(clazz, new HashMap<String, String>(), null, null);
+	}
+
+	@Test
+	public void applySingleParameter() {
+
+		Class<? extends Annotation> clazz = Pattern.class;
+
+		Map<String, String> expected = new HashMap<String, String>();
+		expected.put("regexp", "regexp");
+
+		testClass(clazz, expected, "regexp", "regexp");
+	}
+
+	@Test
+	public void applyMultipleParameters() {
+
+		Class<? extends Annotation> clazz = Pattern.class;
+
+		Map<String, String> expected = new HashMap<String, String>();
+		expected.put("regexp", UUID.randomUUID().toString());
+		expected.put("message", UUID.randomUUID().toString());
+
+		testClass(clazz, expected, expected, null);
+	}
+
+
+	@Test
+	public void ignoresExtraParams() {
+
+		Class<? extends Annotation> clazz = Pattern.class;
+
+		Map<String, Object> expected = new HashMap<String, Object>();
+		expected.put("regexp", UUID.randomUUID().toString());
+		expected.put("message", UUID.randomUUID().toString());
+
+		Map<String, Object> extras = new HashMap<String, Object>(expected);
+
+		extras.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+		testClass(clazz, expected, extras, null);
+	}
+
+	@Test
+	public void testStringParameters() {
+
+		Map<String, String> params = new HashMap<String, String>();
+		params.put("regexp", UUID.randomUUID().toString());
+		params.put("message", UUID.randomUUID().toString());
+		testClass(Pattern.class, params, params, null);
+	}
+
+	@Test
+	public void testIntParameters() {
+
+		Map<String, Integer> params = new HashMap<String, Integer>();
+		params.put("integer", random.nextInt());
+		params.put("fraction", random.nextInt());
+		testClass(Digits.class, params, params, null);
+	}
+
+	@Test
+	public void testLongParameters() {
+
+		Map<String, Long> params = new HashMap<String, Long>();
+		params.put("value", random.nextLong());
+		testClass(Max.class, params, params, null);
+	}
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/all.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/all.json
@@ -2,12 +2,12 @@
     "type" : "object",
     "properties" : {
         "x" : {
-            "minimum" : 1.1,
-            "minimum" : 2.2,
-            "minItems" : "1",
-            "maxItems" : "2",
-            "minLength" : "1",
-            "maxLength" : "2",
+            "minimum" : 1,
+            "maximum" : 2,
+            "minItems" : 1,
+            "maxItems" : 2,
+            "minLength" : 1,
+            "maxLength" : 2,
             "pattern" : "abc.*",
             "required" : true
         }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/pattern.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/pattern.json
@@ -4,6 +4,13 @@
         "pattern" : {
             "type" : "string",
             "pattern" : "abc.*"
+        },
+        "patternAsObject" : {
+            "type": "string",
+            "pattern" : {
+                "regexp": "abc.*",
+                "message": "custom error message"
+            }
         }
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/required.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/required.json
@@ -4,6 +4,16 @@
         "required" : {
             "type" : "string",
             "required" : true
+        },
+        "requiredAsObject" : {
+            "type" : "string",
+            "required" : {
+                "message": "custom error message"
+            }
+        },
+        "requiredAsValue" : {
+            "type" : "string",
+            "required" : "custom error message"
         }
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/size.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/size.json
@@ -1,0 +1,33 @@
+{
+  "type" : "object",
+  "properties" : {
+    "min" : {
+      "type" : "string",
+      "size": {
+        "min": 1
+      }
+    },
+    "max" : {
+      "type" : "string",
+      "size": {
+        "max": 2
+      }
+    },
+    "minMax": {
+      "type" : "string",
+      "size": {
+        "min": 1,
+        "max": 2,
+        "message": "custom error message"
+      }
+    },
+    "minMaxCustomMessage": {
+      "type" : "string",
+      "size": {
+        "min": 1,
+        "max": 2,
+        "message": "custom error message"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This allows for any properties of an annotation to be assigned inside the schema document.

I would like to be able to assign custom message's for errors that are returned when a field doesn't match a regexp, or if a required field isn't present.  I left the min/max items/length alone and added a new size rule that can have the message set as well as the min/max value.