### PR TITLE
Added option to not overwrite files if there are no changes

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -16,7 +16,8 @@
 
 package org.jsonschema2pojo.ant;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -103,6 +104,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean removeOldOutput = false;
 
+    private boolean overwriteEvenIfUnchanged = true;
+
     private String outputEncoding = "UTF-8";
 
     private boolean useJodaDates = false;
@@ -140,7 +143,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private String timeType = null;
 
     private String dateType = null;
-    
+
     private boolean formatDateTimes = false;
 
 
@@ -506,6 +509,18 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
+     * Sets the 'overwriteEvenIfUnchanged' property of this class
+     *
+     * @param overwriteEvenIfUnchanged
+     *            If false, then the output is first compared to what is already
+     *            in the target directory and only written to if changed.
+     *            Default is true
+     */
+    public void setOverwriteEvenIfUnchanged(boolean overwriteEvenIfUnchanged) {
+        this.overwriteEvenIfUnchanged = overwriteEvenIfUnchanged;
+    }
+
+    /**
      * Sets the 'outputEncoding' property of this class
      *
      * @param outputEncoding
@@ -670,13 +685,13 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public void setIncludeDynamicAccessors(boolean includeDynamicAccessors) {
         this.includeDynamicAccessors = includeDynamicAccessors;
     }
-    
+
     /**
      * Sets the 'formatDateTimes' property of this class
      *
      * @param formatDateTimes
-     *            Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation 
-     *            with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSS</code> 
+     *            Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation
+     *            with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSS</code>
      *            and timezone set to default value of `UTC`
      */
     public void setFormatDateTime(boolean formatDateTimes) {
@@ -798,6 +813,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isRemoveOldOutput() {
         return removeOldOutput;
+    }
+
+    @Override
+    public boolean isOverwriteEvenIfUnchanged() {
+        return overwriteEvenIfUnchanged;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -200,6 +200,11 @@
         <td align="center" valign="top">No (default <code>JSONSCHEMA</code>)</td>
       </tr>
       <tr>
+        <td valign="top">overwriteEvenIfUnchanged</td>
+        <td valign="top">If false, then the output is first compared to what is already in the target directory and only written to if the contents aren't the same.
+        <td align="center" valign="top">No (default <code>true</code>)</td>
+      </tr>
+      <tr>
         <td valign="top">skip</td>
         <td valign="top">Whether to skip type generation entirely (useful when set via a build property to allow quick disabling of this task using a command line property).</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.cli;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -108,6 +108,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-R", "--remove-old-output" }, description = "Whether to empty the target directory before generation occurs, to clear out all source files that have been generated previously (indiscriminately deletes all files and folders).")
     private boolean removeOldOutput = false;
 
+    @Parameter(names = { "--overwrite-even-if-unchanged" }, description = "If false, then do not write file to target if it is not different from the file that is already there.")
+    private boolean overwriteEvenIfUnchanged = true;
+
     @Parameter(names = { "-e", "--output-encoding" }, description = "The character encoding that should be used when writing the generated Java source files.")
     private String outputEncoding = "UTF-8";
 
@@ -161,10 +164,10 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-ida", "--include-dynamic-accessors" }, description = "Include dynamic getter, setter, and builder support on generated types.")
     private boolean includeDynamicAccessors = false;
-    
+
     @Parameter(names = { "-fdt", "--format-date-times" }, description = "Whether the fields of type `date-time` have the `@JsonFormat` annotation with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` and timezone set to default value of `UTC`")
     private boolean formatDateTimes = false;
-    
+
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
 
@@ -283,6 +286,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isRemoveOldOutput() {
         return removeOldOutput;
+    }
+
+    @Override
+    public boolean isOverwriteEvenIfUnchanged() {
+        return overwriteEvenIfUnchanged;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CachingCodeWriter.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CachingCodeWriter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+
+import com.sun.codemodel.CodeWriter;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.writer.FilterCodeWriter;
+
+/**
+ * This {@link CodeWriter} variant won't write out files if the contents of the current file and the desired file are the same.
+ * For example, useful for prevent recompilation of all files in Maven.
+ */
+public class CachingCodeWriter extends FilterCodeWriter {
+
+    private GenerationConfig config;
+    private List<RequestedFile> requestedSourceFiles = new ArrayList<RequestedFile>();
+
+    public CachingCodeWriter(GenerationConfig config, CodeWriter core) {
+        super(core);
+        this.config = config;
+    }
+
+    @Override
+    public Writer openSource(JPackage pkg, String fileName) throws IOException {
+        RequestedFile binary = new RequestedFile(pkg, fileName);
+        requestedSourceFiles.add(binary);
+        return binary.getOutput();
+    }
+
+    @Override
+    public void close() throws IOException {
+
+        nextRequestedSource:
+        for (RequestedFile source : requestedSourceFiles) {
+            final File dir;
+            if (source.getPkg().isUnnamed()) {
+                dir = config.getTargetDirectory();
+            } else {
+                dir = new File(config.getTargetDirectory(), source.getPkg().name().replace('.', File.separatorChar));
+            }
+
+            File targetFile = new File(dir, source.getFileName());
+
+            if (targetFile.exists()) {
+
+                BufferedReader currentFile = null;
+                try {
+                    currentFile = new BufferedReader(new InputStreamReader(new FileInputStream(targetFile), config.getOutputEncoding()));
+
+                    BufferedReader requestedFile = new BufferedReader(new StringReader(source.getOutput().toString()));
+
+                    if (IOUtils.contentEqualsIgnoreEOL(currentFile, requestedFile)) {
+                        continue nextRequestedSource;
+                    }
+
+                } finally {
+                    if (currentFile != null) {
+                        currentFile.close();
+                    }
+                }
+            }
+
+            generateOutput(source);
+
+        }
+
+        super.close();
+    }
+
+    private void generateOutput(RequestedFile source) throws IOException {
+        Writer output = super.openSource(source.getPkg(), source.getFileName());
+        IOUtils.copy(new StringReader(source.getOutput().toString()), output);
+        output.close();
+    }
+
+    private static class RequestedFile {
+        private final JPackage pkg;
+        private final String fileName;
+        private final StringWriter output;
+        public RequestedFile(JPackage pkg, String fileName) {
+            this.pkg = pkg;
+            this.fileName = fileName;
+            output = new StringWriter();
+        }
+        public JPackage getPkg() {
+            return pkg;
+        }
+        public String getFileName() {
+            return fileName;
+        }
+        public StringWriter getOutput() {
+            return output;
+        }
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -166,6 +166,11 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return false;
     }
 
+    @Override
+    public boolean isOverwriteEvenIfUnchanged() {
+        return true;
+    }
+
     /**
      * @return false
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -226,6 +226,16 @@ public interface GenerationConfig {
     boolean isRemoveOldOutput();
 
     /**
+     * Gets the 'overwriteEvenIfUnchanged' configuration option.
+     * Defaults to 'true'
+     *
+     * @return If false, then the output of a schema is first compared with
+     *         what is already in the target directory. If the same, then
+     *         nothing is written. If true, then the old behaviour is used.
+     */
+    boolean isOverwriteEvenIfUnchanged();
+
+    /**
      * Gets the 'outputEncoding' configuration option.
      *
      * @return The character encoding that should be used when writing the
@@ -412,12 +422,12 @@ public interface GenerationConfig {
      *         date-time) to generated Java types.
      */
     String getTimeType();
-    
+
     /**
-     * Gets the `formatDateTime` configuration option 
+     * Gets the `formatDateTime` configuration option
      *
-     * @return Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation 
-     *         with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSSZ</code> 
+     * @return Whether the fields of type <code>date-type</code> have the <code>@JsonFormat</code> annotation
+     *         with pattern set to the default value of <code>yyyy-MM-dd'T'HH:mm:ss.SSSZ</code>
      */
     boolean isFormatDateTimes();
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
@@ -16,7 +16,9 @@
 
 package org.jsonschema2pojo;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.removeEnd;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -79,6 +81,10 @@ public class Jsonschema2Pojo {
         if (config.getTargetDirectory().exists() || config.getTargetDirectory().mkdirs()) {
             CodeWriter sourcesWriter = new FileCodeWriterWithEncoding(config.getTargetDirectory(), config.getOutputEncoding());
             CodeWriter resourcesWriter = new FileCodeWriterWithEncoding(config.getTargetDirectory(), config.getOutputEncoding());
+            if (!config.isOverwriteEvenIfUnchanged()) {
+                sourcesWriter = new CachingCodeWriter(config, sourcesWriter);
+                resourcesWriter = new CachingCodeWriter(config, resourcesWriter);
+            }
             codeModel.build(sourcesWriter, resourcesWriter);
         } else {
             throw new GenerationException("Could not create or access target directory " + config.getTargetDirectory().getAbsolutePath());

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -15,9 +15,9 @@
  */
 package org.jsonschema2pojo.gradle
 
+import org.jsonschema2pojo.AllFileFilter
 import org.jsonschema2pojo.AnnotationStyle
 import org.jsonschema2pojo.Annotator
-import org.jsonschema2pojo.AllFileFilter
 import org.jsonschema2pojo.GenerationConfig
 import org.jsonschema2pojo.NoopAnnotator
 import org.jsonschema2pojo.SourceType
@@ -55,6 +55,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean serializable
   char[] propertyWordDelimiters
   boolean removeOldOutput
+  boolean overwriteEvenIfUnchanged
   SourceType sourceType
   String targetVersion
   boolean useCommonsLang3
@@ -196,9 +197,9 @@ public class JsonSchemaExtension implements GenerationConfig {
        |formatDateTimes = ${formatDateTimes}
      """.stripMargin()
   }
-  
+
   public boolean isFormatDateTimes() {
     return formatDateTimes;
   }
-  
+
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OverwriteIfUnchangedIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OverwriteIfUnchangedIT.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright Â© 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+
+import java.io.File;
+import java.net.URL;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class OverwriteIfUnchangedIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void doNotAlterFilesIfTheContentIsTheSame() {
+
+        URL schema1 = getClass().getResource("/schema/properties/primitiveProperties.json");
+
+        File generateDir = schemaRule.generate(schema1, "com.example", config("overwriteEvenIfUnchanged", false));
+
+        File source = new File(generateDir, "com/example/PrimitiveProperties.java");
+        Assert.assertTrue("Source ought to have been created", source.exists());
+        source.setLastModified(0L);
+
+        Assert.assertEquals("Test can't be fully trusted, can't change lastModified of a File", 0L, source.lastModified());
+
+        schemaRule.generate(schema1, "com.example", config("overwriteEvenIfUnchanged", false));
+
+        File actual = new File(generateDir, "com/example/PrimitiveProperties.java");
+        Assert.assertTrue("Result file ought to have been created", actual.exists());
+        Assert.assertEquals("File ought not to have been overwritten", 0L, actual.lastModified());
+
+    }
+
+    @Test
+    public void byDefaultPluginDoesOverwriteEvenIfUnchanged() {
+
+        URL schema1 = getClass().getResource("/schema/properties/primitiveProperties.json");
+
+        File generateDir = schemaRule.generate(schema1, "com.example", config("overwriteEvenIfUnchanged", true));
+
+        File source = new File(generateDir, "com/example/PrimitiveProperties.java");
+        Assert.assertTrue("Source ought to have been created", source.exists());
+        source.setLastModified(0L);
+
+        Assert.assertEquals("Test can't be fully trusted, can't change lastModified of a File", 0L, source.lastModified());
+
+        schemaRule.generate(schema1, "com.example", config());
+
+        File actual = new File(generateDir, "com/example/PrimitiveProperties.java");
+        Assert.assertTrue("Source ought to have been created", actual.exists());
+        Assert.assertNotEquals("File ought to have been overwritten", 0L, actual.lastModified());
+    }
+
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.maven;
 
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -327,6 +327,16 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean removeOldOutput = false;
 
     /**
+     * If false, then the output is first compared to what is already present in
+     * the target directory, if it is the same then no file is written.
+     *
+     * @parameter expression="${jsonschema2pojo.overwriteEvenIfUnchanged}"
+     *            default-value="true"
+     * @since 0.4.30
+     */
+    private boolean overwriteEvenIfUnchanged = true;
+
+    /**
      * The character encoding that should be used when writing the generated
      * Java source files.
      *
@@ -542,9 +552,9 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @readonly
      */
     private MavenProject project;
-    
+
     /**
-     * Whether the fields of type `date-time` have the `@JsonFormat` annotation 
+     * Whether the fields of type `date-time` have the `@JsonFormat` annotation
      * with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS`
      * and timezone set to default value of `UTC`
      *
@@ -751,6 +761,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isRemoveOldOutput() {
         return removeOldOutput;
+    }
+
+    @Override
+    public boolean isOverwriteEvenIfUnchanged() {
+        return overwriteEvenIfUnchanged;
     }
 
     @Override


### PR DESCRIPTION
Hi, we (at my workplace) noticed that FileCodeWriter will always overwrite files, even if there are no changes), this in turns triggers further recompilations across our multi-module project. (Even after accounting for https://issues.apache.org/jira/browse/MCOMPILER-209)

This change 'buffers' the output of FileCodeWriter and compares it to the current output file (if it's there) and if and only if it's different will it write out the file.

I'm not yet sure about the naming of the new property (overwriteEvenIfUnchanged, default true so that the default behaviour is unchanged) or the new classname (I'm now thinking 'BufferedCodeWriter is a more apt name instead of CachingCodeWriter). Feedback very welcome here.

I have added an integration test (OverwriteIfUnchangedIT) for this change and all tests are passing on my (Windows) machine.