### PR TITLE
Add 'formatTypeMapping' config option to allow overriding types used for formats

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -27,9 +27,13 @@ import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -176,6 +180,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private SourceSortOrder sourceSortOrder = SourceSortOrder.OS;
 
     private Language targetLanguage = Language.JAVA;
+
+    private Map<String, String> formatTypeMapping = new HashMap<>();
 
     /**
      * Execute this task (it's expected that all relevant setters will have been
@@ -871,6 +877,14 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         this.targetLanguage = targetLanguage;
     }
 
+    public void setFormatTypeMapping(Map<String, String> formatTypeMapping) {
+        this.formatTypeMapping = formatTypeMapping;
+    }
+    public void setFormatTypeMapping(String[] formatTypeMapping) {
+        this.formatTypeMapping = Arrays.stream(formatTypeMapping)
+            .collect(Collectors.toMap(m -> m.split(":")[0], m -> m.split(":")[1]));
+    }
+
     @Override
     public boolean isGenerateBuilders() {
         return generateBuilders;
@@ -1181,6 +1195,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public Language getTargetLanguage() {
         return targetLanguage;
+    }
+
+    @Override
+    public Map<String, String> getFormatTypeMapping() {
+        return formatTypeMapping;
     }
     
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -499,7 +499,8 @@
     </tr>
     <tr>
         <td valign="top">formatTypeMapping</td>
-        <td valign="top">A mapping from format identifier (e.g. 'uri') to Java type (e.g. 'java.net.URI').
+        <td valign="top">A mapping from format identifier (e.g. 'uri') to Java type (e.g. 'java.net.URI'):
+            <code>&gt;format&lt;:&gt;fully.qualified.Type&lt;</code>.
         </td>
         <td align="center" valign="top">None (default <code>''</code> (none))</td>
     </tr>

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -497,6 +497,12 @@
         </td>
         <td align="center" valign="top">No (default <code>OS</code>)</td>
     </tr>
+    <tr>
+        <td valign="top">formatTypeMapping</td>
+        <td valign="top">A mapping from format identifier (e.g. 'uri') to Java type (e.g. 'java.net.URI').
+        </td>
+        <td align="center" valign="top">None (default <code>''</code> (none))</td>
+    </tr>
 
 </table>
 

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -21,8 +21,11 @@ import static org.apache.commons.lang3.StringUtils.*;
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.jsonschema2pojo.AllFileFilter;
 import org.jsonschema2pojo.AnnotationStyle;
@@ -215,6 +218,9 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-tl", "--target-language" }, description = "The type of code that will be generated.  Available options are: JAVA or SCALA")
     private Language targetLanguage = Language.JAVA;
+
+    @Parameter(names = { "-ftm", "--format-type-mapping" }, description = "Mapping from format identifier to type: <format>:<fully.qualified.Type>.", variableArity = true)
+    private List<String> formatTypeMapping = new ArrayList<>();
     
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -532,9 +538,16 @@ public class Arguments implements GenerationConfig {
     public SourceSortOrder getSourceSortOrder() {
         return sourceSortOrder;
     }
-    
+
     @Override
     public Language getTargetLanguage() {
         return targetLanguage;
+    }
+
+    @Override
+    public Map<String, String> getFormatTypeMapping() {
+        return formatTypeMapping
+                .stream()
+                .collect(Collectors.toMap(m -> m.split(":")[0], m -> m.split(":")[1]));
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -19,7 +19,9 @@ package org.jsonschema2pojo;
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 
 import org.jsonschema2pojo.rules.RuleFactory;
 
@@ -433,6 +435,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
     @Override
     public Language getTargetLanguage() {
         return Language.JAVA;
+    }
+
+    /**
+     * @return {@link Collections#emptyMap}
+     */
+    @Override
+    public Map<String, String> getFormatTypeMapping() {
+        return Collections.emptyMap();
     }
     
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
 import java.util.Iterator;
+import java.util.Map;
 
 import org.jsonschema2pojo.rules.RuleFactory;
 
