### PR TITLE
Update recommended jackson version gradle plugin

### DIFF
--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -38,7 +38,7 @@ dependencies {
   // Required if generating JSR-303 annotations
   compile 'javax.validation:validation-api:1.1.0.CR2'
   // Required if generating Jackson 2 annotations
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.1.4'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.8.8'
   // Required if generating JodaTime data types
   compile 'joda-time:joda-time:2.2'
 }


### PR DESCRIPTION
The version suggested in the Gradle Plugin README is a version of jackson that doesn't have the `com.fasterxml.jackson.annotation.JsonPropertyDescription` annotation.
The new recommended version has the annotation.