### PR TITLE
Added support for formatting times

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -151,7 +151,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean formatDates = false;
 
+    private boolean formatTimes = false;
+
     private String customDatePattern;
+
+    private String customTimePattern;
 
     private String customDateTimePattern;
 
@@ -709,6 +713,17 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
+     * Sets the 'formatTimes' property of this class
+     *
+     * @param formatTimes
+     *            Whether the fields of type <code>time</code> have the <code>@JsonFormat</code> annotation
+     *            with pattern set to the default value of <code>HH:mm:ss.SSS</code>.
+     */
+    public void setFormatTimes(boolean formatTimes) {
+        this.formatTimes = formatTimes;
+    }
+
+    /**
      * Sets the 'formatDates' property of this class
      *
      * @param formatDates
@@ -729,6 +744,18 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
      */
     public void setCustomDatePattern(String customDatePattern) {
         this.customDatePattern = customDatePattern;
+    }
+
+    /**
+     * Sets the 'customTimePattern' property of this class
+     *
+     * @param customTimePattern
+     *            A custom pattern to use when formatting time fields during
+     *            serialization. Requires support from your JSON binding
+     *            library.
+     */
+    public void setCustomTimePattern(String customTimePattern) {
+        this.customTimePattern = customTimePattern;
     }
 
     /**
@@ -1017,8 +1044,18 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     @Override
+    public boolean isFormatTimes() {
+        return formatTimes;
+    }
+
+    @Override
     public String getCustomDatePattern() {
         return customDatePattern;
+    }
+
+    @Override
+    public String getCustomTimePattern() {
+        return customTimePattern;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -412,6 +412,12 @@
         <td align="center" valign="top">No (default <code>false</code>)</td>
     </tr>
     <tr>
+        <td valign="top">formatTimes</td>
+        <td valign="top">Whether the fields of type `time` are formatted during serialization with a default pattern of HH:mm:ss.SSS.
+        </td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+    </tr>
+    <tr>
         <td valign="top">formatDateTimes</td>
         <td valign="top">Whether the fields of type `date` are formatted during serialization with a default pattern of yyyy-MM-dd'T'HH:mm:ss.SSSZ.
         </td>
@@ -420,6 +426,12 @@
     <tr>
         <td valign="top">customDatePattern</td>
         <td valign="top">A custom pattern to use when formatting date fields during serialization. Requires support from your JSON binding library.
+        </td>
+        <td align="center" valign="top">No (default none)</td>
+    </tr>
+    <tr>
+        <td valign="top">customTimePattern</td>
+        <td valign="top">A custom pattern to use when formatting time fields during serialization. Requires support from your JSON binding library.
         </td>
         <td align="center" valign="top">No (default none)</td>
     </tr>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -173,11 +173,17 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-fd", "--format-dates" }, description = "Whether the fields of type `date` are formatted during serialization with a default pattern of `yyyy-MM-dd`")
     private boolean formatDates = false;
 
+    @Parameter(names = { "-ft", "--format-times" }, description = "Whether the fields of type `time` are formatted during serialization with a default pattern of `HH:mm:ss.SSS`")
+    private boolean formatTimes = false;
+
     @Parameter(names = { "-fdt", "--format-date-times" }, description = "Whether the fields of type `date-time` are formatted during serialization with a default pattern of `yyyy-MM-dd'T'HH:mm:ss.SSSZ` and timezone set to default value of `UTC`")
     private boolean formatDateTimes = false;
 
     @Parameter(names = { "-dp", "--date-pattern" }, description = "A custom pattern to use when formatting date fields during serialization")
     private String customDatePattern;
+
+    @Parameter(names = { "-tp", "--time-pattern" }, description = "A custom pattern to use when formatting time fields during serialization")
+    private String customTimePattern;
 
     @Parameter(names = { "-dtp", "--date-time-pattern" }, description = "A custom pattern to use when formatting date-time fields during serialization")
     private String customDateTimePattern;
@@ -449,6 +455,11 @@ public class Arguments implements GenerationConfig {
     }
 
     @Override
+    public boolean isFormatTimes() {
+        return formatTimes;
+    }
+
+    @Override
     public String getRefFragmentPathDelimiters() {
         return refFragmentPathDelimiters;
     }
@@ -456,6 +467,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public String getCustomDatePattern() {
         return customDatePattern;
+    }
+
+    @Override
+    public String getCustomTimePattern() {
+        return customTimePattern;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
@@ -100,6 +100,10 @@ public abstract class AbstractAnnotator implements Annotator {
     }
 
     @Override
+    public void timeField(JFieldVar field, JsonNode node) {
+    }
+
+    @Override
     public void dateTimeField(JFieldVar field, JsonNode node) {
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
@@ -183,5 +183,16 @@ public interface Annotator {
      */
     void dateField(JFieldVar field, JsonNode propertyNode);
 