@@ -562,5 +563,12 @@ public interface GenerationConfig {
      *         </ul>
      */
     Language getTargetLanguage();
-    
+
+    /**
+     * Gets the 'formatTypeMapping' configuration option.
+     *
+     * @return An optional mapping from format identifier (e.g. 'uri') to
+     *         fully qualified type name (e.g. 'java.net.URI').
+     */
+    Map<String, String> getFormatTypeMapping();
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -96,7 +96,7 @@ public class FormatRule implements Rule<JType, JType> {
         Class<?> type = getType(node.asText());
         if (type != null) {
             JType jtype = baseType.owner().ref(type);
-            if (ruleFactory.getGenerationConfig().isUsePrimitives() && Number.class.isAssignableFrom(type)) {
+            if (ruleFactory.getGenerationConfig().isUsePrimitives()) {
                 jtype = jtype.unboxify();
             }
             return jtype;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
@@ -43,7 +43,7 @@ import org.joda.time.LocalTime;
 public class FormatRuleJodaTest {
 
     private GenerationConfig config = mock(GenerationConfig.class);
-    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private FormatRule rule;
 
     private final String formatValue;
     private final Class<?> expectedType;
@@ -66,6 +66,7 @@ public class FormatRuleJodaTest {
         when(config.isUseJodaLocalTimes()).thenReturn(true);
         when(config.isUseJodaLocalDates()).thenReturn(true);
         when(config.isUseJodaDates()).thenReturn(true);
+        rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
     }
 
     @Test

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
@@ -72,7 +72,7 @@ public class FormatRulePrimitivesTest {
     }
 
     @Test
-    public void applyGeneratesTypeFromFormatValue() {
+    public void usePrimitivesWithCustomTypeMapping() {
         JType result = rule.apply("fooBar", TextNode.valueOf("test"), null, new JCodeModel().ref(Object.class), null);
 
         Class<?> expected = primitive != null ? primitive : wrapper;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JType;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.SchemaStore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class FormatRulePrimitivesTest {
+
+    private final GenerationConfig config = mock(GenerationConfig.class);
+    private final FormatRule rule;
+
+    private final Class<?> primitive;
+    private final Class<?> wrapper;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return asList(new Object[][] {
+                { boolean.class, Boolean.class },
+                { byte.class, Byte.class },
+                { char.class, Character.class },
+                { double.class, Double.class },
+                { float.class, Float.class },
+                { int.class, Integer.class },
+                { long.class, Long.class },
+                { short.class, Short.class },
+                { void.class, Void.class },
+                { null, BigDecimal.class },
+                { null, String.class }});
+    }
+
+    public FormatRulePrimitivesTest(Class<?> primitive, Class<?> wrapper) {
+        this.primitive = primitive;
+        this.wrapper = wrapper;
+
+        when(config.isUsePrimitives()).thenReturn(true);
+        when(config.getFormatTypeMapping()).thenReturn(Collections.singletonMap("test", wrapper.getName()));
+        rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    }
+
+    @Test
+    public void applyGeneratesTypeFromFormatValue() {
+        JType result = rule.apply("fooBar", TextNode.valueOf("test"), null, new JCodeModel().ref(Object.class), null);
+
+        Class<?> expected = primitive != null ? primitive : wrapper;
+        assertThat(result.fullName(), equalTo(expected.getName()));
+        assertThat(result.isPrimitive(), equalTo(primitive != null));
+    }
+
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -90,6 +90,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   String refFragmentPathDelimiters
   SourceSortOrder sourceSortOrder
   Language targetLanguage
+  Map<String, String> formatTypeMapping
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -144,6 +145,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     formatDateTimes = false
     refFragmentPathDelimiters = "#/."
     sourceSortOrder = SourceSortOrder.OS
+    formatTypeMapping = Collections.emptyMap()
   }
 
   @Override
@@ -163,10 +165,6 @@ public class JsonSchemaExtension implements GenerationConfig {
 
   public void setAnnotationStyle(String style) {
     annotationStyle = AnnotationStyle.valueOf(style.toUpperCase())
-  }
-
-  public void setUseTitleAsClassname(boolean useTitleAsClassname) {
-    useTitleAsClassname = useTitleAsClassname
   }
 
   public void setInclusionLevel(String level) {
@@ -255,6 +253,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |refFragmentPathDelimiters = ${refFragmentPathDelimiters}
        |sourceSortOrder = ${sourceSortOrder}
        |targetLanguage = ${targetLanguage}
+       |formatTypeMapping = ${formatTypeMapping}
      """.stripMargin()
   }
   

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FormatTypeMappingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FormatTypeMappingIT.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.typeCompatibleWith;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertThat;
+
+public class FormatTypeMappingIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void canOverrideDateRelatedTypes() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("formatTypeMapping", mapping("date", LocalDate.class, "time", LocalTime.class, "date-time", DateTime.class)));
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
+
+        Method dateTime = generatedType.getMethod("getStringAsDateTime");
+        Method time = generatedType.getMethod("getStringAsTime");
+        Method date = generatedType.getMethod("getStringAsDate");
+        assertThat(dateTime.getReturnType(), typeCompatibleWith(DateTime.class));
+        assertThat(time.getReturnType(), typeCompatibleWith(LocalTime.class));
+        assertThat(date.getReturnType(), typeCompatibleWith(LocalDate.class));
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void canOverrideTypes() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("formatTypeMapping", mapping("uri", URL.class)));
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
+
+        Method getter = generatedType.getMethod("getStringAsUri");
+        assertThat(getter.getReturnType(), typeCompatibleWith(URL.class));
+    }
+
+    @Test
+    public void canOverrideNonStandardTypes() throws Exception {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/nonStandard.json", "com.example",
+                config("formatTypeMapping", mapping("non-standard", URL.class)));
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.NonStandard");
+
+        Method getter = generatedType.getMethod("getStringAsNonStandard");
+        assertThat(getter.getReturnType(), typeCompatibleWith(URL.class));
+    }
+
+    private static Map<String, String> mapping(Object... keyValues) {
+        return config(keyValues)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Entry::getKey, e -> ((Class<?>) e.getValue()).getName()));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/format/nonStandard.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/format/nonStandard.json
@@ -1,0 +1,9 @@
+{
+    "type" : "object",
+    "properties" : {
+        "stringAsNonStandard" : {
+            "type" : "string",
+            "format" : "non-standard"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -25,8 +25,10 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -737,6 +739,13 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String targetLanguage = "java";
 
     /**
+     * @parameter property="jsonschema2pojo.formatTypeMapping"
+     *            default-value=""
+     * @since 1.0.0
+     */
+    private Map<String, String> formatTypeMapping = new HashMap<>();
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -1144,5 +1153,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public Language getTargetLanguage() {
         return Language.valueOf(targetLanguage.toUpperCase());
+    }
+
+    @Override
+    public Map<String, String> getFormatTypeMapping() {
+        return formatTypeMapping;
     }
 }


### PR DESCRIPTION
This commit introduces a new option `formatTypeMapping`, which maps from format
(e.g. 'uri') to type (e.g. 'java.net.URI'). The current base types and configurations
are left as-is. This means, that it is still possible to set 'useJodaDate' or 'dateType'
as before. Alternatively, a mapping 'date' > 'org.joda.time.LocalDate' achieves the same
output.

With this change it is also possible to map non-standard formats to types. This logic is
intentional, but not recommended to users as it invalidates the schema.

This (partly) fixes gh-910 and is an alternative to gh-918.