### PR TITLE
Improve Optionals for Getters code to allow for specifying on a field level

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -77,7 +77,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         ruleFactory.getAnnotator().propertyField(field, jclass, nodeName, node);
 
         if (isIncludeGetters) {
-            JMethod getter = addGetter(jclass, field, nodeName, node, isRequired(nodeName, node, schema));
+            JMethod getter = addGetter(jclass, field, nodeName, node, isRequired(nodeName, node, schema), usesOptional(nodeName, node, schema));
             ruleFactory.getAnnotator().propertyGetter(getter, jclass, nodeName);
             propertyAnnotations(nodeName, node, schema, getter);
         }
@@ -118,6 +118,24 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         }
 
         JsonNode requiredArray = schema.getContent().get("required");
+
+        if (requiredArray != null) {
+            for (JsonNode requiredNode : requiredArray) {
+                if (nodeName.equals(requiredNode.asText()))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean usesOptional(String nodeName, JsonNode node, Schema schema) {
+        if (node.has("java_optional")) {
+            final JsonNode requiredNode = node.get("java_optional");
+            return requiredNode.asBoolean();
+        }
+
+        JsonNode requiredArray = schema.getContent().get("java_optional");
 
         if (requiredArray != null) {
             for (JsonNode requiredNode : requiredArray) {
@@ -178,9 +196,9 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         return node.path("type").asText().equals("array");
     }
 
-    private JType getReturnType(final JDefinedClass c, final JFieldVar field, final boolean required) {
+    private JType getReturnType(final JDefinedClass c, final JFieldVar field, final boolean required, final boolean usesOptional) {
         JType returnType = field.type();
-        if (ruleFactory.getGenerationConfig().isUseOptionalForGetters()) {
+        if (ruleFactory.getGenerationConfig().isUseOptionalForGetters() || usesOptional) {
             if (!required && field.type().isReference()) {
                 returnType = c.owner().ref("java.util.Optional").narrow(field.type());
             }
@@ -189,14 +207,14 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         return returnType;
     }
 
-    private JMethod addGetter(JDefinedClass c, JFieldVar field, String jsonPropertyName, JsonNode node, boolean isRequired) {
+    private JMethod addGetter(JDefinedClass c, JFieldVar field, String jsonPropertyName, JsonNode node, boolean isRequired, boolean usesOptional) {
 
-        JType type = getReturnType(c, field, isRequired);
+        JType type = getReturnType(c, field, isRequired, usesOptional);
 
         JMethod getter = c.method(JMod.PUBLIC, type, getGetterName(jsonPropertyName, field.type(), node));
 
         JBlock body = getter.body();
-        if (ruleFactory.getGenerationConfig().isUseOptionalForGetters() && !isRequired
+        if ((ruleFactory.getGenerationConfig().isUseOptionalForGetters() || usesOptional) && !isRequired
                 && field.type().isReference()) {
             body._return(c.owner().ref("java.util.Optional").staticInvoke("ofNullable").arg(field));
         } else {


### PR DESCRIPTION
Change the Use Optionals for Getters functionality to allow for specifying to use optionals on a field level aswell as for the whole schema. Not a breaking change.