### PR TITLE
Fix compilation errors for non-string enums

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -255,19 +255,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
                 existingConstantNames.add(constantName);
 
                 JEnumConstant constant = _enum.enumConstant(constantName);
-
-                String typeName = type.unboxify().fullName();
-                if(typeName.equals("int")){ // integer
-                    constant.arg(JExpr.lit(value.intValue()));
-                } else if(typeName.equals("long")){ // integer-as-long
-                    constant.arg(JExpr.lit(value.longValue()));
-                } else if(typeName.equals("double")){ // number
-                    constant.arg(JExpr.lit(value.doubleValue()));
-                } else if(typeName.equals("boolean")){ // boolean
-                    constant.arg(JExpr.lit(value.booleanValue()));
-                } else {
-                    constant.arg(JExpr.lit(value.asText()));
-                }
+                constant.arg(DefaultRule.getDefaultValue(type, value));
                 ruleFactory.getAnnotator().enumConstant(constant, value.asText());
             }
         }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -19,7 +19,6 @@ package org.jsonschema2pojo.rules;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import org.jsonschema2pojo.Annotator;
@@ -27,6 +26,7 @@ import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -59,7 +59,7 @@ public class EnumRuleTest {
     public void applyGeneratesUniqueEnumNamesForMultipleEnumNodesWithSameName() {
 
         Answer<String> firstArgAnswer = new FirstArgAnswer<String>();
-        when(nameHelper.getFieldName(anyString(), any(JsonNode.class))).thenAnswer(firstArgAnswer);
+        when(nameHelper.getFieldName(anyString(), Matchers.any(JsonNode.class))).thenAnswer(firstArgAnswer);
         when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
         when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
@@ -98,6 +98,23 @@ public class DefaultIT {
     }
 
     @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void integerEnumPropertyHasCorrectDefaultBigIntegerValue() throws Exception {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example", config("useBigIntegers", true));
+        Class<?> c = resultsClassLoader.loadClass("com.example.Default");
+
+        Object instance = c.newInstance();
+        Class<Enum> enumClass = (Class<Enum>) c.getClassLoader().loadClass("com.example.Default$IntegerEnumWithDefault");
+        Method getter = c.getMethod("getIntegerEnumWithDefault");
+
+        Enum e = (Enum) getter.invoke(instance);
+        assertThat(e, is(equalTo(enumClass.getEnumConstants()[1])));
+        assertThat((BigInteger) e.getClass().getMethod("value").invoke(e), is(equalTo(new BigInteger("2"))));
+
+    }
+
+    @Test
     public void numberPropertyHasCorrectDefaultValue() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
         Object instance = classWithDefaults.newInstance();
@@ -117,6 +134,23 @@ public class DefaultIT {
         Object instance = c.newInstance();
         Method getter = c.getMethod("getNumberWithDefault");
         assertThat((BigDecimal) getter.invoke(instance), is(equalTo(new BigDecimal("1.337"))));
+
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void numberEnumPropertyHasCorrectDefaultBigDecimalValue() throws Exception {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/default/default.json", "com.example", config("useBigDecimals", true));
+        Class<?> c = resultsClassLoader.loadClass("com.example.Default");
+
+        Object instance = c.newInstance();
+        Class<Enum> enumClass = (Class<Enum>) c.getClassLoader().loadClass("com.example.Default$NumberEnumWithDefault");
+        Method getter = c.getMethod("getNumberEnumWithDefault");
+
+        Enum e = (Enum) getter.invoke(instance);
+        assertThat(e, is(equalTo(enumClass.getEnumConstants()[1])));
+        assertThat((BigDecimal) e.getClass().getMethod("value").invoke(e), is(equalTo(new BigDecimal("2.3"))));
 
     }
 
@@ -184,6 +218,34 @@ public class DefaultIT {
         Method getter = classWithDefaults.getMethod("getEnumWithDefault");
 
         assertThat((Enum) getter.invoke(instance), is(equalTo(enumClass.getEnumConstants()[1])));
+
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void integerEnumPropertyHasCorrectDefaultValue() throws Exception {
+
+        Object instance = classWithDefaults.newInstance();
+        Class<Enum> enumClass = (Class<Enum>) classWithDefaults.getClassLoader().loadClass("com.example.Default$IntegerEnumWithDefault");
+        Method getter = classWithDefaults.getMethod("getIntegerEnumWithDefault");
+
+        Enum e = (Enum) getter.invoke(instance);
+        assertThat(e, is(equalTo(enumClass.getEnumConstants()[1])));
+        assertThat((Integer) e.getClass().getMethod("value").invoke(e), is(equalTo(2)));
+
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void numberEnumPropertyHasCorrectDefaultValue() throws Exception {
+
+        Object instance = classWithDefaults.newInstance();
+        Class<Enum> enumClass = (Class<Enum>) classWithDefaults.getClassLoader().loadClass("com.example.Default$NumberEnumWithDefault");
+        Method getter = classWithDefaults.getMethod("getNumberEnumWithDefault");
+
+        Enum e = (Enum) getter.invoke(instance);
+        assertThat(e, is(equalTo(enumClass.getEnumConstants()[1])));
+        assertThat((Double) e.getClass().getMethod("value").invoke(e), is(equalTo(2.3D)));
 
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -18,12 +18,14 @@ package org.jsonschema2pojo.integration;
 
 import static java.lang.reflect.Modifier.*;
 import static org.hamcrest.Matchers.*;
-import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.hamcrest.core.IsInstanceOf;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
@@ -147,7 +149,20 @@ public class EnumIT {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void doubleEnumAtRootCreatesIntBackedEnum() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    public void intEnumAtRootCreatesBigIntegerBackedEnum() throws Exception {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/integerEnumAsRoot.json", "com.example", config("useBigIntegers", true));
+
+        Class<Enum> rootEnumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.enums.IntegerEnumAsRoot");
+
+        assertThat(rootEnumClass.isEnum(), is(true));
+        assertThat(rootEnumClass.getDeclaredMethod("fromValue", BigInteger.class), is(notNullValue()));
+        assertThat(isPublic(rootEnumClass.getModifiers()), is(true));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void doubleEnumAtRootCreatesDoubleBackedEnum() throws Exception {
 
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/doubleEnumAsRoot.json", "com.example");
 
@@ -158,6 +173,19 @@ public class EnumIT {
         assertThat(isPublic(rootEnumClass.getModifiers()), is(true));
     }
     
+    @Test
+    @SuppressWarnings("unchecked")
+    public void doubleEnumAtRootCreatesBigDecimalBackedEnum() throws Exception {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/doubleEnumAsRoot.json", "com.example", config("useBigDecimals", true));
+
+        Class<Enum> rootEnumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.enums.DoubleEnumAsRoot");
+
+        assertThat(rootEnumClass.isEnum(), is(true));
+        assertThat(rootEnumClass.getDeclaredMethod("fromValue", BigDecimal.class), is(notNullValue()));
+        assertThat(isPublic(rootEnumClass.getModifiers()), is(true));
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void enumWithEmptyStringAsValue() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/default/default.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/default/default.json
@@ -56,6 +56,16 @@
             "enum" : ["one", "two", "three"],
             "default" : "two"
         },
+        "integerEnumWithDefault" : {
+            "type" : "integer",
+            "enum" : [1, 2, 3],
+            "default" : 2
+        },
+        "numberEnumWithDefault" : {
+            "type" : "number",
+            "enum" : [1.2, 2.3, 3.14],
+            "default" : 2.3
+        },
         "arrayWithDefault" : {
             "type" : "array",
             "items" : {


### PR DESCRIPTION
Use the correct argument type for the factory method and the constructor of enums with non-string backing types: number and integer.