### PR TITLE
Fix for #742 : Generating 2 constructors

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -159,8 +159,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
         parcelableHelper.addDescribeContents(jclass);
         parcelableHelper.addCreator(jclass);
         parcelableHelper.addConstructorFromParcel(jclass);
-        // Add empty constructor
-        jclass.constructor(JMod.PUBLIC);
+        // #742 : includeConstructors will include the default constructor
+        if (!ruleFactory.getGenerationConfig().isIncludeConstructors()) {
+            // Add empty constructor
+            jclass.constructor(JMod.PUBLIC);
+        }
     }
 
     /**

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
@@ -57,8 +57,22 @@ public class ParcelableIT {
 
     @Test
     public void parcelableSuperclassIsUnparceled() throws ClassNotFoundException, IOException {
+        // Explicitely set includeConstructors to false if default value changes in the future
         Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-superclass-schema.json", "com.example", 
-                config("parcelable", true))
+                config("parcelable", true, "includeConstructors", false))
+                .loadClass("com.example.ParcelableSuperclassSchema");
+
+        Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-superclass-data.json"), parcelableType);
+        Parcel parcel = parcelableWriteToParcel(instance);
+        Parcelable unparceledInstance = parcelableReadFromParcel(parcel, parcelableType, instance);
+
+        assertThat(instance, is(equalTo(unparceledInstance)));
+    }
+
+    @Test
+    public void parcelableDefaultConstructorDoesNotConflict() throws ClassNotFoundException, IOException {
+        Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-superclass-schema.json", "com.example", 
+                config("parcelable", true, "includeConstructors", true))
                 .loadClass("com.example.ParcelableSuperclassSchema");
 
         Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-superclass-data.json"), parcelableType);


### PR DESCRIPTION
Fix regression introduced by #602 when configuration option `includeConstructors` is true : empty default constructor added twice.

Updated existing integration test and added another one; test Parcelable generation with the option on and off to ensure compilation and serialization/deserialization work properly.

Please let me know if there other configurations that may generate an empty constructor (I looked through the code and couldn't find any).