### PR TITLE
Fix for #602 : Writing to /Reading from Parcelable ignores superclass

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -158,6 +158,9 @@ public class ObjectRule implements Rule<JPackage, JType> {
         parcelableHelper.addWriteToParcel(jclass);
         parcelableHelper.addDescribeContents(jclass);
         parcelableHelper.addCreator(jclass);
+        parcelableHelper.addConstructorFromParcel(jclass);
+        // Add empty constructor
+        jclass.constructor(JMod.PUBLIC);
     }
 
     /**

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
@@ -55,4 +55,16 @@ public class ParcelableIT {
         assertThat(instance, is(equalTo(unparceledInstance)));
     }
 
+    @Test
+    public void parcelableSuperclassIsUnparceled() throws ClassNotFoundException, IOException {
+        Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-superclass-schema.json", "com.example", 
+                config("parcelable", true))
+                .loadClass("com.example.ParcelableSuperclassSchema");
+
+        Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-superclass-data.json"), parcelableType);
+        Parcel parcel = parcelableWriteToParcel(instance);
+        Parcelable unparceledInstance = parcelableReadFromParcel(parcel, parcelableType, instance);
+
+        assertThat(instance, is(equalTo(unparceledInstance)));
+    }
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-data.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-data.json
@@ -1,0 +1,8 @@
+{
+    "baseBooleanProperty": true,
+    "baseStringProperty": "basestring",
+    "baseIntegerProperty": 1234,
+    "booleanProperty" : true,
+    "stringProperty" : "aaa",
+    "integerProperty" : 10
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-schema-base.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-schema-base.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "baseBooleanProperty" : {
+            "type" : "boolean",
+            "default": false
+        },
+        "baseStringProperty" : {
+            "type" : "string"
+        },
+        "baseIntegerProperty" : {
+            "type" : "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-schema.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-schema.json
@@ -1,7 +1,7 @@
 {
     "type" : "object",
     "extends": {
-        "$ref": "parcelable-schema-base.json"
+        "$ref": "parcelable-superclass-schema-base.json"
     },
     "properties" : {
         "booleanProperty" : {

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-schema.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/parcelable/parcelable-superclass-schema.json
@@ -1,0 +1,21 @@
+{
+    "type" : "object",
+    "extends": {
+        "$ref": "parcelable-schema-base.json"
+    },
+    "properties" : {
+        "booleanProperty" : {
+            "type" : "boolean"
+        },
+        "stringProperty" : {
+            "type" : "string"
+        },
+        "integerProperty" : {
+            "type" : "integer"
+        },
+        "baseIntegerProperty": {
+            "title": "Tests overriding of property",
+            "type": "integer"
+        }
+    }
+}


### PR DESCRIPTION
When a generated `Parcelable` model subclasses another `Parcelable` model, the subclass needs to call its parent to allow the parent's properties to be written to/read from the `Parcel`
- Calls `super.writeToParcel` if the parent implements `Parcelable`
- Creates a protected constructor with a Parcel as a single parameter that reads from the `Parcel`, calling `super(in)` if the parent implements `Parcelable`
- Moved the read from `Parcel` code that used to be into `CREATOR#createFromParcel` to the newly created constructor; `createFromParcel` now just returns `new Ctor(in)` instead.
- Explicitely added an empty constructor since the newly added ctor shadows the default empty one 