### PR TITLE
Add support for excluding fields from generated toString methods

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -88,6 +88,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean includeToString = true;
 
+    private String[] toStringExcludes = new String[] {};
+
     private AnnotationStyle annotationStyle = AnnotationStyle.JACKSON;
 
     private InclusionLevel inclusionLevel = InclusionLevel.NON_NULL;
@@ -806,6 +808,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isIncludeToString() {
         return includeToString;
+    }
+
+    @Override
+    public String[] getToStringExcludes() {
+        return toStringExcludes;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -228,6 +228,11 @@
         <td align="center" valign="top">No (default <code>true</code>)</td>
     </tr>
     <tr>
+        <td valign="top">toStringExcludes</td>
+        <td valign="top">A string containing fields to be excluded from toString generation.</td>
+        <td align="center" valign="top">No (default <code>""</code> (none))</td>
+    </tr>
+    <tr>
         <td valign="top">initializeCollections</td>
         <td valign="top">Whether to initialize Set and List fields as empty collections, or leave them as
             <code>null</code>.

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -87,6 +87,9 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-S", "--omit-tostring" }, description = "Omit the toString method in the generated Java types")
     private boolean omitToString = false;
+    
+    @Parameter(names = { "-tse", "--tostring-excludes" }, description = "The fields that should be excluded from generated toString methods")
+    private String toStringExcludes = "";
 
     @Parameter(names = { "-a", "--annotation-style" })
     private AnnotationStyle annotationStyle = AnnotationStyle.JACKSON;
@@ -266,6 +269,11 @@ public class Arguments implements GenerationConfig {
         return !omitToString;
     }
 
+    @Override
+    public String[] getToStringExcludes() {
+        return defaultString(toStringExcludes).split(" ");
+    }
+    
     @Override
     public AnnotationStyle getAnnotationStyle() {
         return annotationStyle;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -107,6 +107,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isIncludeToString() {
         return true;
     }
+    
+    /**
+     * @return no exclusions
+     */
+    @Override
+    public String[] getToStringExcludes() {
+        return new String[] {};
+    }
 
     /**
      * @return {@link AnnotationStyle#JACKSON2}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -137,7 +137,15 @@ public interface GenerationConfig {
      *         generated Java types.
      */
     boolean isIncludeToString();
-
+    
+    /**
+     * Gets the 'toStringExcludes' configuration option.
+     *
+     * @return An array of strings representing fields 
+     *         that should be excluded from toString methods
+     */
+    String[] getToStringExcludes();
+ 
     /**
      * Gets the 'annotationStyle' configuration option.
      *

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -51,6 +51,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean includeJsr303Annotations
   boolean includeJsr305Annotations
   boolean includeToString
+  String[] toStringExcludes
   boolean initializeCollections
   String outputEncoding
   boolean parcelable
@@ -93,6 +94,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeConstructors = false
     constructorsRequiredPropertiesOnly = false
     includeToString = true
+    toStringExcludes = [] as String[]
     annotationStyle = AnnotationStyle.JACKSON
     inclusionLevel = InclusionLevel.NON_NULL
     customAnnotator = NoopAnnotator.class
@@ -181,6 +183,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeHashcodeAndEquals = ${includeHashcodeAndEquals}
        |includeConstructors = ${includeConstructors}
        |includeToString = ${includeToString}
+       |toStringExcludes = ${Arrays.toString(toStringExcludes)}
        |annotationStyle = ${annotationStyle.toString().toLowerCase()}
        |inclusionLevel = ${InclusionLevel.toString() }
        |customAnnotator = ${customAnnotator.getName()}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringExcludesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringExcludesIT.java
@@ -1,0 +1,73 @@
+/**
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class IncludeToStringExcludesIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private void testConfig(Map<String,Object> config, String expectedResultTemplate) throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config);
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
+
+        // throws NoSuchMethodException if method is not found
+        Method toString = generatedType.getDeclaredMethod("toString");
+        try {
+            Object primitiveProperties = generatedType.newInstance();
+            Object result = toString.invoke(primitiveProperties);
+            assertEquals(String.format(expectedResultTemplate, Integer.toHexString(System.identityHashCode(primitiveProperties))), result);
+        } catch (Exception e) {
+            fail("Unable to invoke toString method: "+ e.getMessage());
+        }
+    }
+
+    @Test
+    public void beansIncludeAllToStringPropertiesByDefaultCL() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        testConfig(config(),
+                "com.example.PrimitiveProperties@%s[a=<null>,b=<null>,c=<null>,additionalProperties={}]");
+    }
+
+    @Test
+    public void beansIncludeAllToStringPropertiesByDefaultCL3() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        testConfig(config("useCommonsLang3", true),
+                "com.example.PrimitiveProperties@%s[a=<null>,b=<null>,c=<null>,additionalProperties={}]");
+    }
+
+    @Test
+    public void beansOmitToStringPropertiesWhenConfigIsSetCL() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        testConfig(config("toStringExcludes", new String[] {"b","c"}),
+                "com.example.PrimitiveProperties@%s[a=<null>,additionalProperties={}]");
+    }
+
+    @Test
+    public void beansOmitToStringPropertiesWhenConfigIsSetCL3() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        testConfig(config("useCommonsLang3", true,"toStringExcludes", new String[] {"b","c"}),
+                "com.example.PrimitiveProperties@%s[a=<null>,additionalProperties={}]");
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringIT.java
@@ -42,7 +42,7 @@ public class IncludeToStringIT {
 
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void beansOmitHashCodeAndEqualsWhenConfigIsSet() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+    public void beansOmitToStringWhenConfigIsSet() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("includeToString", false));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -215,6 +215,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.3.1
      */
     private boolean includeToString = true;
+    
+    /**
+     * The fields to be excluded from toString generation
+     *
+     * @parameter expression="${jsonschema2pojo.toStringExcludes}"
+     *            default-value=""
+     * @since 0.4.34
+     */
+    private String[] toStringExcludes = new String[] {};
 
     /**
      * The style of annotations to use in the generated Java types.
@@ -760,6 +769,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isIncludeToString() {
         return includeToString;
+    }
+    
+    @Override
+    public String[] getToStringExcludes() {
+        return toStringExcludes;
     }
 
     @Override


### PR DESCRIPTION
We need the ability to exclude certain fields ( for example passwords ) from the generated toString methods, as these toString methods are invoked by some logging statements.

This PR adds support for excluding fields by name from the toString method , using the builtin support for this feature in the CommonsLang(3) ReflectionToStringBuilder:

https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/builder/ReflectionToStringBuilder.html#toStringExclude-java.lang.Object-java.lang.String...-

A new optional string array parameter `toStringExcludes` is added to support this
