### PR TITLE
Configuration option to force camel case

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -176,6 +176,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private Language targetLanguage = Language.JAVA;
     
+    private boolean fieldNamesToLowercase = false;
+    
     /**
      * Execute this task (it's expected that all relevant setters will have been
      * called by Ant to provide task configuration <em>before</em> this method
@@ -862,6 +864,15 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         this.targetLanguage = targetLanguage;
     }
 
+    /**
+     * Sets the 'fieldNamesToLowercase' property of this class
+     *
+     * @param fieldNamesToLowercase Whether there is a need to convert JSON field names to lowercase before generating property names. 
+     */
+    public void setFieldNamesToLowercase(boolean fieldNamesToLowercase) {
+        this.fieldNamesToLowercase = fieldNamesToLowercase;
+    }
+
     @Override
     public boolean isGenerateBuilders() {
         return generateBuilders;
@@ -1172,6 +1183,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public Language getTargetLanguage() {
         return targetLanguage;
+    }
+
+    @Override
+    public boolean isFieldNamesToLowercase() {
+        return fieldNamesToLowercase;
     }
     
 }

--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -176,7 +176,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private Language targetLanguage = Language.JAVA;
     
-    private boolean fieldNamesToLowercase = false;
+	private boolean forceCamelCase = false;
     
     /**
      * Execute this task (it's expected that all relevant setters will have been
@@ -865,12 +865,12 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
-     * Sets the 'fieldNamesToLowercase' property of this class
+     * Sets the 'forceCamelCase' property of this class
      *
-     * @param fieldNamesToLowercase Whether there is a need to convert JSON field names to lowercase before generating property names. 
+     * @param forceCamelCase Whether JSON field names should be converted to lowercase before generating class, property and method names. 
      */
