### PR TITLE
Replace commons-lang equals, hashCode, and toString with generated code

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Reference;
@@ -117,8 +118,6 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private boolean useJodaLocalDates = false;
 
     private boolean useJodaLocalTimes = false;
-
-    private boolean useCommonsLang3 = false;
 
     private boolean parcelable = false;
 
@@ -600,12 +599,9 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
      * Sets the 'useCommonsLang3' property of this class
      *
      * @param useCommonsLang3
-     *            Whether to use commons-lang 3.x imports instead of
-     *            commons-lang 2.x imports when adding equals, hashCode and
-     *            toString methods.
      */
     public void setUseCommonsLang3(boolean useCommonsLang3) {
-        this.useCommonsLang3 = useCommonsLang3;
+        super.log("useCommonsLang3 is deprecated. Please remove it from your config.", Project.MSG_WARN);
     }
 
     /**
@@ -1007,11 +1003,6 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseJodaLocalTimes() {
         return useJodaLocalTimes;
-    }
-
-    @Override
-    public boolean isUseCommonsLang3() {
-        return useCommonsLang3;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -339,13 +339,6 @@
         <td align="center" valign="top">No</td>
     </tr>
     <tr>
-        <td valign="top">useCommonsLang3</td>
-        <td valign="top">Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals,
-            hashCode and toString methods.
-        </td>
-        <td align="center" valign="top">No (default <code>false</code>)</td>
-    </tr>
-    <tr>
         <td valign="top">useDoubleNumbers</td>
         <td valign="top">Whether to use the java type <code>double</code> (or <code>Double</code>) instead of <code>float</code>
             (or <code>Float</code>) when representing the JSON Schema type 'number'.

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -138,7 +138,7 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-dt", "--date-class" }, description = "Specify date class")
     private String dateType;
 
-    @Parameter(names = { "-c3", "--commons-lang3" }, description = "Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals, hashCode and toString methods.")
+    @Parameter(names = { "-c3", "--commons-lang3" }, description = "Deprecated. Please remove it from your command-line arguments.")
     private boolean useCommonsLang3 = false;
 
     @Parameter(names = { "-pl", "--parcelable" }, description = "**EXPERIMENTAL** Whether to make the generated types 'parcelable' (for Android development).")
@@ -364,7 +364,6 @@ public class Arguments implements GenerationConfig {
         return useJodaLocalTimes;
     }
 
-    @Override
     public boolean isUseCommonsLang3() {
         return useCommonsLang3;
     }

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Jsonschema2PojoCLI.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Jsonschema2PojoCLI.java
@@ -45,6 +45,10 @@ public final class Jsonschema2PojoCLI {
 
         Arguments arguments = new Arguments().parse(args);
 
+        if (arguments.isUseCommonsLang3()) {
+            System.err.println("--commons-lang3 is deprecated. Please remove the argument from your command-line arguments.");
+        }
+
         Jsonschema2Pojo.generate(arguments);
     }
 

--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>jackson-mapper-asl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -210,14 +210,6 @@ public class DefaultGenerationConfig implements GenerationConfig {
      * @return <code>false</code>
      */
     @Override
