### PR TITLE
Derive child schemas for objects and arrays

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Schema.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Schema.java
@@ -28,13 +28,13 @@ public class Schema {
 
     private final URI id;
     private final JsonNode content;
-    private final JsonNode parentContent;
+    private final Schema parent;
     private JType javaType;
 
-    public Schema(URI id, JsonNode content, JsonNode parentContent) {
+    public Schema(URI id, JsonNode content, Schema parent) {
         this.id = id;
         this.content = content;
-        this.parentContent = parentContent;
+        this.parent = parent != null ? parent : this;
     }
 
     public JType getJavaType() {
@@ -59,12 +59,20 @@ public class Schema {
         return content;
     }
 
-    public JsonNode getParentContent() {
-        return parentContent;
+    public Schema getParent() {
+        return parent;
     }
     
     public boolean isGenerated() {
         return javaType != null;
+    }
+
+    public Schema derive(JsonNode content) {
+        if (content != this.content) {
+            return new Schema(id, content, this);
+        } else {
+            return this;
+        }
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
@@ -89,7 +89,7 @@ public class SchemaMapper {
 
         ObjectNode schemaNode = readSchema(schemaUrl);
 
-        return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage, new Schema(null, schemaNode, schemaNode));
+        return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage, new Schema(null, schemaNode, null));
 
     }
 
@@ -118,7 +118,7 @@ public class SchemaMapper {
         JsonNode schemaNode = objectMapper().readTree(json);
 
         return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage,
-                new Schema(schemaLocation, schemaNode, schemaNode));
+                new Schema(schemaLocation, schemaNode, null));
     }
 
     public JType generate(JCodeModel codeModel, String className, String packageName, String json) throws IOException {
@@ -133,7 +133,7 @@ public class SchemaMapper {
             schemaNode = objectMapper().readTree(json);
         }
 
-        return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage, new Schema(null, schemaNode, schemaNode));
+        return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage, new Schema(null, schemaNode, null));
     }
 
     private ObjectMapper objectMapper() {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -76,6 +76,8 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
             return apply(nameFromRef != null ? nameFromRef : nodeName, schemaNode, parent, generatableType, schema);
         }
 
