### PR TITLE
add partial support of wildcards in "javaType" declarations

### DIFF
--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/TypeUtilTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/TypeUtilTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JCodeModel;
+
+public class TypeUtilTest {
+
+    @Test
+    public void testResolveTypeCanHandleWildcard() {
+        final JCodeModel codeModel = new JCodeModel();
+        final JClass _class = TypeUtil.resolveType(codeModel.rootPackage(), "java.util.List<?>");
+
+        assertThat(_class.erasure(), equalTo(codeModel.ref(List.class)));
+        assertThat(_class.typeParams(), emptyArray());
+        assertThat(_class.isParameterized(), is(Boolean.TRUE));
+        assertThat(_class.getTypeParameters(), hasSize(1));
+        assertThat(_class.getTypeParameters().get(0)._extends(), is(equalTo(codeModel.ref(Object.class))));
+    }
+
+    @Test
+    public void testResolveTypeCanHandleExtendsWildcard() {
+        final JCodeModel codeModel = new JCodeModel();
+        final JClass _class = TypeUtil.resolveType(codeModel.rootPackage(), "java.util.List<? extends java.lang.Number>");
+
+        assertThat(_class.erasure(), equalTo(codeModel.ref(List.class)));
+        assertThat(_class.typeParams(), emptyArray());
+        assertThat(_class.isParameterized(), is(Boolean.TRUE));
+        assertThat(_class.getTypeParameters(), hasSize(1));
+        assertThat(_class.getTypeParameters().get(0)._extends(), is(equalTo(codeModel.ref(Number.class))));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveTypeForSuperWildcardThrowsException() {
+        TypeUtil.resolveType(new JCodeModel().rootPackage(), "java.util.List<? super java.lang.String>");
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.Map;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
@@ -94,8 +95,36 @@ public class GenericTypeIT {
         assertThat(getterMethod.getGenericReturnType(), is(instanceOf(ParameterizedType.class)));
 
         Type[] typeArguments = ((ParameterizedType) getterMethod.getGenericReturnType()).getActualTypeArguments();
-        assertThat(typeArguments[0], is(equalTo((Type)String.class)));
-        assertThat(typeArguments[1], is(equalTo((Type)String[][].class)));
+        assertThat(typeArguments[0], is(equalTo((Type) String.class)));
+        assertThat(typeArguments[1], is(equalTo((Type) String[][].class)));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void genericTypeCanBeWildcard() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+
+        Method getterMethod = classWithGenericTypes.getMethod("getE");
+        assertThat((Class<Map>) getterMethod.getReturnType(), is(equalTo(Map.class)));
+        assertThat(getterMethod.getGenericReturnType(), is(instanceOf(ParameterizedType.class)));
+
+        Type[] typeArguments = ((ParameterizedType) getterMethod.getGenericReturnType()).getActualTypeArguments();
+        assertThat(typeArguments, arrayContaining(is(equalTo((Type) String.class)), is(instanceOf(WildcardType.class))));
+        assertThat(((WildcardType) typeArguments[1]).getUpperBounds(), arrayContaining(is((Type) Object.class)));
+        assertThat(((WildcardType) typeArguments[1]).getLowerBounds(), emptyArray());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void genericTypeCanBeExtendsWildcard() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+
+        Method getterMethod = classWithGenericTypes.getMethod("getF");
+        assertThat((Class<Map>) getterMethod.getReturnType(), is(equalTo(Map.class)));
+        assertThat(getterMethod.getGenericReturnType(), is(instanceOf(ParameterizedType.class)));
+
+        Type[] typeArguments = ((ParameterizedType) getterMethod.getGenericReturnType()).getActualTypeArguments();
+        assertThat(typeArguments, arrayContaining(is(equalTo((Type) String.class)), is(instanceOf(WildcardType.class))));
+        assertThat(((WildcardType) typeArguments[1]).getUpperBounds(), arrayContaining(is((Type) Number.class)));
+        assertThat(((WildcardType) typeArguments[1]).getLowerBounds(), emptyArray());
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/type/genericJavaType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/type/genericJavaType.json
@@ -15,6 +15,12 @@
         },
         "d" : {
             "javaType" : "java.util.Map<String,Double>"
+        },
+        "e" : {
+            "javaType" : "java.util.Map<String,?>"
+        },
+        "f" : {
+            "javaType" : "java.util.Map<String,? extends Number>"
         }
     }
 }


### PR DESCRIPTION
Added support for the following syntax in "javaType" declarations:
- `?`
- `? extends ...`

Unfortunately, due to limitations of [Sun JCodeModel](https://github.com/javaee/jaxb-codemodel/blob/master/codemodel/codemodel/src/main/java/com/sun/codemodel/JTypeWildcard.java) it is impossible to add support for `? super ...`

Maybe it is time to think about using a more comprehensive and better maintained [JCodeModel fork](https://github.com/phax/jcodemodel/)?