### PR TITLE
Add option to specify custom separator characters

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -146,7 +146,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean formatDateTimes = false;
 
-    private String customSeparatorCharacters = "#/.";
+    private String refFragmentPathDelimiters = "#/.";
 
     /**
      * Execute this task (it's expected that all relevant setters will have been
@@ -698,12 +698,14 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
-     * Sets the 'customSeparatorCharacters' property of this class
+     * Sets the 'refFragmentPathDelimiters' property of this class
      *
-     * @param customSeparatorCharacters Separators characters to be used to split JSON Pointers ($ref).
+     * @param refFragmentPathDelimiters A string containing any characters that should act as path delimiters when
+     *                                  resolving $ref fragments. By default, #, / and . are used in an attempt
+     *                                  to support JSON Pointer and JSON Path.
      */
-    public void setCustomSeparatorCharacters(String customSeparatorCharacters) {
-        this.customSeparatorCharacters = customSeparatorCharacters;
+    public void setRefFragmentPathDelimiters(String refFragmentPathDelimiters) {
+        this.refFragmentPathDelimiters = refFragmentPathDelimiters;
     }
 
     @Override
@@ -949,7 +951,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     @Override
-    public String isCustomSeparatorCharacters() {
-        return customSeparatorCharacters;
+    public String getRefFragmentPathDelimiters() {
+        return refFragmentPathDelimiters;
     }
 }

--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -146,6 +146,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean formatDateTimes = false;
 
+    private String customSeparatorCharacters = "#/.";
 
     /**
      * Execute this task (it's expected that all relevant setters will have been
@@ -696,6 +697,15 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         this.formatDateTimes = formatDateTimes;
     }
 
+    /**
+     * Sets the 'customSeparatorCharacters' property of this class
+     *
+     * @param customSeparatorCharacters Separators characters to be used to split JSON Pointers ($ref).
+     */
+    public void setCustomSeparatorCharacters(String customSeparatorCharacters) {
+        this.customSeparatorCharacters = customSeparatorCharacters;
+    }
+
     @Override
     public boolean isGenerateBuilders() {
         return generateBuilders;
@@ -938,4 +948,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         return formatDateTimes;
     }
 
+    @Override
+    public String isCustomSeparatorCharacters() {
+        return customSeparatorCharacters;
+    }
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -409,8 +409,9 @@
         <td align="center" valign="top">No (default <code>false</code>)</td>
     </tr>
     <tr>
-        <td valign="top">customSeparatorCharacters</td>
-        <td valign="top">Separators characters to be used to split JSON Pointers ($ref).
+        <td valign="top">refFragmentPathDelimiters</td>
+        <td valign="top">A string containing any characters that should act as path delimiters when resolving $ref
+            fragments. By default, #, / and . are used in an attempt to support JSON Pointer and JSON Path.
         </td>
         <td align="center" valign="top">No (default <code>#/.</code>)</td>
     </tr>

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -408,6 +408,12 @@
         </td>
         <td align="center" valign="top">No (default <code>false</code>)</td>
     </tr>
+    <tr>
+        <td valign="top">customSeparatorCharacters</td>
+        <td valign="top">Separators characters to be used to split JSON Pointers ($ref).
+        </td>
+        <td align="center" valign="top">No (default <code>#/.</code>)</td>
+    </tr>
 </table>
 
 <h3>Examples</h3>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -169,8 +169,8 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-fdt", "--format-date-times" }, description = "Whether the fields of type `date-time` have the `@JsonFormat` annotation with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` and timezone set to default value of `UTC`")
     private boolean formatDateTimes = false;
 
-    @Parameter(names = {"-csc", "--custom-separator-characters"}, description = "Separators characters to be used to split JSON Pointers ($ref).")
-    private String customSeparatorCharacters = "#/.";
+    @Parameter(names = {"-rpd", "--ref-fragment-path-delimiters"}, description = "A string containing any characters that should act as path delimiters when resolving $ref fragments. By default, #, / and . are used in an attempt to support JSON Pointer and JSON Path.")
+    private String refFragmentPathDelimiters = "#/.";
     
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -422,8 +422,8 @@ public class Arguments implements GenerationConfig {
     }
 
     @Override
-    public String isCustomSeparatorCharacters() {
-        return customSeparatorCharacters;
+    public String getRefFragmentPathDelimiters() {
+        return refFragmentPathDelimiters;
     }
 
 }

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -168,6 +168,9 @@ public class Arguments implements GenerationConfig {
     
     @Parameter(names = { "-fdt", "--format-date-times" }, description = "Whether the fields of type `date-time` have the `@JsonFormat` annotation with pattern set to the default value of `yyyy-MM-dd'T'HH:mm:ss.SSS` and timezone set to default value of `UTC`")
     private boolean formatDateTimes = false;
+
+    @Parameter(names = {"-csc", "--custom-separator-characters"}, description = "Separators characters to be used to split JSON Pointers ($ref).")
+    private String customSeparatorCharacters = "#/.";
     
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -416,6 +419,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isFormatDateTimes() {
         return formatDateTimes;
+    }
+
+    @Override
+    public String isCustomSeparatorCharacters() {
+        return customSeparatorCharacters;
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -332,4 +332,12 @@ public class DefaultGenerationConfig implements GenerationConfig {
    public boolean isFormatDateTimes() {
       return false;
    }
+
+    /**
+     * @return "#/."
+     */
+    @Override
+    public String isCustomSeparatorCharacters() {
+        return "#/.";
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -337,7 +337,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
      * @return "#/."
      */
     @Override
-    public String isCustomSeparatorCharacters() {
+    public String getRefFragmentPathDelimiters() {
         return "#/.";
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class FragmentResolver {
 
-    public JsonNode resolve(JsonNode tree, String path, String separatorChars) {
+    public JsonNode resolve(JsonNode tree, String path, String refFragmentPathDelimiters) {
 
-        return resolve(tree, new ArrayList<String>(asList(split(path, separatorChars))));
+        return resolve(tree, new ArrayList<String>(asList(split(path, refFragmentPathDelimiters))));
 
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class FragmentResolver {
 
-    public JsonNode resolve(JsonNode tree, String path) {
+    public JsonNode resolve(JsonNode tree, String path, String separatorChars) {
 
-        return resolve(tree, new ArrayList<String>(asList(split(path, "#/."))));
+        return resolve(tree, new ArrayList<String>(asList(split(path, separatorChars))));
 
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -441,4 +441,11 @@ public interface GenerationConfig {
      */
     boolean isFormatDateTimes();
 
+    /**
+     * Gets the `customSeparatorCharacters` configuration option.
+     *
+     * @return The separator characters to be used to split JSON Pointers.
+     */
+    String isCustomSeparatorCharacters();
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -442,10 +442,11 @@ public interface GenerationConfig {
     boolean isFormatDateTimes();
 
     /**
-     * Gets the `customSeparatorCharacters` configuration option.
+     * Gets the `refFragmentPathDelimiters` configuration option.
      *
-     * @return The separator characters to be used to split JSON Pointers.
+     * @return A string containing any characters that should act as path delimiters when resolving $ref fragments.
+     *         By default, #, / and . are used in an attempt to support JSON Pointer and JSON Path.
      */
-    String isCustomSeparatorCharacters();
+    String getRefFragmentPathDelimiters();
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -41,14 +41,14 @@ public class SchemaStore {
      *            the id of the schema being created
      * @return a schema object containing the contents of the given path
      */
-    public synchronized Schema create(URI id) {
+    public synchronized Schema create(URI id, String separatorChars) {
 
         if (!schemas.containsKey(id)) {
 
             JsonNode content = contentResolver.resolve(removeFragment(id));
 
             if (id.toString().contains("#")) {
-                JsonNode childContent = fragmentResolver.resolve(content, '#' + id.getFragment());
+                JsonNode childContent = fragmentResolver.resolve(content, '#' + id.getFragment(), separatorChars);
                 schemas.put(id, new Schema(id, childContent, content));
             } else {
                 schemas.put(id, new Schema(id, content, content));
@@ -77,7 +77,7 @@ public class SchemaStore {
      * @return a schema object containing the contents of the given path
      */
     @SuppressWarnings("PMD.UselessParentheses")
-    public Schema create(Schema parent, String path) {
+    public Schema create(Schema parent, String path, String separatorChars) {
 
         if (!path.equals("#")) {
             // if path is an empty string then resolving it below results in jumping up a level. e.g. "/path/to/file.json" becomes "/path/to"
@@ -109,11 +109,11 @@ public class SchemaStore {
         }
 
         if (selfReferenceWithoutParentFile(parent, path) || substringBefore(stringId, "#").isEmpty()) {
-            schemas.put(id, new Schema(id, fragmentResolver.resolve(parent.getParentContent(), path), parent.getParentContent()));
+            schemas.put(id, new Schema(id, fragmentResolver.resolve(parent.getParentContent(), path, separatorChars), parent.getParentContent()));
             return schemas.get(id);
         }
 
-        return create(id);
+        return create(id, separatorChars);
 
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -39,16 +39,18 @@ public class SchemaStore {
      * 
      * @param id
      *            the id of the schema being created
+     * @param refFragmentPathDelimiters A string containing any characters
+     *                                  that should act as path delimiters when resolving $ref fragments.
      * @return a schema object containing the contents of the given path
      */
-    public synchronized Schema create(URI id, String separatorChars) {
+    public synchronized Schema create(URI id, String refFragmentPathDelimiters) {
 
         if (!schemas.containsKey(id)) {
 
             JsonNode content = contentResolver.resolve(removeFragment(id));
 
             if (id.toString().contains("#")) {
-                JsonNode childContent = fragmentResolver.resolve(content, '#' + id.getFragment(), separatorChars);
+                JsonNode childContent = fragmentResolver.resolve(content, '#' + id.getFragment(), refFragmentPathDelimiters);
                 schemas.put(id, new Schema(id, childContent, content));
             } else {
                 schemas.put(id, new Schema(id, content, content));
@@ -74,10 +76,12 @@ public class SchemaStore {
      *            the relative path of this schema (will be used to create a
      *            complete URI by resolving this path against the parent
      *            schema's id)
+     * @param refFragmentPathDelimiters A string containing any characters
+     *                                  that should act as path delimiters when resolving $ref fragments.
      * @return a schema object containing the contents of the given path
      */
     @SuppressWarnings("PMD.UselessParentheses")
-    public Schema create(Schema parent, String path, String separatorChars) {
+    public Schema create(Schema parent, String path, String refFragmentPathDelimiters) {
 
         if (!path.equals("#")) {
             // if path is an empty string then resolving it below results in jumping up a level. e.g. "/path/to/file.json" becomes "/path/to"
@@ -109,11 +113,11 @@ public class SchemaStore {
         }
 
         if (selfReferenceWithoutParentFile(parent, path) || substringBefore(stringId, "#").isEmpty()) {
-            schemas.put(id, new Schema(id, fragmentResolver.resolve(parent.getParentContent(), path, separatorChars), parent.getParentContent()));
+            schemas.put(id, new Schema(id, fragmentResolver.resolve(parent.getParentContent(), path, refFragmentPathDelimiters), parent.getParentContent()));
             return schemas.get(id);
         }
 
-        return create(id, separatorChars);
+        return create(id, refFragmentPathDelimiters);
 
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -328,7 +328,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 path = "#" + schema.getId().getFragment() + "/extends";
             }
 
-            Schema superSchema = ruleFactory.getSchemaStore().create(schema, path, ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
+            Schema superSchema = ruleFactory.getSchemaStore().create(schema, path, ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
 
             if (followRefs) {
                 superSchema = resolveSchemaRefsRecursive(superSchema);
@@ -342,7 +342,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
     private Schema resolveSchemaRefsRecursive(Schema schema) {
         JsonNode schemaNode = schema.getContent();
         if (schemaNode.has("$ref")) {
-            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
+            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             return resolveSchemaRefsRecursive(schema);
         }
         return schema;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -328,7 +328,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 path = "#" + schema.getId().getFragment() + "/extends";
             }
 
-            Schema superSchema = ruleFactory.getSchemaStore().create(schema, path);
+            Schema superSchema = ruleFactory.getSchemaStore().create(schema, path, ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
 
             if (followRefs) {
                 superSchema = resolveSchemaRefsRecursive(superSchema);
@@ -342,7 +342,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
     private Schema resolveSchemaRefsRecursive(Schema schema) {
         JsonNode schemaNode = schema.getContent();
         if (schemaNode.has("$ref")) {
-            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText());
+            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
             return resolveSchemaRefsRecursive(schema);
         }
         return schema;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -147,7 +147,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
     private JsonNode resolveRefs(JsonNode node, Schema parent) {
         if (node.has("$ref")) {
-            Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText(), ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
+            Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             JsonNode refNode = refSchema.getContent();
             return resolveRefs(refNode, parent);
         } else {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -147,7 +147,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
     private JsonNode resolveRefs(JsonNode node, Schema parent) {
         if (node.has("$ref")) {
-            Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText());
+            Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText(), ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
             JsonNode refNode = refSchema.getContent();
             return resolveRefs(refNode, parent);
         } else {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -56,7 +56,7 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
     public JType apply(String nodeName, JsonNode schemaNode, JClassContainer generatableType, Schema schema) {
 
         if (schemaNode.has("$ref")) {
-            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText());
+            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
             schemaNode = schema.getContent();
 
             if (schema.isGenerated()) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -56,7 +56,7 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
     public JType apply(String nodeName, JsonNode schemaNode, JClassContainer generatableType, Schema schema) {
 
         if (schemaNode.has("$ref")) {
-            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().isCustomSeparatorCharacters());
+            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             schemaNode = schema.getContent();
 
             if (schema.isGenerated()) {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
@@ -38,7 +38,7 @@ public class FragmentResolverTest {
         root.set("child2", root.objectNode());
         root.set("child3", root.objectNode());
 
-        assertThat((ObjectNode) resolver.resolve(root, "#"), is(sameInstance(root)));
+        assertThat((ObjectNode) resolver.resolve(root, "#", "#/."), is(sameInstance(root)));
 
     }
 
@@ -71,17 +71,17 @@ public class FragmentResolverTest {
         z.set("1", _1);
         z.set("2", _2);
 
-        assertThat((ObjectNode) resolver.resolve(root, "#/a"), is(sameInstance(a)));
-        assertThat((ObjectNode) resolver.resolve(root, "#/b"), is(sameInstance(b)));
-        assertThat((ObjectNode) resolver.resolve(root, "#/c"), is(sameInstance(c)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a", "#/."), is(sameInstance(a)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/b", "#/."), is(sameInstance(b)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/c", "#/."), is(sameInstance(c)));
 
-        assertThat((ObjectNode) resolver.resolve(root, "#/a/x"), is(sameInstance(x)));
-        assertThat((ObjectNode) resolver.resolve(root, "#/a/y"), is(sameInstance(y)));
-        assertThat((ObjectNode) resolver.resolve(root, "#/a/z"), is(sameInstance(z)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a/x", "#/."), is(sameInstance(x)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a/y", "#/."), is(sameInstance(y)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a/z", "#/."), is(sameInstance(z)));
 
-        assertThat((ObjectNode) resolver.resolve(root, "#/a/z/0"), is(sameInstance(_0)));
-        assertThat((ObjectNode) resolver.resolve(root, "#/a/z/1"), is(sameInstance(_1)));
-        assertThat((ObjectNode) resolver.resolve(root, "#/a/z/2"), is(sameInstance(_2)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a/z/0", "#/."), is(sameInstance(_0)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a/z/1", "#/."), is(sameInstance(_1)));
+        assertThat((ObjectNode) resolver.resolve(root, "#/a/z/2", "#/."), is(sameInstance(_2)));
 
     }
 
@@ -97,9 +97,9 @@ public class FragmentResolverTest {
         a.add(root.objectNode());
         a.add(root.objectNode());
 
-        assertThat(resolver.resolve(root, "#/a/0"), is(sameInstance(a.get(0))));
-        assertThat(resolver.resolve(root, "#/a/1"), is(sameInstance(a.get(1))));
-        assertThat(resolver.resolve(root, "#/a/2"), is(sameInstance(a.get(2))));
+        assertThat(resolver.resolve(root, "#/a/0", "#/."), is(sameInstance(a.get(0))));
+        assertThat(resolver.resolve(root, "#/a/1", "#/."), is(sameInstance(a.get(1))));
+        assertThat(resolver.resolve(root, "#/a/2", "#/."), is(sameInstance(a.get(2))));
 
     }
 
@@ -111,9 +111,9 @@ public class FragmentResolverTest {
         root.add(root.objectNode());
         root.add(root.objectNode());
 
-        assertThat(resolver.resolve(root, "#/0"), is(sameInstance(root.get(0))));
-        assertThat(resolver.resolve(root, "#/1"), is(sameInstance(root.get(1))));
-        assertThat(resolver.resolve(root, "#/2"), is(sameInstance(root.get(2))));
+        assertThat(resolver.resolve(root, "#/0", "#/."), is(sameInstance(root.get(0))));
+        assertThat(resolver.resolve(root, "#/1", "#/."), is(sameInstance(root.get(1))));
+        assertThat(resolver.resolve(root, "#/2", "#/."), is(sameInstance(root.get(2))));
 
     }
 
@@ -122,7 +122,7 @@ public class FragmentResolverTest {
 
         ObjectNode root = new ObjectMapper().createObjectNode();
 
-        resolver.resolve(root, "#/a/b/c");
+        resolver.resolve(root, "#/a/b/c", "#/.");
 
     }
 
@@ -134,7 +134,7 @@ public class FragmentResolverTest {
         ArrayNode a = root.arrayNode();
         root.set("a", a);
 
-        resolver.resolve(root, "#/a/b");
+        resolver.resolve(root, "#/a/b", "#/.");
 
     }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
@@ -36,7 +36,7 @@ public class SchemaStoreTest {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        Schema schema = new SchemaStore().create(schemaUri);
+        Schema schema = new SchemaStore().create(schemaUri, "#/.");
 
         assertThat(schema, is(notNullValue()));
         assertThat(schema.getId(), is(equalTo(schemaUri)));
@@ -51,8 +51,8 @@ public class SchemaStoreTest {
         URI addressSchemaUri = getClass().getResource("/schema/address.json").toURI();
 
         SchemaStore schemaStore = new SchemaStore();
-        Schema addressSchema = schemaStore.create(addressSchemaUri);
-        Schema enumSchema = schemaStore.create(addressSchema, "enum.json");
+        Schema addressSchema = schemaStore.create(addressSchemaUri, "#/.");
+        Schema enumSchema = schemaStore.create(addressSchema, "enum.json", "#/.");
 
         String expectedUri = removeEnd(addressSchemaUri.toString(), "address.json") + "enum.json";
 
@@ -68,8 +68,8 @@ public class SchemaStoreTest {
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
         SchemaStore schemaStore = new SchemaStore();
-        Schema addressSchema = schemaStore.create(schemaUri);
-        Schema selfRefSchema = schemaStore.create(addressSchema, "#");
+        Schema addressSchema = schemaStore.create(schemaUri, "#/.");
+        Schema selfRefSchema = schemaStore.create(addressSchema, "#", "#/.");
 
         assertThat(addressSchema, is(sameInstance(selfRefSchema)));
 
@@ -81,9 +81,9 @@ public class SchemaStoreTest {
         URI schemaUri = getClass().getResource("/schema/embeddedRef.json").toURI();
 
         SchemaStore schemaStore = new SchemaStore();
-        Schema topSchema = schemaStore.create(schemaUri);
-        Schema embeddedSchema = schemaStore.create(topSchema, "#/definitions/embedded");
-        Schema selfRefSchema = schemaStore.create(embeddedSchema, "#");
+        Schema topSchema = schemaStore.create(schemaUri, "#/.");
+        Schema embeddedSchema = schemaStore.create(topSchema, "#/definitions/embedded", "#/.");
+        Schema selfRefSchema = schemaStore.create(embeddedSchema, "#", "#/.");
 
         assertThat(topSchema, is(sameInstance(selfRefSchema)));
 
@@ -95,8 +95,8 @@ public class SchemaStoreTest {
         URI addressSchemaUri = getClass().getResource("/schema/address.json").toURI();
 
         SchemaStore schemaStore = new SchemaStore();
-        Schema addressSchema = schemaStore.create(addressSchemaUri);
-        Schema innerSchema = schemaStore.create(addressSchema, "#/properties/post-office-box");
+        Schema addressSchema = schemaStore.create(addressSchemaUri, "#/.");
+        Schema innerSchema = schemaStore.create(addressSchema, "#/properties/post-office-box", "#/.");
 
         String expectedUri = addressSchemaUri.toString() + "#/properties/post-office-box";
 
@@ -114,9 +114,9 @@ public class SchemaStoreTest {
 
         SchemaStore schemaStore = new SchemaStore();
 
-        Schema schema1 = schemaStore.create(schemaUri);
+        Schema schema1 = schemaStore.create(schemaUri, "#/.");
 
-        Schema schema2 = schemaStore.create(schemaUri);
+        Schema schema2 = schemaStore.create(schemaUri, "#/.");
 
         assertThat(schema1, is(sameInstance(schema2)));
 
@@ -130,7 +130,7 @@ public class SchemaStoreTest {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        Schema schema = new SchemaStore().create(schemaUri);
+        Schema schema = new SchemaStore().create(schemaUri, "#/.");
 
         schema.setJavaTypeIfEmpty(firstClass);
         assertThat(schema.getJavaType(), is(equalTo(firstClass)));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -27,7 +27,6 @@ import java.net.URISyntaxException;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
-import org.jsonschema2pojo.SourceType;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -58,7 +57,7 @@ public class SchemaRuleTest {
         JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
 
         final GenerationConfig mockGenerationConfig = mock(GenerationConfig.class);
-        when(mockGenerationConfig.isCustomSeparatorCharacters()).thenReturn("#/.");
+        when(mockGenerationConfig.getRefFragmentPathDelimiters()).thenReturn("#/.");
 
         TypeRule mockTypeRule = mock(TypeRule.class);
         when(mockRuleFactory.getTypeRule()).thenReturn(mockTypeRule);
@@ -116,7 +115,7 @@ public class SchemaRuleTest {
         schema.setJavaType(previouslyGeneratedType);
 
         final GenerationConfig mockGenerationConfig = mock(GenerationConfig.class);
-        when(mockGenerationConfig.isCustomSeparatorCharacters()).thenReturn("#/.");
+        when(mockGenerationConfig.getRefFragmentPathDelimiters()).thenReturn("#/.");
 
         when(mockRuleFactory.getSchemaStore()).thenReturn(schemaStore);
         when(mockRuleFactory.getGenerationConfig()).thenReturn(mockGenerationConfig);

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -24,8 +24,10 @@ import static org.mockito.Mockito.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
+import org.jsonschema2pojo.SourceType;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -55,9 +57,13 @@ public class SchemaRuleTest {
 
         JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
 
+        final GenerationConfig mockGenerationConfig = mock(GenerationConfig.class);
+        when(mockGenerationConfig.isCustomSeparatorCharacters()).thenReturn("#/.");
+
         TypeRule mockTypeRule = mock(TypeRule.class);
         when(mockRuleFactory.getTypeRule()).thenReturn(mockTypeRule);
         when(mockRuleFactory.getSchemaStore()).thenReturn(new SchemaStore());
+        when(mockRuleFactory.getGenerationConfig()).thenReturn(mockGenerationConfig);
 
         ArgumentCaptor<JsonNode> captureJsonNode = ArgumentCaptor.forClass(JsonNode.class);
         ArgumentCaptor<Schema> captureSchema = ArgumentCaptor.forClass(Schema.class);
@@ -106,10 +112,14 @@ public class SchemaRuleTest {
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
         SchemaStore schemaStore = new SchemaStore();
-        Schema schema = schemaStore.create(schemaUri);
+        Schema schema = schemaStore.create(schemaUri, "#/.");
         schema.setJavaType(previouslyGeneratedType);
 
+        final GenerationConfig mockGenerationConfig = mock(GenerationConfig.class);
+        when(mockGenerationConfig.isCustomSeparatorCharacters()).thenReturn("#/.");
+
         when(mockRuleFactory.getSchemaStore()).thenReturn(schemaStore);
+        when(mockRuleFactory.getGenerationConfig()).thenReturn(mockGenerationConfig);
 
         ObjectNode schemaNode = new ObjectMapper().createObjectNode();
         schemaNode.put("$ref", schemaUri.toString());

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -73,7 +73,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean usePrimitives
   FileFilter fileFilter
   boolean formatDateTimes
-  String customSeparatorCharacters
+  String refFragmentPathDelimiters
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -117,7 +117,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     targetVersion = '1.6'
     includeDynamicAccessors = false
     formatDateTimes = false
-    customSeparatorCharacters = "#/."
+    refFragmentPathDelimiters = "#/."
   }
 
   @Override
@@ -203,7 +203,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |targetVersion = ${targetVersion}
        |includeDynamicAccessors = ${includeDynamicAccessors}
        |formatDateTimes = ${formatDateTimes}
-       |customSeparatorCharacters = ${customSeparatorCharacters}
+       |refFragmentPathDelimiters = ${refFragmentPathDelimiters}
      """.stripMargin()
   }
   
@@ -211,8 +211,4 @@ public class JsonSchemaExtension implements GenerationConfig {
     return formatDateTimes;
   }
 
-  @Override
-  String isCustomSeparatorCharacters() {
-    return customSeparatorCharacters;
-  }
 }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -73,6 +73,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean usePrimitives
   FileFilter fileFilter
   boolean formatDateTimes
+  String customSeparatorCharacters
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -116,6 +117,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     targetVersion = '1.6'
     includeDynamicAccessors = false
     formatDateTimes = false
+    customSeparatorCharacters = "#/."
   }
 
   @Override
@@ -201,11 +203,16 @@ public class JsonSchemaExtension implements GenerationConfig {
        |targetVersion = ${targetVersion}
        |includeDynamicAccessors = ${includeDynamicAccessors}
        |formatDateTimes = ${formatDateTimes}
+       |customSeparatorCharacters = ${customSeparatorCharacters}
      """.stripMargin()
   }
   
   public boolean isFormatDateTimes() {
     return formatDateTimes;
   }
-  
+
+  @Override
+  String isCustomSeparatorCharacters() {
+    return customSeparatorCharacters;
+  }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomSeparatorCharactersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomSeparatorCharactersIT.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2010-2014 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertThat;
+
+public class CustomSeparatorCharactersIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void defaultCustomSeparatorCharactersIsStandard() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/nonStandardRef.json", "com.example",
+                config("customSeparatorCharacters", "#/"));
+
+        assertThat(resultsClassLoader.loadClass("com.example.Foo").getName(), is("com.example.Foo"));
+        assertThat(resultsClassLoader.loadClass("com.example.Bar").getName(), is("com.example.Bar"));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RefFragmentPathDelimitersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RefFragmentPathDelimitersIT.java
@@ -20,22 +20,18 @@ import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
-import static org.junit.Assert.assertThat;
 
-public class CustomSeparatorCharactersIT {
+public class RefFragmentPathDelimitersIT {
 
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
-    public void defaultCustomSeparatorCharactersIsStandard() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+    public void refFragmentPathDelimitersUsedInAPropertyIsReadSuccessfully() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/nonStandardRef.json", "com.example",
-                config("customSeparatorCharacters", "#/"));
+                config("refFragmentPathDelimiters", "#/"));
 
-        assertThat(resultsClassLoader.loadClass("com.example.Foo").getName(), is("com.example.Foo"));
-        assertThat(resultsClassLoader.loadClass("com.example.Bar").getName(), is("com.example.Bar"));
+        resultsClassLoader.loadClass("com.example.Foo");
     }
-
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/nonStandardRef.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/nonStandardRef.json
@@ -1,0 +1,27 @@
+{
+  "type" : "object",
+  "properties" : {
+    "foo" : {
+      "$ref" : "#/definitions/com.example.Foo"
+    }
+  },
+  "additionalProperties" : false,
+  "definitions" : {
+    "com.example.Foo" : {
+      "type" : "object",
+      "properties" : {
+        "bar" : {
+          "$ref" : "#/definitions/com.example.Bar"
+        }
+      }
+    },
+    "com.example.Bar" : {
+      "type" : "object",
+      "properties" : {
+        "test" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/nonStandardRef.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/nonStandardRef.json
@@ -11,14 +11,6 @@
       "type" : "object",
       "properties" : {
         "bar" : {
-          "$ref" : "#/definitions/com.example.Bar"
-        }
-      }
-    },
-    "com.example.Bar" : {
-      "type" : "object",
-      "properties" : {
-        "test" : {
           "type" : "string"
         }
       }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -579,6 +579,14 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      */
     private boolean formatDateTimes = false;
 
+    /**
+     * Separators characters to be used to split JSON Pointers ($ref).
+     *
+     * @parameter expression="${jsonschema2pojo.customSeparatorCharacters}" default-value="#/."
+     * @since 0.4.31
+     */
+    private String customSeparatorCharacters = "#/.";
+
     private FileFilter fileFilter = new AllFileFilter();
 
     /**
@@ -915,6 +923,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isFormatDateTimes() {
         return formatDateTimes;
+    }
+
+    @Override
+    public String isCustomSeparatorCharacters() {
+        return customSeparatorCharacters;
     }
 
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -580,12 +580,13 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean formatDateTimes = false;
 
     /**
-     * Separators characters to be used to split JSON Pointers ($ref).
+     * A string containing any characters that should act as path delimiters when resolving $ref fragments.
+     * By default, #, / and . are used in an attempt to support JSON Pointer and JSON Path.
      *
-     * @parameter expression="${jsonschema2pojo.customSeparatorCharacters}" default-value="#/."
+     * @parameter expression="${jsonschema2pojo.refFragmentPathDelimiters}" default-value="#/."
      * @since 0.4.31
      */
-    private String customSeparatorCharacters = "#/.";
+    private String refFragmentPathDelimiters = "#/.";
 
     private FileFilter fileFilter = new AllFileFilter();
 
@@ -926,8 +927,8 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     }
 
     @Override
-    public String isCustomSeparatorCharacters() {
-        return customSeparatorCharacters;
+    public String getRefFragmentPathDelimiters() {
+        return refFragmentPathDelimiters;
     }
 
 }


### PR DESCRIPTION
This adds the option suggested in #688, so nonstandard JSON Pointers found in $ref can be split correctly.

The option's default is the current value, `#/.`, so it should not break any existing projects.

Let me know if something is missing and needs to be done before merging, also let me know if the wording of the descriptions is a bit weird.