### PR TITLE
#832 Changed maven central repo listing id key to default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
 
     <repositories>
         <repository>
-            <id>maven-central</id>
+            <id>central</id>
             <url>http://repo1.maven.org/maven2</url>
         </repository>
         <repository>


### PR DESCRIPTION
As far as I understand the need for the explicit repository, this could be a solution in strict nexus/artifactory environments.