### PR TITLE
Fix a pluralization problem for className ended with status.

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
@@ -105,7 +105,8 @@ public class Inflector {
             .irregular("person", "people")
             .irregular("child", "children")
             .irregular("sex", "sexes")
-            .irregular("move", "moves");
+            .irregular("move", "moves")
+            .irregular("tatus", "tatus");
 
         builder.uncountable(new String[] { "equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "s" });
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
@@ -52,6 +52,8 @@ public class InflectorTest {
         assertThat(Inflector.getInstance().singularize("squid"), is("squid"));
         assertThat(Inflector.getInstance().singularize("mattress"), is("mattress"));
         assertThat(Inflector.getInstance().singularize("address"), is("address"));
+        assertThat(Inflector.getInstance().singularize("status"), is("status"));
+        assertThat(Inflector.getInstance().singularize("EntityStatus"), is("EntityStatus"));
 
         assertThat(Inflector.getInstance().singularize("men"), is("man"));
         assertThat(Inflector.getInstance().singularize("women"), is("woman"));
@@ -62,6 +64,8 @@ public class InflectorTest {
 
         assertThat(Inflector.getInstance().pluralize("mattress"), is("mattresses"));
         assertThat(Inflector.getInstance().pluralize("address"), is("addresses"));
+        assertThat(Inflector.getInstance().pluralize("status"), is("status"));
+        assertThat(Inflector.getInstance().pluralize("EntityStatus"), is("EntityStatus"));
 
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -224,8 +224,8 @@ public class EnumIT {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/multipleEnumArraysWithSameName.json", "com.example");
 
         resultsClassLoader.loadClass("com.example.MultipleEnumArraysWithSameName");
-        resultsClassLoader.loadClass("com.example.Status");
-        resultsClassLoader.loadClass("com.example.Status_");
+        resultsClassLoader.loadClass("com.example.ObjectStatus");
+        resultsClassLoader.loadClass("com.example.ObjectStatus_");
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/multipleEnumArraysWithSameName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/multipleEnumArraysWithSameName.json
@@ -4,7 +4,7 @@
         "foo": {
             "type": "object",
             "properties": {
-                "statuses": {
+                "objectStatus": {
                     "type": "array",
                     "items": {
                         "type": "string",
@@ -19,7 +19,7 @@
         "bar": {
             "type": "object",
             "properties": {
-                "statuses": {
+                "objectStatus": {
                     "type": "array",
                     "items": {
                         "type": "string",


### PR DESCRIPTION
#695 Fix this problem

- tested locally 

- unit tests updated according to changes


Note: For unknown reasons if I write "status" instead of "tatus" the following happend :

entityStatus -> entitystatus (for the generated classname) that's why I only wrote "tatus".

(It is my first PR on github I hope it will work xD)