### PR TITLE
Use FilenameUtils to fix relative source paths (and remove extra underscore classes that appear when using a relative source path)

### DIFF
--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -217,7 +218,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * @since 0.3.1
      */
     private boolean includeToString = true;
-    
+
     /**
      * The fields to be excluded from toString generation
      *
@@ -715,12 +716,12 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * <li><code>java</code> (Generate .java source files)</li>
      * <li><code>scala</code> (Generate .scala source files, using scalagen)</li>
      * </ul>
-     * 
+     *
      * @parameter expression="${jsonschema2pojo.targetLanguage}" default-value="java"
      * @since 0.5.0
      */
     private String targetLanguage = "java";
-    
+
     /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
@@ -751,6 +752,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
 
         // verify source directories
         if (sourceDirectory != null) {
+            sourceDirectory = FilenameUtils.normalize(sourceDirectory);
             // verify sourceDirectory
             try {
                 URLUtil.parseURL(sourceDirectory);
@@ -759,9 +761,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
             }
         } else if (!isEmpty(sourcePaths)) {
             // verify individual source paths
-            for (String source : sourcePaths) {
+            for (int i = 0; i < sourcePaths.length; i++) {
+                sourcePaths[i] = FilenameUtils.normalize(sourcePaths[i]);
                 try {
-                    URLUtil.parseURL(source);
+                    URLUtil.parseURL(sourcePaths[i]);
                 } catch (IllegalArgumentException e) {
                     throw new MojoExecutionException(e.getMessage(), e);
                 }
@@ -865,7 +868,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     public boolean isIncludeToString() {
         return includeToString;
     }
-    
+
     @Override
     public String[] getToStringExcludes() {
         return toStringExcludes;
@@ -1117,7 +1120,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     public SourceSortOrder getSourceSortOrder() {
         return SourceSortOrder.valueOf(sourceSortOrder.toUpperCase());
     }
-    
+
     @Override
     public Language getTargetLanguage() {
         return Language.valueOf(targetLanguage.toUpperCase());


### PR DESCRIPTION
Use FilenameUtils to fix relative source paths in the maven plugin.  This in turn fixes the extra "underscore" classes that get generated with a relative source path.