### PR TITLE
Enable Travis CI for gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: clojure
+script: lein check
+branches:
+  only:
+    - gh-pages
+    - /.*/


### PR DESCRIPTION
Let Travis check Clojure syntax.

Travis ignores the gh-pages branch by default, we have to explicitly include it:

https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches