### PR TITLE
Implement "suppressWarnings" and "holderClass" configuration parameters.

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -177,6 +177,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private Language targetLanguage = Language.JAVA;
 
+    private boolean suppressWarnings = false;
+
+    private String holderClass = null;
+
     /**
      * Execute this task (it's expected that all relevant setters will have been
      * called by Ant to provide task configuration <em>before</em> this method
@@ -867,9 +871,19 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public void setSourceSortOrder(SourceSortOrder sourceSortOrder) {
         this.sourceSortOrder = sourceSortOrder;
     }
-    
+
     public void setTargetLanguage(Language targetLanguage) {
         this.targetLanguage = targetLanguage;
+    }
+
+    public void setSuppressWarnings(final boolean suppressWarnings)
+    {
+        this.suppressWarnings = suppressWarnings;
+    }
+
+    public void setHolderClass(String holderClass)
+    {
+        this.holderClass = isNotBlank(holderClass) ? holderClass : null;
     }
 
     @Override
@@ -1178,10 +1192,22 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public SourceSortOrder getSourceSortOrder() {
         return sourceSortOrder;
     }
-    
+
     @Override
     public Language getTargetLanguage() {
         return targetLanguage;
     }
-    
+
+    @Override
+    public boolean isSuppressWarnings()
+    {
+        return suppressWarnings;
+    }
+
+    @Override
+    public String getHolderClass()
+    {
+        return holderClass;
+    }
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -107,7 +107,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isIncludeToString() {
         return true;
     }
-    
+
     /**
      * @return no exclusions
      */
@@ -425,7 +425,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public SourceSortOrder getSourceSortOrder() {
         return SourceSortOrder.OS;
     }
-    
+
     /**
      * @return {@link Language#JAVA}
      */
@@ -433,5 +433,17 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public Language getTargetLanguage() {
         return Language.JAVA;
     }
