### PR TITLE
Fix failing tests

### DIFF
--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Locale;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
@@ -222,7 +223,7 @@ public class CustomDateTimeFormatIT {
         final Object instance = classWhenFormatDatesTrue.newInstance();
         classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTime", Date.class).invoke(instance, new Date(999999999999L));
 
-        final String json = new ObjectMapper().writeValueAsString(instance);
+        final String json = new ObjectMapper().setLocale(Locale.ENGLISH).writeValueAsString(instance);
 
         assertThat(json, is("{\"customFormatCustomTime\":\"1:46 AM\"}"));
     }

--- a/jsonschema2pojo-scalagen/src/test/scala/com/mysema/examples/SuperConstructors.java
+++ b/jsonschema2pojo-scalagen/src/test/scala/com/mysema/examples/SuperConstructors.java
@@ -1,6 +1,6 @@
 package com.mysema.examples;
 
-public class SuperConstructors extends SuperClass {
+public class SuperConstructors extends SuperConstructorsSuperClass {
     
     public SuperConstructors() {
         this("first", "last");
@@ -12,8 +12,8 @@ public class SuperConstructors extends SuperClass {
 
 }
 
-class SuperClass {
+class SuperConstructorsSuperClass {
     
-    public SuperClass(String first) {
+    public SuperConstructorsSuperClass(String first) {
     }
 }

--- a/jsonschema2pojo-scalagen/src/test/scala/com/mysema/scalagen/SerializationTest.scala
+++ b/jsonschema2pojo-scalagen/src/test/scala/com/mysema/scalagen/SerializationTest.scala
@@ -261,7 +261,7 @@ class SerializationTest extends AbstractParserTest {
   def SuperConstructors {
     val sources = toScala[SuperConstructors]
     assertContains(sources,
-      "class SuperConstructors(first: String, last: String) extends SuperClass(first) {")
+      "class SuperConstructors(first: String, last: String) extends SuperConstructorsSuperClass(first) {")
   }
 
   @Test


### PR DESCRIPTION
There were two tests failing:
* one in SerializationTest, because OSX's case insensitive file system found a different Superclass definition than the SuperClass it was meant to find
* one in CustomDateTimeFormatIT because the JSON serializer was using the system locale and the test was expecting results with english locale.