### PR TITLE
Configure interfaces for generated top-level classes

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -153,6 +153,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean includeDynamicBuilders = false;
 
+    private String[] additionalInterfaces = new String[0];
+
     private String dateTimeType;
 
     private String timeType;
@@ -777,6 +779,16 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
+     * Sets the 'additionalInterfaces' property of this class
+     *
+     * @param additionalInterfaces
+     *            Interfaces added to generated classes.
+     */
+    public void setAdditionalInterfaces(String[] additionalInterfaces) {
+        this.additionalInterfaces = additionalInterfaces;
+    }
+
+    /**
      * Sets the 'formatDateTimes' property of this class
      *
      * @param formatDateTimes
@@ -1111,6 +1123,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isIncludeDynamicBuilders() {
         return includeDynamicBuilders;
+    }
+
+    @Override
+    public String[] getAdditionalInterfaces() {
+        return additionalInterfaces;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -194,6 +194,11 @@
         <td align="center" valign="top">No (default <code>false</code>)</td>
     </tr>
     <tr>
+        <td valign="top">additionalInterfaces</td>
+        <td valign="top">Interfaces added generated classes.</td>
+        <td align="center" valign="top">No (default <code>""</code> (none))</td>
+    </tr>
+    <tr>
         <td valign="top">includeConstructors</td>
         <td valign="top">Whether to generate constructors for generated Java types</td>
         <td align="center" valign="top">No (default <code>false</code>)</td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -21,6 +21,7 @@ import static org.apache.commons.lang3.StringUtils.*;
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -188,6 +189,9 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-idb", "--include-dynamic-builders" }, description = "Include dynamic builder support on generated types.")
     private boolean includeDynamicBuilders = false;
+
+    @Parameter(names = { "-ai", "--additional-interface" }, description = "Add given interfaces to generated classes.")
+    private String[] additionalInterfaces = new String[0];
 
     @Parameter(names = { "-fd", "--format-dates" }, description = "Whether the fields of type `date` are formatted during serialization with a default pattern of `yyyy-MM-dd`")
     private boolean formatDates = false;
@@ -466,6 +470,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isIncludeDynamicBuilders() {
         return includeDynamicBuilders;
+    }
+
+    @Override
+    public String[] getAdditionalInterfaces() {
+        return additionalInterfaces;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -19,7 +19,9 @@ package org.jsonschema2pojo;
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 import org.jsonschema2pojo.rules.RuleFactory;
 
@@ -355,6 +357,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
     @Override
     public boolean isIncludeDynamicBuilders() {
         return false;
+    }
+
+    /**
+     * @return <code>{}</code>
+     */
+    @Override
+    public String[] getAdditionalInterfaces() {
+        return new String[] {};
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
 import java.util.Iterator;
+import java.util.List;
 
 import org.jsonschema2pojo.rules.RuleFactory;
 
@@ -426,6 +427,13 @@ public interface GenerationConfig {
      * @return Whether to include dynamic builders or to omit these methods
      */
     boolean isIncludeDynamicBuilders();
+
+    /**
+     * Gets the `additionalInterfaces` configuration option.
+     *
+     * @return a list of interfaces added to each generated class
+     */
+    String[] getAdditionalInterfaces();
 
     /**
      * Gets the `dateTimeType` configuration option.

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -122,6 +122,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), node, jclass, schema);
 
+        if (parent == null) {
+            for (String _interface : ruleFactory.getGenerationConfig().getAdditionalInterfaces()) {
+                jclass._implements(resolveType(jclass._package(), _interface));
+            }
+        }
         if (node.has("javaInterfaces")) {
             addInterfaces(jclass, node.get("javaInterfaces"));
         }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
 import org.junit.Before;

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -52,6 +52,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean includeDynamicGetters
   boolean includeDynamicSetters
   boolean includeDynamicBuilders
+  String[] additionalInterfaces
   boolean includeConstructors
   boolean constructorsRequiredPropertiesOnly
   boolean includeHashcodeAndEquals
@@ -139,6 +140,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeDynamicGetters = false
     includeDynamicSetters = false
     includeDynamicBuilders = false
+    additionalInterfaces = [] as String[]
     formatDates = false
     formatTimes = false
     formatDateTimes = false
@@ -246,6 +248,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeDynamicGetters = ${includeDynamicGetters}
        |includeDynamicSetters = ${includeDynamicSetters}
        |includeDynamicBuilders = ${includeDynamicBuilders}
+       |additionalInterfaces = ${additionalInterfaces}
        |formatDates = ${formatDates}
        |formatTimes = ${formatTimes}
        |formatDateTimes = ${formatDateTimes}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/AdditionalInterfacesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/AdditionalInterfacesIT.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.typeCompatibleWith;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertThat;
+
+public class AdditionalInterfacesIT {
+
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void noInterfacesAddedByDefault() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example");
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
+
+        assertThat(generatedType.getInterfaces(), is(emptyArray()));
+    }
+
+    @Test
+    public void interfacesAddedToObject() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+                config("additionalInterfaces", new String[] { Serializable.class.getName() }));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
+
+        assertThat(generatedType.getInterfaces(), arrayWithSize(1));
+        assertThat(generatedType, typeCompatibleWith(Serializable.class));
+    }
+
+    @Test
+    public void interfacesNotAddedToEnum() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithEmptyString.json", "com.example",
+                config("additionalInterfaces", new String[] { Serializable.class.getName() }));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.EnumWithEmptyString");
+
+        assertThat(generatedType.getInterfaces(), is(emptyArray()));
+    }
+
+    @Test
+    public void interfacesAreNotAddedToObjectInSubHierarchy() throws ClassNotFoundException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/type/types.json", "com.example",
+                config("additionalInterfaces", new String[] { Serializable.class.getName() }));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.Types");
+        Method objectPropertyGetter = generatedType.getMethod("getObjectProperty");
+
+        assertThat(objectPropertyGetter.getReturnType(), not(typeCompatibleWith(Serializable.class)));
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -627,6 +627,14 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean includeDynamicBuilders = false;
 
     /**
+     * Interfaces to add to all generated classes.
+     *
+     * @parameter property="jsonschema2pojo.additionalInterfaces"
+     *            default-value=""
+     */
+    private String[] additionalInterfaces = new String[0];
+
+    /**
      * The project being built.
      *
      * @parameter property="project"
@@ -1074,6 +1082,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isIncludeDynamicBuilders() {
         return includeDynamicBuilders;
+    }
+
+    @Override
+    public String[] getAdditionalInterfaces() {
+        return additionalInterfaces;
     }
 
     @Override


### PR DESCRIPTION
Add configuration to add interfaces to all top-level generated classes.

This depends on gh-917 in order to know if a rule is applied top-level or sub-level.
Alternatively, if gh-906 is fixed by providing sub-schemas for sub-levels
this could be used to check nesting.

Fixes gh-909, depends on gh-917.