### PR TITLE
Fix for 725

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
@@ -57,6 +57,9 @@ public class RequiredArrayRule implements Rule<JDefinedClass, JDefinedClass> {
 
         for (Iterator<JsonNode> iterator = node.elements(); iterator.hasNext(); ) {
             String requiredArrayItem = iterator.next().asText();
+            if (requiredArrayItem.isEmpty()) {
+                continue;
+            }
 
             JsonNode propertyNode = null;
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredArray.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredArray.json
@@ -11,5 +11,5 @@
             "type" : "string"
         }
     },
-    "required": [ "requiredProperty"]
+    "required": [ "requiredProperty", ""]
 }


### PR DESCRIPTION
In my project I've hit the #725 issue - while working with `machine generated` schema, that contains an empty element in `required` array.

For verification purposes I've used slightly modified schema from #725 (added nonempty element to mix up empty and nonempty ones in array).

```
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "title": "Silly",
    "type":"object",
    "description":"silly example",
    "required": ["", "code", ""],
    "properties": {
        "code" : {
            "type":"string",
            "description":"blah blah blah"
        }
    }
}
```

Also the schema was changed `requiredArray.json` (added empty element to `required` array) to make integration test fail when run without the change.