-    
+
+    @Override
+    public boolean isSuppressWarnings()
+    {
+        return false;
+    }
+
+    @Override
+    public String getHolderClass()
+    {
+        return null;
+    }
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -137,15 +137,15 @@ public interface GenerationConfig {
      *         generated Java types.
      */
     boolean isIncludeToString();
-    
+
     /**
      * Gets the 'toStringExcludes' configuration option.
      *
-     * @return An array of strings representing fields 
+     * @return An array of strings representing fields
      *         that should be excluded from toString methods
      */
     String[] getToStringExcludes();
- 
+
     /**
      * Gets the 'annotationStyle' configuration option.
      *
@@ -555,7 +555,7 @@ public interface GenerationConfig {
 
     /**
      * Gets the 'targetLanguage' configuration option.
-     * 
+     *
      * @return The type of code that will be generated.
      *         <p>
      *         Supported values:
@@ -565,5 +565,23 @@ public interface GenerationConfig {
      *         </ul>
      */
     Language getTargetLanguage();
-    
+
+    /**
+     * Gets the 'suppressWarnings' configuration option.
+     *
+     * @return Whether the generated classes will have a SuppressWarnings
+     * annotation set.
+     */
+    boolean isSuppressWarnings();
+
+    /**
+     * Gets the 'holderClass' configuration option.
+     *
+     * @return A class that will be wrapped around every generated field.
+     * Setting this to null disables the use of a holder class.
+     * If a holder class is used and generation of setters has been enabled,
+     * an additional "clear" method will be generated to clear a previously
+     * set value.
+     */
+    String getHolderClass();
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -317,6 +317,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         ruleFactory.getAnnotator().propertyInclusion(newType, node);
 
+        if (ruleFactory.getGenerationConfig().isSuppressWarnings())
+        {
+            newType.annotate(SuppressWarnings.class).param("value", "all");
+        }
+
         return newType;
 
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -112,6 +112,23 @@ public class NameHelper {
         return jsonFieldName;
     }
 
+    private String getMethodName(String prefix, String propertyName, JsonNode node) {
+        propertyName = getPropertyNameForAccessor(propertyName, node);
+
+        String methodName;
+        if (propertyName.length() > 1 && Character.isUpperCase(propertyName.charAt(1))) {
+            methodName = prefix + propertyName;
+        } else {
+            methodName = prefix + capitalize(propertyName);
+        }
+
+        if (methodName.equals(prefix + "Class")) {
+            methodName = prefix + "Class_";
+        }
+
+        return methodName;
+    }
+
     /**
      * Generate setter method name for property.
      *
@@ -120,22 +137,18 @@ public class NameHelper {
      * @return
      */
     public String getSetterName(String propertyName, JsonNode node) {
-        propertyName = getPropertyNameForAccessor(propertyName, node);
+        return getMethodName("set", propertyName, node);
+    }
 
-        String prefix = "set";
-
-        String setterName;
-        if (propertyName.length() > 1 && Character.isUpperCase(propertyName.charAt(1))) {
-            setterName = prefix + propertyName;
-        } else {
-            setterName = prefix + capitalize(propertyName);
-        }
-
-        if (setterName.equals("setClass")) {
-            setterName = "setClass_";
-        }
-
-        return setterName;
+    /**
+     * Generate clearer method name for property.
+     *
+     * @param propertyName
+     * @param node
+     * @return
+     */
+    public String getClearerName(String propertyName, JsonNode node) {
+        return getMethodName("clear", propertyName, node);
     }
 
     /**

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -90,6 +90,8 @@ public class JsonSchemaExtension implements GenerationConfig {
   String refFragmentPathDelimiters
   SourceSortOrder sourceSortOrder
   Language targetLanguage
+  boolean suppressWarnings
+  String holderClass
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -144,6 +146,8 @@ public class JsonSchemaExtension implements GenerationConfig {
     formatDateTimes = false
     refFragmentPathDelimiters = "#/."
     sourceSortOrder = SourceSortOrder.OS
+    suppressWarnings = false
+    holderClass = ''
   }
 
   @Override
@@ -251,6 +255,8 @@ public class JsonSchemaExtension implements GenerationConfig {
        |refFragmentPathDelimiters = ${refFragmentPathDelimiters}
        |sourceSortOrder = ${sourceSortOrder}
        |targetLanguage = ${targetLanguage}
+       |suppressWarnings = ${suppressWarnings}
+       |holderClass = ${holderClass}
      """.stripMargin()
   }
   

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -729,6 +729,27 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String targetLanguage = "java";
 
     /**
+     * Whether a SuppressWarnings annotation will be added to generated Java classes or not.
+     *
+     * @parameter expression="${jsonschema2pojo.suppressWarnings}" default-value="false"
+     * @since 1.0.0-alpha3
+     */
+    private boolean suppressWarnings = false;
+
+    /**
+     * Defines a holder class that will be wrapped around every generated field.
+     * An empty value disables the use of a holder class.
+     *
+     * If a holder class is used and generation of setters has been enabled,
+     * an additional "clear" method will be generated to clear a previously
+     * set value.
+     *
+     * @parameter expression="${jsonschema2pojo.holderClass}" default-value=""
+     * @since 1.0.0-alpha3
+     */
+    private String holderClass;
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -1136,5 +1157,17 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public Language getTargetLanguage() {
         return Language.valueOf(targetLanguage.toUpperCase());
+    }
+
+    @Override
+    public boolean isSuppressWarnings()
+    {
+        return suppressWarnings;
+    }
+
+    @Override
+    public String getHolderClass()
+    {
+        return holderClass == null || holderClass.isEmpty() ? null : holderClass;
     }
 }


### PR DESCRIPTION
Hi. I'd like to contribute two new features to the project.

## suppressWarnings

Default value: false

When set, adds a SuppressWarnings annotation to generated classes.

If I don't do this, I have to keep removing the warnings from the list in my IDE every time the project is built.

## holderClass

Default value: _&lt;empty&gt;_

Causes all generated properties to be wrapped around the chosen holder class.

My use case is that I want to distinguish between null values and values that weren't present in the original JSON message prior to conversion to a Java object. This approach allows me to do that.

With this option enabled, generated classes may end up looking like this:

```java
import com.google.gson.annotations.Expose;
import com.google.gson.annotations.SerializedName;
import com.foo.bar.SimpleHolder;


/**
 * PersonEntity
 * 
 */
@SuppressWarnings("all")
public class Person {

    @SerializedName("firstName")
    @Expose
    private SimpleHolder<String> firstName;

    public String getFirstName() {
        return firstName.get();
    }

    public void setFirstName(String firstName) {
        this.firstName = new SimpleHolder<String>(firstName);
    }

    public void clearFirstName() {
        this.firstName = null;
    }

}
```

I'm using GSON for my JSON conversion. It's been extended with a TypeAdapter that wraps/unwraps SimpleHolder objects for me.

The end result is that the value of ```firstName``` will be ```null``` if the original JSON content did not have the field, or a ```SimpleHolder``` containing ```null``` if the original JSON content did have the field, but its value was ```null```.

If the developer calls ```getFirstName``` it will either return null (if the JSON content the object was derived from explicitly said this) or it will throw a ```NullPointerException``` due to the ```firstName``` field being unset.