-    public boolean isUseCommonsLang3() {
-        return false;
-    }
-
-    /**
-     * @return <code>false</code>
-     */
-    @Override
     public boolean isParcelable() {
         return false;
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -287,14 +287,6 @@ public interface GenerationConfig {
     boolean isUseJodaLocalTimes();
 
     /**
-     * Gets the 'useCommonsLang3' configuration option.
-     *
-     * @return Whether to use commons-lang 3.x imports instead of commons-lang
-     *         2.x imports when adding equals, hashCode and toString methods.
-     */
-    boolean isUseCommonsLang3();
-
-    /**
      * Gets the 'parcelable' configuration option.
      *
      * @return Whether to make the generated types 'parcelable' (for Android

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -33,8 +33,6 @@ repositories {
 }
 
 dependencies {
-  // Required if generating equals, hashCode, or toString methods
-  compile 'commons-lang:commons-lang:2.6'
   // Required if generating JSR-303 annotations
   compile 'javax.validation:validation-api:1.1.0.CR2'
   // Required if generating Jackson 2 annotations
@@ -152,10 +150,6 @@ jsonSchema2Pojo {
   formatDateTimes = true
   formatDates = true
   formatTimes = true
-    
-  // Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals, 
-  // hashCode and toString methods.
-  useCommonsLang3 = false
   
   // Whether to initialize Set and List fields as empty collections, or leave them as null.
   initializeCollections = true

--- a/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
@@ -45,8 +45,6 @@ dependencies {
     compile 'com.google.code.gson:gson:2.5'
     // Required if generating Moshi 1.x annotations
     compile 'com.squareup.moshi:moshi:1.5.0'
-    // Required if generating equals, hashCode, or toString methods
-    compile 'commons-lang:commons-lang:2.6'
     // Required if generating JSR-303 annotations
     compile 'javax.validation:validation-api:1.1.0.CR2'
     // Required if generating Jackson 2 annotations
@@ -139,10 +137,6 @@ jsonSchema2Pojo {
     // Whether to use {@link org.joda.time.DateTime} instead of {@link java.util.Date} when adding
     // date type fields to generated Java types.
     boolean useJodaDates = false
-
-    // Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals,
-    // hashCode and toString methods.
-    boolean useCommonsLang3 = false
 
     // Whether to initialize Set and List fields as empty collections, or leave them as null.
     boolean initializeCollections = true

--- a/jsonschema2pojo-gradle-plugin/example/android/lib/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/lib/build.gradle
@@ -44,8 +44,6 @@ dependencies {
     compile 'com.google.code.gson:gson:2.5'
     // Required if generating Moshi 1.x annotations
     compile 'com.squareup.moshi:moshi:1.5.0'
-    // Required if generating equals, hashCode, or toString methods
-    compile 'commons-lang:commons-lang:2.6'
     // Required if generating JSR-303 annotations
     compile 'javax.validation:validation-api:1.1.0.CR2'
     // Required if generating Jackson 2 annotations
@@ -137,10 +135,6 @@ jsonSchema2Pojo {
     // Whether to use {@link org.joda.time.DateTime} instead of {@link java.util.Date} when adding
     // date type fields to generated Java types.
     boolean useJodaDates = false
-
-    // Whether to use commons-lang 3.x imports instead of commons-lang 2.x imports when adding equals,
-    // hashCode and toString methods.
-    boolean useCommonsLang3 = false
 
     // Whether to initialize Set and List fields as empty collections, or leave them as null.
     boolean initializeCollections = true

--- a/jsonschema2pojo-gradle-plugin/example/java/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/java/build.gradle
@@ -20,7 +20,6 @@ repositories {
 }
 
 dependencies {
-  compile 'commons-lang:commons-lang:2.6'
   compile 'javax.validation:validation-api:1.1.0.CR2'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.1.4'
 

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaAndroidTask.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaAndroidTask.groovy
@@ -49,6 +49,10 @@ class GenerateJsonSchemaAndroidTask extends SourceTask {
     def configuration = project.jsonSchema2Pojo
     configuration.targetDirectory = outputDir
 
+    if (Boolean.TRUE.equals(configuration.properties.get("useCommonsLang3"))) {
+      logger.warn 'useCommonsLang3 is deprecated. Please remove it from your config.'
+    }
+
     logger.info 'Using this configuration:\n{}', configuration
     Jsonschema2Pojo.generate(configuration)
   }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaJavaTask.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaJavaTask.groovy
@@ -63,6 +63,10 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
 
   @TaskAction
   def generate() {
+    if (Boolean.TRUE.equals(configuration.properties.get("useCommonsLang3"))) {
+      logger.warn 'useCommonsLang3 is deprecated. Please remove it from your config.'
+    }
+
     logger.info 'Using this configuration:\n{}', configuration
     Jsonschema2Pojo.generate(configuration)
   }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -225,7 +225,6 @@ public class JsonSchemaExtension implements GenerationConfig {
        |dateTimeType = ${dateTimeType}
        |dateType = ${dateType}
        |timeType = ${timeType}
-       |useCommonsLang3 = ${useCommonsLang3}
        |parcelable = ${parcelable}
        |serializable = ${serializable}
        |initializeCollections = ${initializeCollections}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ToStringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ToStringIT.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright © 2017 David Ehrmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ToStringIT {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Rule
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void testScalars() throws Exception {
+        Class<?> scalarTypesClass = schemaRule.generateAndCompile("/schema/toString/scalarTypes.json", "com.example")
+                .loadClass("com.example.ScalarTypes");
+
+        assertEquals("com.example.ScalarTypes@<ref>[stringField=<null>,numberField=<null>,integerField=<null>,booleanField=<null>,nullField=<null>,bytesField=<null>]",
+                toStringAndReplaceAddress(Collections.emptyMap(), scalarTypesClass));
+
+        Map<String, Object> scalarTypes = new HashMap<String, Object>();
+        scalarTypes.put("stringField", "hello");
+        scalarTypes.put("numberField", 4.25);
+        scalarTypes.put("integerField", 42);
+        scalarTypes.put("booleanField", true);
+        scalarTypes.put("bytesField", "YWJj");
+        scalarTypes.put("nullField", null);
+
+        assertEquals("com.example.ScalarTypes@<ref>[stringField=hello,numberField=4.25,integerField=42,booleanField=true,nullField=<null>,bytesField={97,98,99}]",
+                toStringAndReplaceAddress(scalarTypes, scalarTypesClass));
+    }
+
+    @Test
+    public void testComposites() throws Exception {
+        Class<?> compositeTypesClass = schemaRule.generateAndCompile("/schema/toString/compositeTypes.json", "com.example")
+                .loadClass("com.example.CompositeTypes");
+
+        assertEquals("com.example.CompositeTypes@<ref>[mapField=<null>,objectField=<null>,arrayField=[],uniqueArrayField=[]]",
+                toStringAndReplaceAddress(Collections.emptyMap(), compositeTypesClass));
+
+        Map<String, Integer> intPair = new HashMap<String, Integer>();
+        intPair.put("l", 0);
+        intPair.put("r", 1);
+
+        Map<String, Object> compositeTypes = new HashMap<String, Object>();
+        compositeTypes.put("mapField", Collections.singletonMap("intPair", intPair));
+        compositeTypes.put("objectField", intPair);
+        compositeTypes.put("arrayField", Collections.singleton(intPair));
+        compositeTypes.put("uniqueArrayField", Collections.singleton(intPair));
+
+        assertEquals("com.example.CompositeTypes@<ref>"
+                        + "[mapField={intPair=com.example.IntPair@<ref>[l=0,r=1]}"
+                        + ",objectField=com.example.IntPair@<ref>[l=0,r=1]"
+                        + ",arrayField=[com.example.IntPair@<ref>[l=0,r=1]]"
+                        + ",uniqueArrayField=[com.example.IntPair@<ref>[l=0,r=1]]]",
+                toStringAndReplaceAddress(compositeTypes, compositeTypesClass));
+    }
+
+    @Test
+    public void testArrayOfArrays() throws Exception {
+        Class<?> arrayOfArraysClass = schemaRule.generateAndCompile("/schema/toString/arrayOfArrays.json", "com.example")
+                .loadClass("com.example.ArrayOfArrays");
+
+        Map<String, ?> arrayOfNullArrays = Collections.singletonMap("grid", Arrays.asList(null, null));
+
+        assertEquals("com.example.ArrayOfArrays@<ref>[grid=[null, null]]",
+                toStringAndReplaceAddress(arrayOfNullArrays, arrayOfArraysClass));
+
+        Map<String, ?> arrayOfArrays = Collections.singletonMap("grid", Arrays.asList(
+                Arrays.asList(1, 2, 3),
+                Arrays.asList(4, 5, 6),
+                Arrays.asList(7, 8, 9)));
+
+        assertEquals("com.example.ArrayOfArrays@<ref>[grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]",
+                toStringAndReplaceAddress(arrayOfArrays, arrayOfArraysClass));
+    }
+
+    @Test
+    public void testInheritance() throws Exception {
+        Class<?> squareClass = schemaRule.generateAndCompile("/schema/toString/square.json", "com.example")
+                .loadClass("com.example.Square");
+
+        Map<String, Object> square = new HashMap<String, Object>();
+        square.put("sides", 4);
+        square.put("diagonals", Arrays.asList(Math.sqrt(2.0), Math.sqrt(2.0)));
+        square.put("length", 1.0);
+
+        assertEquals("com.example.Square@<ref>[sides=4,diagonals=[1.4142135623730951, 1.4142135623730951],length=1.0]",
+                toStringAndReplaceAddress(square, squareClass));
+    }
+
+    private static String toStringAndReplaceAddress(Object object, Class<?> clazz) {
+        Object converted = OBJECT_MAPPER.convertValue(object, clazz);
+        String convertedString = null;
+
+        if (converted != null) {
+            convertedString = converted.toString();
+        }
+
+        if (convertedString != null) {
+            convertedString = convertedString.replaceAll("@[0-9a-f]+", "@<ref>");
+        }
+
+        return convertedString;
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLangRemovalIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLangRemovalIT.java
@@ -27,28 +27,17 @@ import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class CommonsLang3IT {
+public class CommonsLangRemovalIT {
 
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
-    public void hashCodeAndEqualsUseCommonsLang2ByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+    public void hashCodeAndEqualsDontUseCommonsLang() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
 
         File generatedOutputDirectory = schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example");
 
         assertThat(generatedOutputDirectory, not(containsText("org.apache.commons.lang3.")));
-        assertThat(generatedOutputDirectory, containsText("org.apache.commons.lang."));
-
-    }
-
-    @Test
-    public void hashCodeAndEqualsUseCommonsLang3() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
-
-        File generatedOutputDirectory = schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example",
-                config("useCommonsLang3", true));
-
         assertThat(generatedOutputDirectory, not(containsText("org.apache.commons.lang.")));
-        assertThat(generatedOutputDirectory, containsText("org.apache.commons.lang3."));
 
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringExcludesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringExcludesIT.java
@@ -48,26 +48,14 @@ public class IncludeToStringExcludesIT {
     }
 
     @Test
-    public void beansIncludeAllToStringPropertiesByDefaultCL() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+    public void beansIncludeAllToStringPropertiesByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
         testConfig(config(),
                 "com.example.PrimitiveProperties@%s[a=<null>,b=<null>,c=<null>,additionalProperties={}]");
     }
 
     @Test
-    public void beansIncludeAllToStringPropertiesByDefaultCL3() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
-        testConfig(config("useCommonsLang3", true),
-                "com.example.PrimitiveProperties@%s[a=<null>,b=<null>,c=<null>,additionalProperties={}]");
-    }
-
-    @Test
-    public void beansOmitToStringPropertiesWhenConfigIsSetCL() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+    public void beansOmitToStringProperties() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
         testConfig(config("toStringExcludes", new String[] {"b","c"}),
-                "com.example.PrimitiveProperties@%s[a=<null>,additionalProperties={}]");
-    }
-
-    @Test
-    public void beansOmitToStringPropertiesWhenConfigIsSetCL3() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
-        testConfig(config("useCommonsLang3", true,"toStringExcludes", new String[] {"b","c"}),
                 "com.example.PrimitiveProperties@%s[a=<null>,additionalProperties={}]");
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/ant/build.xml
+++ b/jsonschema2pojo-integration-tests/src/test/resources/ant/build.xml
@@ -40,7 +40,6 @@
                          useJodaDates="true"
                          useJodaLocalDates="true"
                          useJodaLocalTimes="true"
-                         useCommonsLang3="true"
                          parcelable="true"
                          initializeCollections="false">
             <classpath>

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/arrayOfArrays.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/arrayOfArrays.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "grid": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/compositeTypes.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/compositeTypes.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "mapField": {
+      "type": "object",
+      "javaType" : "java.util.Map<String,com.example.IntPair>"
+    },
+    "objectField": {
+      "$ref": "intPair.json"
+    },
+    "arrayField": {
+      "type": "array",
+      "items": {
+        "$ref": "intPair.json"
+      }
+    },
+    "uniqueArrayField": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "intPair.json"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/intPair.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/intPair.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "javaType": "com.example.IntPair",
+  "properties": {
+    "l": {
+      "type": "integer"
+    },
+    "r": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/polygon.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/polygon.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "sides": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/quadrilateral.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/quadrilateral.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "extends": {
+    "$ref": "polygon.json"
+  },
+  "properties": {
+    "diagonals": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "minItems": 2,
+        "maxItems": 2
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/scalarTypes.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/scalarTypes.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "stringField": {
+      "type": "string"
+    },
+    "numberField": {
+      "type": "number"
+    },
+    "integerField": {
+      "type": "integer"
+    },
+    "booleanField": {
+      "type": "boolean"
+    },
+    "nullField": {
+      "type": "null"
+    },
+    "bytesField": {
+      "type": "string",
+      "media" : {
+        "binaryEncoding": "base64"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/square.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/toString/square.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "extends": {
+    "$ref": "quadrilateral.json"
+  },
+  "properties": {
+    "length": {
+      "type": "number"
+    }
+  },
+  "additionalProperties": false
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -790,6 +790,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
             project.addCompileSourceRoot(outputDirectory.getPath());
         }
 
+        if (useCommonsLang3) {
+            getLog().warn("useCommonsLang3 is deprecated. Please remove it from your config.");
+        }
+
         try {
             Jsonschema2Pojo.generate(this);
         } catch (IOException e) {
@@ -952,7 +956,6 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         return useJodaLocalTimes;
     }
 
-    @Override
     public boolean isUseCommonsLang3() {
         return useCommonsLang3;
     }

--- a/jsonschema2pojo-maven-plugin/src/test/resources/example/pom.xml
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/example/pom.xml
@@ -38,11 +38,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.0.0</version>

--- a/jsonschema2pojo-maven-plugin/src/test/resources/filtered/pom.xml
+++ b/jsonschema2pojo-maven-plugin/src/test/resources/filtered/pom.xml
@@ -41,11 +41,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -397,11 +397,6 @@
                 <version>1.8.4</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.2.1</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>2.2.1</version>


### PR DESCRIPTION
commons-lang is a *relatively* large library for users to include just for adding `toString()`, `equals()`, and `hashCode()`. This removes that dependency and uses generated code instead.

It avoids calls like `Objects.hash()`, `Double.hashCode()`, and `Objects.equals()` that were added in later versions of Java.

Generated code looks something like this:
```
public class ComplexTypesArray {
    @Override
    public String toString() {
        StringBuilder sb = new StringBuilder();
        sb.append(ComplexTypesArray.class.getName())
                .append('@')
                .append(Integer.toHexString(System.identityHashCode(this)))
                .append('[');
        sb.append("additionalProperties");
        sb.append('=');
        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
        sb.append(',');
        if (sb.charAt((sb.length()- 1)) == ',') {
            sb.setCharAt((sb.length()- 1), ']');
        } else {
            sb.append(']');
        }
        return sb.toString();
    }

    @Override
    public int hashCode() {
        int result = 1;
        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
        return result;
    }

    @Override
    public boolean equals(Object other) {
        if (other == this) {
            return true;
        }
        if ((other instanceof ComplexTypesArray) == false) {
            return false;
        }
        ComplexTypesArray rhs = ((ComplexTypesArray) other);
        return ((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)
                && this.additionalProperties.equals(rhs.additionalProperties)));
    }
}
```