### PR TITLE
Inconsistencies in Maven POMs

### DIFF
--- a/jsonschema2pojo-scalagen/pom.xml
+++ b/jsonschema2pojo-scalagen/pom.xml
@@ -15,9 +15,7 @@
 
     <properties>
         <commons.collections.version>4.01</commons.collections.version>
-        <commons.lang.version>3.0.1</commons.lang.version>
         <querydsl.version>2.3.0</querydsl.version>
-        <scala.version>2.11.6</scala.version>
         <scala.repoVersion>2.11</scala.repoVersion>
         <scalaArm.scalaVersion>2.11</scalaArm.scalaVersion>
         <scalaArm.libVersion>1.4</scalaArm.libVersion>
@@ -29,7 +27,6 @@
         <dependency>
             <groupId>com.google.code.javaparser</groupId>
             <artifactId>javaparser</artifactId>
-            <version>1.0.10</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.collections</groupId>
@@ -39,25 +36,21 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons.lang.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
         </dependency>
 
         <!-- Scala -->
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -66,8 +59,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.12</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -276,11 +286,6 @@
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
                 <version>1.30</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson2x.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <gson.version>2.5</gson.version>
         <moshi.version>1.5.0</moshi.version>
         <jackson2x.version>2.9.1</jackson2x.version>
+        <scala.version>2.11.6</scala.version>
     </properties>
 
     <build>
@@ -331,7 +332,12 @@
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
-                <version>2.11.6</version>
+                <version>${scala.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-compiler</artifactId>
+                <version>${scala.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.codemodel</groupId>


### PR DESCRIPTION
Looks like there are dependency version inconsistencies in the latest POM:

```
Dependency convergence error for org.apache.commons:commons-lang3:3.0.1 paths to dependency are:
  +-org.jsonschema2pojo:jsonschema2pojo-core:0.5.1
    +-org.jsonschema2pojo:jsonschema2pojo-scalagen:0.5.1
      +-org.apache.commons:commons-lang3:3.0.1
and
  +-org.jsonschema2pojo:jsonschema2pojo-core:0.5.1
    +-org.apache.commons:commons-lang3:3.2.1
```

It appears that the scalagen module uses a different version of commons-lang3 than the core module.

The below commits should address this and also a few minor tweaks to the POM to better use managed dependencies from the root POM.