+    /**
+     * Add the necessary annotations to a time field. For instance, to format
+     * the time in the expected style.
+     *
+     * @param field
+     *            the field that contains data that will be serialized
+     * @param propertyNode
+     *            the schema node defining this property
+     */
+    void timeField(JFieldVar field, JsonNode propertyNode);
+
     void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName);
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
@@ -143,4 +143,11 @@ public class CompositeAnnotator implements Annotator {
             annotator.dateField(field, propertyNode);
         }
    }
+
+    @Override
+    public void timeField(JFieldVar field, JsonNode propertyNode) {
+        for (Annotator annotator : annotators) {
+            annotator.timeField(field, propertyNode);
+        }
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -354,6 +354,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
     }
 
     /**
+     * @return <code>false</code>
+     */
+    @Override
+    public boolean isFormatTimes() {
+        return false;
+    }
+
+    /**
      * @return "#/."
      */
     @Override
@@ -363,6 +371,11 @@ public class DefaultGenerationConfig implements GenerationConfig {
 
     @Override
     public String getCustomDatePattern() {
+        return null;
+    }
+
+    @Override
+    public String getCustomTimePattern() {
         return null;
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -450,6 +450,15 @@ public interface GenerationConfig {
     boolean isFormatDates();
 
     /**
+     * Gets the `formatTimes` configuration option
+     *
+     * @return Whether the fields of type <code>time</code> have the
+     *         <code>@JsonFormat</code> annotation with pattern set to the
+     *         default value of <code>HH:mm:ss.SSS</code>
+     */
+    boolean isFormatTimes();
+
+    /**
      * Gets the `formatDateTime` configuration option
      *
      * @return Whether the fields of type <code>date-type</code> have the
@@ -465,6 +474,14 @@ public interface GenerationConfig {
      *         Requires support from your JSON binding library.
      */
     String getCustomDatePattern();
+
+    /**
+     * Gets the 'customTimePattern' configuration option
+     *
+     * @return The custom format that times will use when types are serialized.
+     *         Requires support from your JSON binding library.
+     */
+    String getCustomTimePattern();
 
     /**
      * Gets the 'customDateTimePattern' configuration option

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -176,6 +176,25 @@ public class Jackson2Annotator extends AbstractAnnotator {
     }
 
     @Override
+    public void timeField(JFieldVar field, JsonNode node) {
+
+        String pattern = null;
+        if (node.has("customTimePattern")) {
+            pattern = node.get("customTimePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomTimePattern())) {
+            pattern = getGenerationConfig().getCustomTimePattern();
+        } else if (getGenerationConfig().isFormatDates()) {
+            pattern = FormatRule.ISO_8601_TIME_FORMAT;
+        }
+
+        if (pattern != null && !field.type().fullName().equals("java.lang.String")) {
+            field.annotate(JsonFormat.class).param("shape", JsonFormat.Shape.STRING).param("pattern", pattern);
+        }
+    }
+
+    @Override
     public void dateTimeField(JFieldVar field, JsonNode node) {
         String timezone = node.has("customTimezone") ? node.get("customTimezone").asText() : "UTC";
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -43,6 +43,7 @@ import com.sun.codemodel.JType;
 public class FormatRule implements Rule<JType, JType> {
 
     public static String ISO_8601_DATE_FORMAT = "yyyy-MM-dd";
+    public static String ISO_8601_TIME_FORMAT = "HH:mm:ss.SSS";
     public static String ISO_8601_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     private final RuleFactory ruleFactory;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -144,6 +144,8 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
             ruleFactory.getAnnotator().dateTimeField(field, node);
         } else if ("date".equalsIgnoreCase(format)) {
             ruleFactory.getAnnotator().dateField(field, node);
+        } else if ("time".equalsIgnoreCase(format)) {
+            ruleFactory.getAnnotator().timeField(field, node);
         }
     }
 

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -136,12 +136,13 @@ jsonSchema2Pojo {
   // date type fields to generated Java types.
   useJodaDates = false
 
-  // Whether to add JsonFormat annotations when using Jackson 2 that cause format "date" and "date-time"
-  // fields to be formatted as yyyy-MM-dd and yyyy-MM-dd'T'HH:mm:ss.SSSZ respectively. To customize these
-  // patterns, use customDatePattern and customDateTimePattern config options or add these inside a schema
-  // to affect an individual field
+  // Whether to add JsonFormat annotations when using Jackson 2 that cause format "date", "time", and "date-time"
+  // fields to be formatted as yyyy-MM-dd, HH:mm:ss.SSS and yyyy-MM-dd'T'HH:mm:ss.SSSZ respectively. To customize these
+  // patterns, use customDatePattern, customTimePattern, and customDateTimePattern config options or add these inside a 
+  // schema to affect an individual field
   formatDateTimes = true
   formatDates = true
+  formatTimes = true
     
   // Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals, 
   // hashCode and toString methods.

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -75,8 +75,10 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean usePrimitives
   FileFilter fileFilter
   boolean formatDates
+  boolean formatTimes
   boolean formatDateTimes
   String customDatePattern
+  String customTimePattern
   String customDateTimePattern
   String refFragmentPathDelimiters
   SourceSortOrder sourceSortOrder
@@ -124,6 +126,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     targetVersion = '1.6'
     includeDynamicAccessors = false
     formatDates = false
+    formatTimes = false
     formatDateTimes = false
     refFragmentPathDelimiters = "#/."
     sourceSortOrder = SourceSortOrder.OS
@@ -217,8 +220,10 @@ public class JsonSchemaExtension implements GenerationConfig {
        |targetVersion = ${targetVersion}
        |includeDynamicAccessors = ${includeDynamicAccessors}
        |formatDates = ${formatDates}
+       |formatTimes = ${formatTimes}
        |formatDateTimes = ${formatDateTimes}
        |customDatePattern = ${customDatePattern}
+       |customTimePattern = ${customTimePattern}
        |customDateTimePattern = ${customDateTimePattern}
        |refFragmentPathDelimiters = ${refFragmentPathDelimiters}
        |sourceSortOrder = ${sourceSortOrder}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -44,20 +44,27 @@ public class CustomDateTimeFormatIT {
 
         classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_true", config(
                 "dateType", "java.util.Date",
+                "timeType", "java.util.Date",
                 "formatDateTimes", Boolean.TRUE,
-                "formatDates", Boolean.TRUE));
+                "formatDates", Boolean.TRUE,
+                "formatTimes", Boolean.TRUE));
 
         classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_false", config(
                 "dateType", "java.util.Date",
+                "timeType", "java.util.Date",
                 "formatDateTimes", Boolean.FALSE,
+                "formatDates", Boolean.FALSE,
                 "formatDates", Boolean.FALSE));
 
         classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_custom", config(
                 "dateType", "java.util.Date",
+                "timeType", "java.util.Date",
                 "customDatePattern", "yyyy",
+                "customTimePattern", "H:mm a",
                 "customDateTimePattern", "yyyy-MM-dd HH:mm X",
                 "formatDateTimes", Boolean.TRUE,
-                "formatDates", Boolean.TRUE));
+                "formatDates", Boolean.TRUE,
+                "formatTimes", Boolean.TRUE));
 
         ClassLoader loader = classSchemaRule.compile();
 
@@ -171,6 +178,16 @@ public class CustomDateTimeFormatIT {
     }
 
     @Test
+    public void testDefaultWhenFormatTimesConfigIsTrue() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setDefaultFormatTime", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"defaultFormatTime\":\"01:46:39.999\"}"));
+    }
+
+    @Test
     public void testDefaultWhenFormatDatesConfigIsFalse() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
         final Object instance = classWhenFormatDatesFalse.newInstance();
         classWhenFormatDatesFalse.getMethod("setDefaultFormatDate", Date.class).invoke(instance, new Date(999999999999L));
@@ -181,6 +198,16 @@ public class CustomDateTimeFormatIT {
     }
 
     @Test
+    public void testDefaultWhenFormatTimesConfigIsFalse() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesFalse.newInstance();
+        classWhenFormatDatesFalse.getMethod("setDefaultFormatTime", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"defaultFormatTime\":999999999999}"));
+    }
+
+    @Test
     public void testCustomDatePattern() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
         final Object instance = classWhenFormatDatesTrue.newInstance();
         classWhenFormatDatesTrue.getMethod("setCustomFormatCustomDate", Date.class).invoke(instance, new Date(999999999999L));
@@ -188,5 +215,15 @@ public class CustomDateTimeFormatIT {
         final String json = new ObjectMapper().writeValueAsString(instance);
 
         assertThat(json, is("{\"customFormatCustomDate\":\"09-09-2001\"}"));
+    }
+
+    @Test
+    public void testCustomTimePattern() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTime", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatCustomTime\":\"1:46 AM\"}"));
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -178,6 +178,11 @@ public class CustomAnnotatorIT {
         }
 
         @Override
+        public void timeField(JFieldVar field, JsonNode propertyNode) {
+            field.annotate(Deprecated.class);
+        }
+
+        @Override
         public void dateTimeField(JFieldVar field, JsonNode propertyNode) {
             field.annotate(Deprecated.class);
         }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
@@ -25,10 +25,19 @@
             "type" : "string",
             "format" : "date"
         },
+        "defaultFormatTime" : {
+            "type": "string",
+            "format": "time"
+        },
         "customFormatCustomDate" : {
             "type" : "string",
             "format" : "date",
             "customDatePattern" : "dd-MM-yyyy"
+        },
+        "customFormatCustomTime" : {
+            "type" : "string",
+            "format" : "time",
+            "customTimePattern" : "H:mm a"
         }
     }
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -589,6 +589,16 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean formatDates = false;
 
     /**
+     * Whether the fields of type `time` are formatted during serialization with
+     * a default pattern of HH:mm:ss.SSS.
+     *
+     * @parameter expression="${jsonschema2pojo.formatTimes}"
+     *            default-value="false"
+     * @since 0.4.33
+     */
+    private boolean formatTimes = false;
+
+    /**
      * Whether the fields of type `date` are formatted during serialization with
      * a default pattern of yyyy-MM-dd'T'HH:mm:ss.SSSZ.
      *
@@ -606,6 +616,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.4.33
      */
     private String customDatePattern;
+
+    /**
+     * A custom pattern to use when formatting time fields during serialization.
+     * Requires support from your JSON binding library.
+     *
+     * @parameter expression "${jsonschema2pojo.customTimePattern}"
+     * @since 0.4.33
+     */
+    private String customTimePattern;
 
     /**
      * A custom pattern to use when formatting date-time fields during
@@ -991,8 +1010,18 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     }
 
     @Override
+    public boolean isFormatTimes() {
+        return formatTimes;
+    }
+
+    @Override
     public String getCustomDatePattern() {
         return customDatePattern;
+    }
+
+    @Override
+    public String getCustomTimePattern() {
+        return customTimePattern;
     }
 
     @Override


### PR DESCRIPTION
The default format is HH:mm:ss.SSS and can be overridden by
specifying a customTimePattern property.