+        schema = schema.derive(schemaNode);
+
         JType javaType;
         if (schemaNode.has("enum")) {
             javaType = ruleFactory.getEnumRule().apply(nodeName, schemaNode, parent, generatableType, schema);

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
@@ -56,7 +56,10 @@ public class ArrayRuleTest {
         propertyNode.set("uniqueItems", BooleanNode.TRUE);
         propertyNode.set("items", itemsNode);
 
-        JClass propertyType = rule.apply("fooBars", propertyNode, null, jpackage, mock(Schema.class));
+        Schema schema = mock(Schema.class);
+        when(schema.derive(any())).thenReturn(schema);
+
+        JClass propertyType = rule.apply("fooBars", propertyNode, null, jpackage, schema);
 
         assertThat(propertyType, notNullValue());
         assertThat(propertyType.erasure(), is(codeModel.ref(Set.class)));
@@ -79,6 +82,7 @@ public class ArrayRuleTest {
 
         Schema schema = mock(Schema.class);
         when(schema.getId()).thenReturn(URI.create("http://example/nonUniqueArray"));
+        when(schema.derive(any())).thenReturn(schema);
         when(config.isUseDoubleNumbers()).thenReturn(true);
 
         JClass propertyType = rule.apply("fooBars", propertyNode, null, jpackage, schema);
@@ -104,6 +108,7 @@ public class ArrayRuleTest {
 
         Schema schema = mock(Schema.class);
         when(schema.getId()).thenReturn(URI.create("http://example/nonUniqueArray"));
+        when(schema.derive(any())).thenReturn(schema);
         when(config.isUsePrimitives()).thenReturn(true);
         when(config.isUseDoubleNumbers()).thenReturn(true);
 
@@ -130,6 +135,7 @@ public class ArrayRuleTest {
 
         Schema schema = mock(Schema.class);
         when(schema.getId()).thenReturn(URI.create("http://example/defaultArray"));
+        when(schema.derive(any())).thenReturn(schema);
 
         JClass propertyType = rule.apply("fooBars", propertyNode, null, jpackage, schema);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
@@ -54,7 +54,7 @@ public class RequiredArrayRuleTest {
         ObjectMapper mapper = new ObjectMapper();
         ArrayNode requiredNode = mapper.createArrayNode().add("fooBar");
 
-        rule.apply("Class", requiredNode, null, jclass, new Schema(null, requiredNode, requiredNode));
+        rule.apply("Class", requiredNode, null, jclass, new Schema(null, requiredNode, null));
 
         JDocComment fooBarJavaDoc = jclass.fields().get("fooBar").javadoc();
         JDocComment fooJavaDoc = jclass.fields().get("foo").javadoc();
@@ -79,7 +79,7 @@ public class RequiredArrayRuleTest {
         ObjectMapper mapper = new ObjectMapper();
         ArrayNode requiredNode = mapper.createArrayNode().add("foo_bar");
 
-        rule.apply("Class", requiredNode, null, jclass, new Schema(null, requiredNode, requiredNode));
+        rule.apply("Class", requiredNode, null, jclass, new Schema(null, requiredNode, null));
 
         Collection<JAnnotationUse> fooBarAnnotations = jclass.fields().get("fooBar").annotations();
         Collection<JAnnotationUse> fooAnnotations = jclass.fields().get("foo").annotations();

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -88,6 +88,7 @@ public class SchemaRuleTest {
 
         Schema schema = mock(Schema.class);
         when(schema.getContent()).thenReturn(schemaContent);
+        when(schema.derive(any())).thenReturn(schema);
         schema.setJavaTypeIfEmpty(jclass);
 
         EnumRule enumRule = mock(EnumRule.class);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
@@ -102,6 +102,30 @@ public class IncludeJsr305AnnotationsIT {
         }
     }
 
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void jsr305AnnotationsGeneratedProperlyInNestedArray() throws ClassNotFoundException, NoSuchFieldException {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/required/requiredNestedInArray.json", "com.example",
+                config("includeJsr305Annotations", true));
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.Nested");
+
+        validateNonnullField(generatedType.getDeclaredField("requiredProperty"));
+        validateNullableField(generatedType.getDeclaredField("nonRequiredProperty"));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void jsr305AnnotationsGeneratedProperlyInNestedObject() throws ClassNotFoundException, NoSuchFieldException {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/required/requiredNestedInObject.json", "com.example",
+                config("includeJsr305Annotations", true));
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.Nested");
+
+        validateNonnullField(generatedType.getDeclaredField("requiredProperty"));
+        validateNullableField(generatedType.getDeclaredField("nonRequiredProperty"));
+    }
+
     private static void validateNonnullField(Field nonnullField) {
         Nonnull nonnullAnnotation = nonnullField.getAnnotation(Nonnull.class);
         Nullable nullableAnnotation = nonnullField.getAnnotation(Nullable.class);
@@ -110,9 +134,9 @@ public class IncludeJsr305AnnotationsIT {
         assertNull("Unexpected @Nullable annotation found.", nullableAnnotation);
     }
 
-    private static void validateNullableField(Field nonnullField) {
-        Nonnull nonnullAnnotation = nonnullField.getAnnotation(Nonnull.class);
-        Nullable nullableAnnotation = nonnullField.getAnnotation(Nullable.class);
+    private static void validateNullableField(Field nullableField) {
+        Nonnull nonnullAnnotation = nullableField.getAnnotation(Nonnull.class);
+        Nullable nullableAnnotation = nullableField.getAnnotation(Nullable.class);
 
         assertNull("Unexpected @Nonnull annotation found.", nonnullAnnotation);
         assertNotNull("Expected @Nullable annotation is missing.", nullableAnnotation);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/FragmentRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/FragmentRefIT.java
@@ -72,7 +72,7 @@ public class FragmentRefIT {
         JsonNode schema = new ObjectMapper().readTree("{\"type\":\"object\", \"properties\":{\"a\":{\"$ref\":\"#/b\"}}, \"b\":\"string\"}");
         
         JPackage p = codeModel._package("com.example");
-        new RuleFactory().getSchemaRule().apply("Example", schema, null, p, new Schema(null, schema, schema));
+        new RuleFactory().getSchemaRule().apply("Example", schema, null, p, new Schema(null, schema, null));
     }
     
     @Test
@@ -101,7 +101,7 @@ public class FragmentRefIT {
               "}");
         
         JPackage p = codeModel._package("com.example");
-        new RuleFactory().getSchemaRule().apply("Example", schema, null, p, new Schema(null, schema, schema));
+        new RuleFactory().getSchemaRule().apply("Example", schema, null, p, new Schema(null, schema, null));
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredNestedInArray.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredNestedInArray.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "nested": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "requiredProperty"
+        ],
+        "properties": {
+          "requiredProperty": {
+            "type": "string"
+          },
+          "nonRequiredProperty": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredNestedInObject.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/required/requiredNestedInObject.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "nested": {
+      "type": "object",
+      "required": [
+        "requiredProperty"
+      ],
+      "properties": {
+        "requiredProperty": {
+          "type": "string"
+        },
+        "nonRequiredProperty": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Derive child schemas for objects and arrays. This approach seems to be suggested by the JavaDoc of SchemaRule already.

The relevant bits are in `SchemaRule#L79`, where a child schema is obtained and passed down the rule tree as the schema for the relevant section. This seems to be the expected behavior by `NotRequiredRule`, among others.

Changes `Schema` to keep reference to its parent `Schema` instead of parent `JsonNode`. This means `Schema(id, JsonNode content, JsonNode parentContent)` is replaced by `Schema(id, JsonNode content, Schema parent)`.

`Schema#getParent` still returns _self_ as did `#getParentContent` previously.

Fixes gh-906 (JSR305 bug) and depends on gh-921 (integration tests for JSR305 bug)