-    public void setFieldNamesToLowercase(boolean fieldNamesToLowercase) {
-        this.fieldNamesToLowercase = fieldNamesToLowercase;
+    public void setForceCamelCase(boolean forceCamelCase) {
+        this.forceCamelCase = forceCamelCase;
     }
 
     @Override
@@ -1184,10 +1184,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public Language getTargetLanguage() {
         return targetLanguage;
     }
-
+    
     @Override
-    public boolean isFieldNamesToLowercase() {
-        return fieldNamesToLowercase;
+    public boolean isForceCamelCase() {
+        return forceCamelCase;
     }
     
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -145,6 +145,11 @@
         <td align="center" valign="top">No</td>
     </tr>
     <tr>
+        <td valign="top">forceCamelCase</td>
+        <td valign="top"> Whether JSON field names should be converted to lowercase before generating class, property and method names.</td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+    </tr>
+    <tr>
         <td valign="top">generateBuilders</td>
         <td valign="top">Whether to generate builder-style methods of the form <code>withXxx(value)</code> (that return
             <code>this</code>), alongside the standard, void-return setters.

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -214,7 +214,7 @@ public class Arguments implements GenerationConfig {
     private Language targetLanguage = Language.JAVA;
     
     @Parameter(names = { "-fnl", "--field-names-to-lowercase" }, description = "Whether there is a need to convert JSON field names to lowercase before generating property names. ")
-    private boolean fieldNamesToLowercase = false;
+    private boolean forceCamelCase = false;
     
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -537,7 +537,7 @@ public class Arguments implements GenerationConfig {
     }
 
     @Override
-    public boolean isFieldNamesToLowercase() {
-        return fieldNamesToLowercase;
+    public boolean isForceCamelCase() {
+        return forceCamelCase;
     }
 }

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -213,6 +213,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-tl", "--target-language" }, description = "The type of code that will be generated.  Available options are: JAVA or SCALA")
     private Language targetLanguage = Language.JAVA;
     
+    @Parameter(names = { "-fnl", "--field-names-to-lowercase" }, description = "Whether there is a need to convert JSON field names to lowercase before generating property names. ")
+    private boolean fieldNamesToLowercase = false;
+    
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
 
@@ -531,5 +534,10 @@ public class Arguments implements GenerationConfig {
     @Override
     public Language getTargetLanguage() {
         return targetLanguage;
+    }
+
+    @Override
+    public boolean isFieldNamesToLowercase() {
+        return fieldNamesToLowercase;
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -443,7 +443,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
      * @return <code>false</code>
      */
     @Override
-    public boolean isFieldNamesToLowercase() {
+    public boolean isForceCamelCase() {
         return false;
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -439,4 +439,11 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return Language.JAVA;
     }
     
+    /**
+     * @return <code>false</code>
+     */
+    @Override
+    public boolean isFieldNamesToLowercase() {
+        return false;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -565,5 +565,12 @@ public interface GenerationConfig {
      *         </ul>
      */
     Language getTargetLanguage();
+
+    /**
+     * Gets the `fieldNamesToLowercase` configuration option.
+     *
+     * @return Whether there is a need to convert JSON field names to lowercase before generating property names. 
+     */
+    boolean isFieldNamesToLowercase();
     
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -565,12 +565,12 @@ public interface GenerationConfig {
      *         </ul>
      */
     Language getTargetLanguage();
-
+    
     /**
-     * Gets the `fieldNamesToLowercase` configuration option.
+     * Gets the `forceCamelCase` configuration option.
      *
-     * @return Whether there is a need to convert JSON field names to lowercase before generating property names. 
+     * @return Whether JSON field names should be converted to lowercase before generating class, property and method names. 
      */
-    boolean isFieldNamesToLowercase();
+    boolean isForceCamelCase();
     
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -77,8 +77,8 @@ public class NameHelper {
      * @param name
      * @return lowercase name 
      */
-    private String ifUppercaseMakeLowercase(String name) {
-        if (generationConfig.isFieldNamesToLowercase())  {
+    private String makeLowercase(String name) {
+        if (generationConfig.isForceCamelCase())  {
             return name.toLowerCase();
         } else {
             return name;
@@ -96,7 +96,7 @@ public class NameHelper {
     public String getPropertyName(String jsonFieldName, JsonNode node) {
         jsonFieldName = getFieldName(jsonFieldName, node);
 
-        jsonFieldName = ifUppercaseMakeLowercase(jsonFieldName);
+        jsonFieldName = makeLowercase(jsonFieldName);
         
         jsonFieldName = replaceIllegalCharacters(jsonFieldName);
         jsonFieldName = normalizeName(jsonFieldName);
@@ -123,7 +123,7 @@ public class NameHelper {
     public String getSetterName(String propertyName, JsonNode node) {
         propertyName = getFieldName(propertyName, node);
 
-        propertyName = ifUppercaseMakeLowercase(propertyName);
+        propertyName = makeLowercase(propertyName);
         
         propertyName = replaceIllegalCharacters(propertyName);
         String setterName = "set" + capitalize(capitalizeTrailingWords(propertyName));
@@ -144,7 +144,7 @@ public class NameHelper {
      */
     public String getFieldName(String propertyName, JsonNode node) {
 
-        propertyName = ifUppercaseMakeLowercase(propertyName);
+        propertyName = makeLowercase(propertyName);
         
         if (node != null && node.has("javaName")) {
             propertyName = node.get("javaName").textValue();
@@ -164,7 +164,7 @@ public class NameHelper {
     public String getGetterName(String propertyName, JType type, JsonNode node) {
         propertyName = getFieldName(propertyName, node);
 
-        propertyName = ifUppercaseMakeLowercase(propertyName);
+        propertyName = makeLowercase(propertyName);
         
         String prefix = type.equals(type.owner()._ref(boolean.class)) ? "is" : "get";
         propertyName = replaceIllegalCharacters(propertyName);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -41,6 +41,7 @@ public class NameHelper {
     }
 
     public String normalizeName(String name) {
+        
         name = capitalizeTrailingWords(name);
 
         if (isDigit(name.charAt(0))) {
@@ -68,6 +69,21 @@ public class NameHelper {
     private String makeLowerCamelCase(String name) {
         return toLowerCase(name.charAt(0)) + name.substring(1);
     }
+    
+    /**
+     * If JSON field name is uppercase (ALL CAPS), convert it to lowercase and prepare it for future 
+     * transformations, including generating class and property names, as well as getter and setter methods.
+     *
+     * @param name
+     * @return lowercase name 
+     */
+    private String ifUppercaseMakeLowercase(String name) {
+        if (generationConfig.isFieldNamesToLowercase())  {
+            return name.toLowerCase();
+        } else {
+            return name;
+        }
+    }
 
     /**
      * Convert jsonFieldName into the equivalent Java fieldname by replacing
@@ -80,6 +96,8 @@ public class NameHelper {
     public String getPropertyName(String jsonFieldName, JsonNode node) {
         jsonFieldName = getFieldName(jsonFieldName, node);
 
+        jsonFieldName = ifUppercaseMakeLowercase(jsonFieldName);
+        
         jsonFieldName = replaceIllegalCharacters(jsonFieldName);
         jsonFieldName = normalizeName(jsonFieldName);
         jsonFieldName = makeLowerCamelCase(jsonFieldName);
@@ -105,6 +123,8 @@ public class NameHelper {
     public String getSetterName(String propertyName, JsonNode node) {
         propertyName = getFieldName(propertyName, node);
 
+        propertyName = ifUppercaseMakeLowercase(propertyName);
+        
         propertyName = replaceIllegalCharacters(propertyName);
         String setterName = "set" + capitalize(capitalizeTrailingWords(propertyName));
 
@@ -124,6 +144,8 @@ public class NameHelper {
      */
     public String getFieldName(String propertyName, JsonNode node) {
 
+        propertyName = ifUppercaseMakeLowercase(propertyName);
+        
         if (node != null && node.has("javaName")) {
             propertyName = node.get("javaName").textValue();
         }
@@ -142,6 +164,8 @@ public class NameHelper {
     public String getGetterName(String propertyName, JType type, JsonNode node) {
         propertyName = getFieldName(propertyName, node);
 
+        propertyName = ifUppercaseMakeLowercase(propertyName);
+        
         String prefix = type.equals(type.owner()._ref(boolean.class)) ? "is" : "get";
         propertyName = replaceIllegalCharacters(propertyName);
         String getterName = prefix + capitalize(capitalizeTrailingWords(propertyName));

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -89,6 +89,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   String refFragmentPathDelimiters
   SourceSortOrder sourceSortOrder
   Language targetLanguage
+  boolean forceCamelCase
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -142,6 +143,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     formatDateTimes = false
     refFragmentPathDelimiters = "#/."
     sourceSortOrder = SourceSortOrder.OS
+    forceCamelCase = false
   }
 
   @Override
@@ -193,7 +195,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   public void setTargetLangauge(String language) {
     targetLangauge = Langauge.valueOf(language.toUpperCase())
   }
-
+  
   @Override
   public String toString() {
     """|generateBuilders = ${generateBuilders}
@@ -249,6 +251,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |refFragmentPathDelimiters = ${refFragmentPathDelimiters}
        |sourceSortOrder = ${sourceSortOrder}
        |targetLanguage = ${targetLanguage}
+       |forceCamelCase = ${forceCamelCase}
      """.stripMargin()
   }
   

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
@@ -178,7 +178,7 @@ public class PropertiesIT {
 
     @Test
     public void classNamesAreNotAllCaps() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/PROPERTIES_ARE_ALL_CAPS.json", "com.example", config("fieldNamesToLowercase", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/PROPERTIES_ARE_ALL_CAPS.json", "com.example", config("forceCamelCase", true));
         
         Class<?> generatedRootType = resultsClassLoader.loadClass("com.example.PropertiesAreAllCaps");
         Object rootTypeInstance = generatedRootType.newInstance();
@@ -192,7 +192,7 @@ public class PropertiesIT {
     
     @Test
     public void propertyNamesAreNotAllCaps() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/PROPERTIES_ARE_ALL_CAPS.json", "com.example", config("fieldNamesToLowercase", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/PROPERTIES_ARE_ALL_CAPS.json", "com.example", config("forceCamelCase", true));
         Class<?> generatedType = resultsClassLoader.loadClass("com.example.PropertiesAreAllCaps");
 
         Object instance = generatedType.newInstance();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
@@ -175,4 +175,46 @@ public class PropertiesIT {
         assertThat(jsonified.has(" PropertyThreeWithSpace"), is(true));
         assertThat(jsonified.has("propertyFour"), is(true));
     }
+
+    @Test
+    public void classNamesAreNotAllCaps() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/PROPERTIES_ARE_ALL_CAPS.json", "com.example", config("fieldNamesToLowercase", true));
+        
+        Class<?> generatedRootType = resultsClassLoader.loadClass("com.example.PropertiesAreAllCaps");
+        Object rootTypeInstance = generatedRootType.newInstance();
+
+        Class<?> generatedNestedType = resultsClassLoader.loadClass("com.example.ObjectProperty");
+        Object nestedTypeInstance = generatedNestedType.newInstance();
+        
+        assertNotNull(rootTypeInstance);
+        assertNotNull(nestedTypeInstance);
+    }
+    
+    @Test
+    public void propertyNamesAreNotAllCaps() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/PROPERTIES_ARE_ALL_CAPS.json", "com.example", config("fieldNamesToLowercase", true));
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.PropertiesAreAllCaps");
+
+        Object instance = generatedType.newInstance();
+
+        new PropertyDescriptor("property1", generatedType).getWriteMethod().invoke(instance, "string1");
+        new PropertyDescriptor("property2", generatedType).getWriteMethod().invoke(instance, "string2");
+        new PropertyDescriptor("thirdProperty", generatedType).getWriteMethod().invoke(instance, "string3");
+        new PropertyDescriptor("threeWordProperty", generatedType).getWriteMethod().invoke(instance, 4);
+        new PropertyDescriptor("notAllCapsProperty", generatedType).getWriteMethod().invoke(instance, true);
+        
+        JsonNode jsonified = mapper.valueToTree(instance);
+
+        assertNotNull(generatedType.getDeclaredField("property1"));
+        assertNotNull(generatedType.getDeclaredField("property2"));
+        assertNotNull(generatedType.getDeclaredField("thirdProperty"));
+        assertNotNull(generatedType.getDeclaredField("threeWordProperty"));
+        assertNotNull(generatedType.getDeclaredField("notAllCapsProperty"));
+
+        assertThat(jsonified.has("PROPERTY1"), is(true));
+        assertThat(jsonified.has("PROPERTY_2"), is(true));
+        assertThat(jsonified.has("THIRD_PROPERTY"), is(true));
+        assertThat(jsonified.has("THREE_WORD_PROPERTY"), is(true));
+        assertThat(jsonified.has("not_ALL_CAPS_property"), is(true));
+    }
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/PROPERTIES_ARE_ALL_CAPS.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/properties/PROPERTIES_ARE_ALL_CAPS.json
@@ -1,0 +1,43 @@
+{
+	"type": "object",
+	"definitions": {
+		"SOME_OBJECT": {
+			"type": "object",
+			"properties": {
+				"OBJECT_FIELD_ONE": {
+					"type": "integer"
+				},
+				"OBJECT_FIELD_TWO": {
+					"type": "integer"
+				}
+			},
+			"required": [
+				"OBJECT_FIELD_ONE",
+				"OBJECT_FIELD_TWO"
+			]
+		}
+	},	
+    "properties" : {
+	    "PROPERTY1" : {
+	      "type" : "string"
+	    },
+	    "PROPERTY_2" : {
+	      "type" : "string"
+	    },
+	    "THIRD_PROPERTY" : {
+	      "type" : "string"
+	    },
+	    "THREE_WORD_PROPERTY" : {
+	      "type" : "integer"
+	    },
+	    "not_ALL_CAPS_property" : {
+	      "type" : "boolean"
+	    }, 
+	    "OBJECT_PROPERTY": {
+		  "type": "array",
+	      "items": {
+	        "$ref": "#/definitions/SOME_OBJECT"
+	      }
+	    }
+  }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -723,6 +723,14 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String targetLanguage = "java";
 
     /**
+     * Whether there is a need to convert JSON field names to lowercase before generating property names. 
+     *
+     * @parameter expression="${jsonschema2pojo.fieldNamesToLowercase}"
+     *            default-value="false"
+     */
+    private boolean fieldNamesToLowercase = false;
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -1124,5 +1132,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public Language getTargetLanguage() {
         return Language.valueOf(targetLanguage.toUpperCase());
+    }
+
+    @Override
+    public boolean isFieldNamesToLowercase() {
+        return fieldNamesToLowercase;
     }
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -723,12 +723,12 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String targetLanguage = "java";
 
     /**
-     * Whether there is a need to convert JSON field names to lowercase before generating property names. 
-     *
-     * @parameter expression="${jsonschema2pojo.fieldNamesToLowercase}"
+     * Whether JSON field names should be converted to lowercase before generating class, property and method names. 
+     *      
+     * @parameter expression="${jsonschema2pojo.forceCamelCase}"
      *            default-value="false"
      */
-    private boolean fieldNamesToLowercase = false;
+    private boolean forceCamelCase = false;
 
     /**
      * Executes the plugin, to read the given source and behavioural properties
@@ -1135,7 +1135,7 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     }
 
     @Override
-    public boolean isFieldNamesToLowercase() {
-        return fieldNamesToLowercase;
+    public boolean isForceCamelCase() {
+        return forceCamelCase;
     }
 }


### PR DESCRIPTION
Added configuration option to force camel case. It can be used when JSON field names (or schema name) contain uppercase sequences.

For example, if we have `EXAMPLE_SCHEMA.json` and `EXAMPLE_FIELD`, they become `EXAMPLESCHEMA.java` with property `eXAMPLEFIELD`, but we usually want something like `ExampleSchema.java` with property `exampleField`. 

What's needed to make this plugin work properly in these cases is just converting them to lowercase before generating class and field names, as well as getter and setter methods. 

That was added in this pull request, and the plugin now features a boolean configuration option 'forceCamelCase', _false_ by default.