### PR TITLE
Don't prefix a class if it already exists without the prefix.

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -259,6 +259,16 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 if (isPrimitive(fqn, _package.owner())) {
                     throw new ClassAlreadyExistsException(primitiveType(fqn, _package.owner()));
                 }
+                JClass existingClass;
+
+                try {
+                    _package.owner().ref(Thread.currentThread().getContextClassLoader().loadClass(fqn));
+                    existingClass = resolveType(_package, fqn + (node.get("javaType").asText().contains("<") ? "<" + substringAfter(node.get("javaType").asText(), "<") : ""));
+
+                    throw new ClassAlreadyExistsException(existingClass);
+                } catch (ClassNotFoundException e) {
+
+                }
 
                 int index = fqn.lastIndexOf(".") + 1;
                 if (index >= 0 && index < fqn.length()) {
@@ -266,16 +276,18 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 }
 
                 try {
+
                     _package.owner().ref(Thread.currentThread().getContextClassLoader().loadClass(fqn));
-                    JClass existingClass = resolveType(_package, fqn + (node.get("javaType").asText().contains("<") ? "<" + substringAfter(node.get("javaType").asText(), "<") : ""));
+                    existingClass = resolveType(_package, fqn + (node.get("javaType").asText().contains("<") ? "<" + substringAfter(node.get("javaType").asText(), "<") : ""));
 
                     throw new ClassAlreadyExistsException(existingClass);
                 } catch (ClassNotFoundException e) {
-                    if (usePolymorphicDeserialization) {
-                        newType = _package.owner()._class(JMod.PUBLIC, fqn, ClassType.CLASS);
-                    } else {
-                        newType = _package.owner()._class(fqn);
-                    }
+
+                }
+                if (usePolymorphicDeserialization) {
+                    newType = _package.owner()._class(JMod.PUBLIC, fqn, ClassType.CLASS);
+                } else {
+                    newType = _package.owner()._class(fqn);
                 }
             } else {
                 if (usePolymorphicDeserialization) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/PrefixSuffixIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/PrefixSuffixIT.java
@@ -39,6 +39,14 @@ public class PrefixSuffixIT {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","Abstract"));
         resultsClassLoader.loadClass("com.example.AbstractPrimitiveProperties");
     }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void customClassPrefixExistingClass() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/objectPropertiesJavaType.json",
+                "com.example", config("classNamePrefix", "SomePrefix"));
+        resultsClassLoader.loadClass("org.jsonschema2pojo.SomePrefixNoopAnnotator");
+    }
     
     @Test
     public void noCapsCustomClassPrefix() throws ClassNotFoundException{
@@ -130,4 +138,5 @@ public class PrefixSuffixIT {
                 "com.example", config("classNamePrefix", "Prefix", "classNameSuffix","Suffix"));
         resultsClassLoader.loadClass("com.example.PrefixPrimitivePropertiesNoJavaTypeSuffix");
     }
+
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/objectPropertiesJavaType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/objectPropertiesJavaType.json
@@ -1,0 +1,9 @@
+{
+  "type" : "object",
+  "properties" : {
+    "a" : {
+      "javaType": "org.jsonschema2pojo.NoopAnnotator",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #650 
For the test I needed to use a package other than java.util, or a security exception is thrown.