### PR TITLE
Features/builders as inner classes

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -1209,6 +1209,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         return useInnerClassBuilders;
     }
 
+    /**
+     * Sets the 'useInnerClassBuilders' property of this class
+     *
+     * @param useInnerClassBuilders determines whether builders will be chainable setters or embedded classes when {@link #isGenerateBuilders()} used
+     */
     public void setUseInnerClassBuilders(boolean useInnerClassBuilders) {
         this.useInnerClassBuilders = useInnerClassBuilders;
     }

--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -69,6 +69,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean generateBuilders;
 
+    private boolean useInnerClassBuilders = false;
+
     private boolean includeConstructors = false;
 
     private boolean usePrimitives;
@@ -1201,5 +1203,13 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public Map<String, String> getFormatTypeMapping() {
         return formatTypeMapping;
     }
-    
+
+    @Override
+    public boolean isUseInnerClassBuilders() {
+        return useInnerClassBuilders;
+    }
+
+    public void setUseInnerClassBuilders(boolean useInnerClassBuilders) {
+        this.useInnerClassBuilders = useInnerClassBuilders;
+    }
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -157,6 +157,11 @@
         <td align="center" valign="top">No (default <code>false</code>)</td>
     </tr>
     <tr>
+        <td valign="top">useInnerClassBuilders</td>
+        <td valign="top">Determines whether builders will be chainable setters or embedded classes when generateBuilders is used</td>
+        <td align="center" valign="top">No (default <code>false</code>)</td>
+    </tr>
+    <tr>
         <td valign="top">includeGetters</td>
         <td valign="top">Whether to include getters or to omit these accessor methods and create public fields instead.</td>
         <td align="center" valign="top">No (default <code>true</code>)</td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -63,6 +63,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-b", "--generate-builders" }, description = "Generate builder-style methods as well as setters")
     private boolean generateBuilderMethods = false;
 
+    @Parameter(names = { "--use-inner-class-builders" }, description = "Generate an inner class with builder-style methods")
+    private boolean useInnerClassBuilders = false;
+
     @Parameter(names = { "-c", "--generate-constructors" }, description = "Generate constructors")
     private boolean generateConstructors = false;
 
@@ -276,6 +279,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isGenerateBuilders() {
         return generateBuilderMethods;
+    }
+
+    @Override
+    public boolean isUseInnerClassBuilders() {
+        return useInnerClassBuilders;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -446,8 +446,5 @@ public class DefaultGenerationConfig implements GenerationConfig {
     }
 
     @Override
-    public boolean isChainableSettersBuilders() { return true; }
-
-    @Override
     public boolean isUseInnerClassBuilders() { return false; }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -444,5 +444,10 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public Map<String, String> getFormatTypeMapping() {
         return Collections.emptyMap();
     }
-    
+
+    @Override
+    public boolean isChainableSettersBuilders() { return true; }
+
+    @Override
+    public boolean isUseInnerClassBuilders() { return false; }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -580,12 +580,4 @@ public interface GenerationConfig {
      */
     default boolean isUseInnerClassBuilders(){ return false;}
 
-
-    /**
-     * If set to true then builder methods will be added to the class as chainable setters. Note: This property works
-     * in collaboration with the {@link #isGenerateBuilders()} method. If the {@link #isGenerateBuilders()} is false,
-     * then this property will not do anything.
-     * @return whether or not to include chainable setters on the generated classes. The default value for this is true.
-     */
-    default boolean isChainableSettersBuilders() { return true; }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -571,4 +571,21 @@ public interface GenerationConfig {
      *         fully qualified type name (e.g. 'java.net.URI').
      */
     Map<String, String> getFormatTypeMapping();
+
+    /**
+     * If set to true, then the gang of four builder pattern will be used to generate builders on generated classes. Note: This property works
+     * in collaboration with the {@link #isGenerateBuilders()} method. If the {@link #isGenerateBuilders()} is false,
+     * then this property will not do anything.
+     * @return whether to include the gang of four builder patter on the generated classes. The default value for this is false.
+     */
+    default boolean isUseInnerClassBuilders(){ return false;}
+
+
+    /**
+     * If set to true then builder methods will be added to the class as chainable setters. Note: This property works
+     * in collaboration with the {@link #isGenerateBuilders()} method. If the {@link #isGenerateBuilders()} is false,
+     * then this property will not do anything.
+     * @return whether or not to include chainable setters on the generated classes. The default value for this is true.
+     */
+    default boolean isChainableSettersBuilders() { return true; }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/ScalaSingleStreamCodeWriter.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/ScalaSingleStreamCodeWriter.java
@@ -16,15 +16,14 @@
 
 package org.jsonschema2pojo;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-
 import com.mysema.scalagen.ConversionSettings;
 import com.mysema.scalagen.Converter;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.writer.SingleStreamCodeWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
 public class ScalaSingleStreamCodeWriter extends SingleStreamCodeWriter {
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -209,7 +209,7 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
         JVar valueParam = builder.param(propertyType, "value");
 
         JBlock body = builder.body();
-        JInvocation mapInvocation = body.invoke(JExpr._this().ref("instance").ref(field), "put");
+        JInvocation mapInvocation = body.invoke(JExpr.ref(JExpr.cast(jclass, JExpr._this().ref("instance")), field), "put");
         mapInvocation.arg(nameParam);
         mapInvocation.arg(valueParam);
         body._return(JExpr._this());

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -166,16 +166,11 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
     }
 
     private JMethod addBuilder(JDefinedClass jclass, JType propertyType, JFieldVar field) {
-        // Requires one of the builder generation methods to be set to true
-        if(! ruleFactory.getGenerationConfig().isUseInnerClassBuilders() && !ruleFactory.getGenerationConfig().isChainableSettersBuilders()) {
-            throw new IllegalStateException("Both chainable setters and inner class builder method generation are disabled, but builder generation is enabled");
-        }
 
         JMethod result = null;
         if(ruleFactory.getGenerationConfig().isUseInnerClassBuilders()) {
             result = addInnerBuilder(jclass, propertyType, field);
-        }
-        if(ruleFactory.getGenerationConfig().isChainableSettersBuilders()) {
+        } else {
             result = addLegacyBuilder(jclass, propertyType, field);
         }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -19,6 +19,11 @@ package org.jsonschema2pojo.rules;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+import org.apache.commons.collections15.CollectionUtils;
 import org.jsonschema2pojo.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -160,7 +165,24 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
         return getter;
     }
 
-    private void addBuilder(JDefinedClass jclass, JType propertyType, JFieldVar field) {
+    private JMethod addBuilder(JDefinedClass jclass, JType propertyType, JFieldVar field) {
+        // Requires one of the builder generation methods to be set to true
+        if(! ruleFactory.getGenerationConfig().isUseInnerClassBuilders() && !ruleFactory.getGenerationConfig().isChainableSettersBuilders()) {
+            throw new IllegalStateException("Both chainable setters and inner class builder method generation are disabled, but builder generation is enabled");
+        }
+
+        JMethod result = null;
+        if(ruleFactory.getGenerationConfig().isUseInnerClassBuilders()) {
+            result = addInnerBuilder(jclass, propertyType, field);
+        }
+        if(ruleFactory.getGenerationConfig().isChainableSettersBuilders()) {
+            result = addLegacyBuilder(jclass, propertyType, field);
+        }
+
+        return result;
+    }
+
+    private JMethod addLegacyBuilder(JDefinedClass jclass, JType propertyType, JFieldVar field) {
         JMethod builder = jclass.method(JMod.PUBLIC, jclass, "withAdditionalProperty");
 
         JVar nameParam = builder.param(String.class, "name");
@@ -171,6 +193,32 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
         mapInvocation.arg(nameParam);
         mapInvocation.arg(valueParam);
         body._return(JExpr._this());
+
+        return builder;
+    }
+
+    private JMethod addInnerBuilder(JDefinedClass jclass, JType propertyType, JFieldVar field) {
+        Optional<JDefinedClass> builderClass = StreamSupport
+            .stream(Spliterators.spliteratorUnknownSize(jclass.classes(), Spliterator.ORDERED), false)
+            .filter(definedClass -> definedClass.name().equals(getBuilderClassName(jclass)))
+            .findFirst();
+
+        JMethod builder = builderClass.get().method(JMod.PUBLIC, builderClass.get(), "withAdditionalProperty");
+
+        JVar nameParam = builder.param(String.class, "name");
+        JVar valueParam = builder.param(propertyType, "value");
+
+        JBlock body = builder.body();
+        JInvocation mapInvocation = body.invoke(JExpr._this().ref("instance").ref(field), "put");
+        mapInvocation.arg(nameParam);
+        mapInvocation.arg(valueParam);
+        body._return(JExpr._this());
+
+        return builder;
+    }
+
+    private String getBuilderClassName(JDefinedClass c) {
+        return ruleFactory.getNameHelper().getBuilderClassName(c);
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -16,6 +16,7 @@
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassAlreadyExistsException;
@@ -96,6 +97,9 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
 
   private void generateNoArgsBuilderConstructor(JDefinedClass instanceClass, JDefinedClass builderClass) {
     JMethod noargsConstructor = builderClass.constructor(JMod.PUBLIC);
+    JAnnotationUse warningSuppression = noargsConstructor.annotate(SuppressWarnings.class);
+    warningSuppression.param("value", "unchecked");
+
     JBlock constructorBlock = noargsConstructor.body();
 
     JFieldVar instanceField = reflectionHelper.searchClassAndSuperClassesForField("instance", builderClass);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -13,19 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
-  Copyright Â© 2010-2017 Nokia
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
-  copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
-  under the License.
- */
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -1,66 +1,91 @@
 /**
  * Copyright Â© 2010-2017 Nokia
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassAlreadyExistsException;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
+import com.sun.codemodel.JTypeVar;
 import com.sun.codemodel.JVar;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.util.ReflectionHelper;
 
 public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
 
   private RuleFactory ruleFactory;
+  private ReflectionHelper reflectionHelper;
 
-  BuilderRule(RuleFactory ruleFactory)
-  {
+  BuilderRule(RuleFactory ruleFactory, ReflectionHelper reflectionHelper) {
     this.ruleFactory = ruleFactory;
+    this.reflectionHelper = reflectionHelper;
   }
 
   @Override
-  public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass generatableType,
-      Schema currentSchema){
+  public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass generatableType, Schema currentSchema) {
+
+    JClass parentBuilderClass = null;
+    JClass parentClass = generatableType._extends();
+    if (!(parentClass.isPrimitive() || reflectionHelper.isFinal(parentClass) || Objects.equals(parentClass.fullName(), "java.lang.Object"))) {
+      String superTypeName = ruleFactory.getNameHelper().getBuilderClassName(parentClass);
+      parentBuilderClass = reflectionHelper._getClass(superTypeName, parentClass._package());
+    }
 
     // Create the inner class for the builder
     JDefinedClass builderClass = null;
+    JTypeVar instanceType = null;
     try {
       String builderName = ruleFactory.getNameHelper().getBuilderClassName(generatableType);
       builderClass = generatableType._class(JMod.PUBLIC + JMod.STATIC, builderName);
+      instanceType = builderClass.generify("T", generatableType);
+
+      if (parentBuilderClass != null) {
+        builderClass._extends(parentBuilderClass);
+      }
     } catch (JClassAlreadyExistsException e) {
       return e.getExistingClass();
     }
 
     // Create the instance variable
-    JFieldVar instanceField = builderClass.field(JMod.PRIVATE, generatableType, "instance");
+    JFieldVar instanceField = builderClass.field(JMod.PRIVATE, instanceType, "instance");
 
     // Create the actual "build" method
-    JMethod buildMethod = builderClass.method(JMod.PUBLIC, generatableType, "build");
+    JMethod buildMethod = builderClass.method(JMod.PUBLIC, instanceType, "build");
 
     JBlock body = buildMethod.body();
-    JVar result = body.decl(generatableType, "result");
-    body.assign(result, JExpr._this().ref(instanceField));
-    body.assign(JExpr._this().ref(instanceField), JExpr._null());
+    JVar result = body.decl(instanceType, "result");
+    body.assign(result, JExpr._this().
+
+        ref(instanceField));
+    body.assign(JExpr._this().
+
+        ref(instanceField), JExpr.
+
+        _null());
     body._return(result);
 
     return builderClass;
   }
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -1,25 +1,42 @@
 /**
  * Copyright Â© 2010-2017 Nokia
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
+/*
+  Copyright Â© 2010-2017 Nokia
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+  copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+  under the License.
+ */
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JTypeVar;
@@ -39,43 +56,75 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
   }
 
   @Override
-  public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass generatableType, Schema currentSchema) {
-
-    JClass parentBuilderClass = null;
-    JClass parentClass = generatableType._extends();
-    if (!(parentClass.isPrimitive() || reflectionHelper.isFinal(parentClass) || Objects.equals(parentClass.fullName(), "java.lang.Object"))) {
-      String superTypeName = ruleFactory.getNameHelper().getBuilderClassName(parentClass);
-      parentBuilderClass = reflectionHelper._getClass(superTypeName, parentClass._package());
-    }
+  public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass instanceClass, Schema currentSchema) {
 
     // Create the inner class for the builder
-    JDefinedClass builderClass = null;
-    JTypeVar instanceType = null;
-    try {
-      String builderName = ruleFactory.getNameHelper().getBuilderClassName(generatableType);
-      builderClass = generatableType._class(JMod.PUBLIC + JMod.STATIC, builderName);
-      instanceType = builderClass.generify("T", generatableType);
+    JDefinedClass builderClass;
 
-      if (parentBuilderClass != null) {
-        builderClass._extends(parentBuilderClass);
-      }
+    try {
+      String builderName = ruleFactory.getNameHelper().getBuilderClassName(instanceClass);
+      builderClass = instanceClass._class(JMod.PUBLIC + JMod.STATIC, builderName);
     } catch (JClassAlreadyExistsException e) {
       return e.getExistingClass();
     }
 
-    // Create the instance variable
-    JFieldVar instanceField = builderClass.field(JMod.PRIVATE, instanceType, "instance");
+    // Determine which builder (if any) this builder should inherit from
+    JClass parentBuilderClass = null;
+    JClass parentClass = instanceClass._extends();
+    if (!(parentClass.isPrimitive() || reflectionHelper.isFinal(parentClass) || Objects.equals(parentClass.fullName(), "java.lang.Object"))) {
+      parentBuilderClass = reflectionHelper.getBuilderClass(parentClass);
+    }
 
-    // Create the actual "build" method
-    JMethod buildMethod = builderClass.method(JMod.PUBLIC, instanceType, "build");
+    // Determine the generic type 'T' that the builder will create instances of
+    JTypeVar instanceType = builderClass.generify("T", instanceClass);
 
-    JBlock body = buildMethod.body();
-    JVar result = body.decl(instanceType, "result");
-    body.assign(result, JExpr._this().ref(instanceField));
-    body.assign(JExpr._this().ref(instanceField), JExpr._null());
-    body._return(result);
+    // For new builders we need to create an instance variable and 'build' method
+    // for inheriting builders we'll receive these from the superType
+    if (parentBuilderClass == null) {
+
+      // Create the instance variable
+      JFieldVar instanceField = builderClass.field(JMod.PROTECTED, instanceType, "instance");
+
+      // Create the actual "build" method
+      JMethod buildMethod = builderClass.method(JMod.PUBLIC, instanceType, "build");
+
+      JBlock body = buildMethod.body();
+      JVar result = body.decl(instanceType, "result");
+      body.assign(result, JExpr._this().ref(instanceField));
+      body.assign(JExpr._this().ref(instanceField), JExpr._null());
+      body._return(result);
+
+      // Create the noargs builder constructor
+      generateNoArgsBuilderConstructor(instanceClass, builderClass);
+    } else {
+      // Declare the inheritance
+      builderClass._extends(parentBuilderClass);
+
+      // Create the noargs builder constructor
+      generateNoArgsBuilderConstructor(instanceClass, builderClass);
+    }
 
     return builderClass;
+  }
+
+  private void generateNoArgsBuilderConstructor(JDefinedClass instanceClass, JDefinedClass builderClass) {
+    JMethod noargsConstructor = builderClass.constructor(JMod.PUBLIC);
+    JBlock constructorBlock = noargsConstructor.body();
+
+    JFieldVar instanceField = reflectionHelper.searchClassAndSuperClassesForField("instance", builderClass);
+
+    // Determine if we need to invoke the super() method for our parent builder
+    JClass parentClass = builderClass._extends();
+    if (!(parentClass.isPrimitive() || reflectionHelper.isFinal(parentClass) || Objects.equals(parentClass.fullName(), "java.lang.Object"))) {
+      constructorBlock.invoke("super");
+    }
+
+    // Only initialize the instance if the object being constructed is actually this class
+    // if it's a subtype then ignore the instance initialization since the subclass will initialize it
+    constructorBlock.directStatement("// Skip initialization when called from subclass");
+    JInvocation comparison = JExpr._this().invoke("getClass").invoke("equals").arg(JExpr.dotclass(builderClass));
+    JConditional ifNotSubclass = constructorBlock._if(comparison);
+    ifNotSubclass._then().assign(JExpr._this().ref(instanceField), JExpr.cast(instanceField.type(), JExpr._new(instanceClass)));
   }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -25,10 +25,6 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JTypeVar;
 import com.sun.codemodel.JVar;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.ReflectionHelper;
 
@@ -75,14 +71,8 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
 
     JBlock body = buildMethod.body();
     JVar result = body.decl(instanceType, "result");
-    body.assign(result, JExpr._this().
-
-        ref(instanceField));
-    body.assign(JExpr._this().
-
-        ref(instanceField), JExpr.
-
-        _null());
+    body.assign(result, JExpr._this().ref(instanceField));
+    body.assign(JExpr._this().ref(instanceField), JExpr._null());
     body._return(result);
 
     return builderClass;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright Â© 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JVar;
+import org.jsonschema2pojo.Schema;
+
+public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
+
+  private RuleFactory ruleFactory;
+
+  BuilderRule(RuleFactory ruleFactory)
+  {
+    this.ruleFactory = ruleFactory;
+  }
+
+  @Override
+  public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass generatableType,
+      Schema currentSchema){
+
+    // Create the inner class for the builder
+    JDefinedClass builderClass = null;
+    try {
+      String builderName = ruleFactory.getNameHelper().getBuilderClassName(generatableType);
+      builderClass = generatableType._class(JMod.PUBLIC + JMod.STATIC, builderName);
+    } catch (JClassAlreadyExistsException e) {
+      return e.getExistingClass();
+    }
+
+    // Create the instance variable
+    JFieldVar instanceField = builderClass.field(JMod.PRIVATE, generatableType, "instance");
+
+    // Create the actual "build" method
+    JMethod buildMethod = builderClass.method(JMod.PUBLIC, generatableType, "build");
+
+    JBlock body = buildMethod.body();
+    JVar result = body.decl(generatableType, "result");
+    body.assign(result, JExpr._this().ref(instanceField));
+    body.assign(JExpr._this().ref(instanceField), JExpr._null());
+    body._return(result);
+
+    return builderClass;
+  }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright Â© 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JInvocation;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
+import com.sun.codemodel.JVar;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.util.NameHelper;
+import org.jsonschema2pojo.util.ReflectionHelper;
+
+public class ConstructorRule  implements Rule<JPackage, JType> {
+
+  private final RuleFactory ruleFactory;
+  private final ReflectionHelper reflectionHelper;
+
+  public ConstructorRule(RuleFactory ruleFactory, ReflectionHelper reflectionHelper) {
+    this.ruleFactory = ruleFactory;
+    this.reflectionHelper = reflectionHelper;
+  }
+
+  /**
+   * Retrieve the list of properties to go in the constructor from node. This
+   * is all properties listed in node["properties"] if ! onlyRequired, and
+   * only required properties if onlyRequired.
+   *
+   * @param node
+   * @return
+   */
+  private LinkedHashSet<String> getConstructorProperties(JsonNode node, boolean onlyRequired) {
+
+    if (!node.has("properties")) {
+      return new LinkedHashSet<>();
+    }
+
+    LinkedHashSet<String> rtn = new LinkedHashSet<>();
+    Set<String> draft4RequiredProperties = new HashSet<>();
+
+    // setup the set of required properties for draft4 style "required"
+    if (onlyRequired && node.has("required")) {
+      JsonNode requiredArray =  node.get("required");
+      if (requiredArray.isArray()) {
+        for (JsonNode requiredEntry: requiredArray) {
+          if (requiredEntry.isTextual()) {
+            draft4RequiredProperties.add(requiredEntry.asText());
+          }
+        }
+      }
+    }
+
+    NameHelper nameHelper = ruleFactory.getNameHelper();
+    for (Iterator<Entry<String, JsonNode>> properties = node.get("properties").fields(); properties.hasNext();) {
+      Map.Entry<String, JsonNode> property = properties.next();
+
+      JsonNode propertyObj = property.getValue();
+      if (onlyRequired) {
+        // draft3 style
+        if (propertyObj.has("required") && propertyObj.get("required").asBoolean()) {
+          rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
+        }
+
+        // draft4 style
+        if (draft4RequiredProperties.contains(property.getKey())) {
+          rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
+        }
+      } else {
+        rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
+      }
+    }
+    return rtn;
+  }
+
+  /**
+   * Recursive, walks the schema tree and assembles a list of all properties of this schema's super schemas
+   */
+  private LinkedHashSet<String> getSuperTypeConstructorPropertiesRecursive(JsonNode node, Schema schema, boolean onlyRequired) {
+    Schema superTypeSchema = reflectionHelper.getSuperSchema(node, schema, true);
+
+    if (superTypeSchema == null) {
+      return new LinkedHashSet<>();
+    }
+
+    JsonNode superSchemaNode = superTypeSchema.getContent();
+
+    LinkedHashSet<String> rtn = getConstructorProperties(superSchemaNode, onlyRequired);
+    rtn.addAll(getSuperTypeConstructorPropertiesRecursive(superSchemaNode, superTypeSchema, onlyRequired));
+
+    return rtn;
+  }
+
+  @Override
+  public JType apply(String nodeName, JsonNode node, JsonNode parent, JPackage _package, Schema currentSchema) {
+    GenerationConfig generationConfig = ruleFactory.getGenerationConfig();
+
+    JDefinedClass jclass = reflectionHelper._getClass(nodeName, node, _package);
+
+    LinkedHashSet<String> classProperties = getConstructorProperties(node, generationConfig.isConstructorsRequiredPropertiesOnly());
+    LinkedHashSet<String> combinedSuperProperties = getSuperTypeConstructorPropertiesRecursive(node, currentSchema, generationConfig.isConstructorsRequiredPropertiesOnly());
+
+    // no properties to put in the constructor => default constructor is good enough.
+    if (classProperties.isEmpty() && combinedSuperProperties.isEmpty()) {
+      return jclass;
+    }
+
+    // add a no-args constructor for serialization purposes
+    JMethod noargsConstructor = jclass.constructor(JMod.PUBLIC);
+    noargsConstructor.javadoc().add("No args constructor for use in serialization");
+
+    // add the public constructor with property parameters
+    JMethod fieldsConstructor = jclass.constructor(JMod.PUBLIC);
+    JBlock constructorBody = fieldsConstructor.body();
+    JInvocation superInvocation = constructorBody.invoke("super");
+
+    Map<String, JFieldVar> fields = jclass.fields();
+    Map<String, JVar> classFieldParams = new HashMap<>();
+
+    for (String property : classProperties) {
+      JFieldVar field = fields.get(property);
+
+      if (field == null) {
+        throw new IllegalStateException("Property " + property + " hasn't been added to JDefinedClass before calling addConstructors");
+      }
+
+      fieldsConstructor.javadoc().addParam(property);
+      JVar param = fieldsConstructor.param(field.type(), field.name());
+      constructorBody.assign(JExpr._this().ref(field), param);
+      classFieldParams.put(property, param);
+    }
+
+    List<JVar> superConstructorParams = new ArrayList<>();
+
+
+    for (String property : combinedSuperProperties) {
+      JFieldVar field = reflectionHelper.searchSuperClassesForField(property, jclass);
+
+      if (field == null) {
+        throw new IllegalStateException("Property " + property + " hasn't been added to JDefinedClass before calling addConstructors");
+      }
+
+      JVar param = classFieldParams.get(property);
+
+      if (param == null) {
+        param = fieldsConstructor.param(field.type(), field.name());
+      }
+
+      fieldsConstructor.javadoc().addParam(property);
+      superConstructorParams.add(param);
+    }
+
+    for (JVar param : superConstructorParams) {
+      superInvocation.arg(param);
+    }
+
+    return jclass;
+  }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -151,6 +151,7 @@ public class ConstructorRule  implements Rule<JDefinedClass, JDefinedClass> {
 
     // Create a new method to be the builder constructor we're defining
     JMethod builderConstructor = builderClass.constructor(JMod.PUBLIC);
+    builderConstructor.annotate(SuppressWarnings.class).param("value", "unchecked");
     JBlock constructorBlock = builderConstructor.body();
 
     // The builder constructor should have the exact same parameters as the instanceConstructor

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -14,18 +14,33 @@
  * limitations under the License.
  */
 
+/*
+  Copyright Â© 2010-2017 Nokia
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
-import com.sun.codemodel.JPackage;
-import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,33 +50,55 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
 import org.jsonschema2pojo.util.ReflectionHelper;
 
-public class ConstructorRule  implements Rule<JPackage, JType> {
+public class ConstructorRule  implements Rule<JDefinedClass, JDefinedClass> {
 
   private final RuleFactory ruleFactory;
   private final ReflectionHelper reflectionHelper;
 
-  public ConstructorRule(RuleFactory ruleFactory, ReflectionHelper reflectionHelper) {
+  ConstructorRule(RuleFactory ruleFactory, ReflectionHelper reflectionHelper) {
     this.ruleFactory = ruleFactory;
     this.reflectionHelper = reflectionHelper;
   }
 
+  @Override
+  public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass instanceClass, Schema currentSchema) {
+
+    GenerationConfig generationConfig = ruleFactory.getGenerationConfig();
+
+    // Determine which properties belong to that class (or its superType/parent)
+    LinkedHashSet<String> classProperties = getConstructorProperties(node, generationConfig.isConstructorsRequiredPropertiesOnly());
+    LinkedHashSet<String> combinedSuperProperties = getSuperTypeConstructorPropertiesRecursive(node, currentSchema, generationConfig.isConstructorsRequiredPropertiesOnly());
+
+    // no properties to put in the constructor => default constructor is good enough.
+    if (classProperties.isEmpty() && combinedSuperProperties.isEmpty()) {
+      return instanceClass;
+    }
+
+    // Generate the no arguments constructor
+    generateNoArgsConstructor(instanceClass);
+
+    // Generate the constructor with the properties which were located
+    JMethod instanceConstructor = generateFieldsConstructor(instanceClass, classProperties, combinedSuperProperties);
+
+    // If we're using InnerClassBuilder implementations then we also need to generate those
+    if (generationConfig.isGenerateBuilders() && generationConfig.isUseInnerClassBuilders()) {
+      JDefinedClass builderClass = ruleFactory.getReflectionHelper().getBuilderClass(instanceClass);
+      generateFieldsBuilderConstructor(builderClass, instanceClass, instanceConstructor);
+    }
+
+    return instanceClass;
+  }
+
   /**
-   * Retrieve the list of properties to go in the constructor from node. This
-   * is all properties listed in node["properties"] if ! onlyRequired, and
+   * Retrieve the list of properties to go in the constructor from node. This is all properties listed in node["properties"] if ! onlyRequired, and
    * only required properties if onlyRequired.
-   *
-   * @param node
-   * @return
    */
   private LinkedHashSet<String> getConstructorProperties(JsonNode node, boolean onlyRequired) {
 
@@ -74,9 +111,9 @@ public class ConstructorRule  implements Rule<JPackage, JType> {
 
     // setup the set of required properties for draft4 style "required"
     if (onlyRequired && node.has("required")) {
-      JsonNode requiredArray =  node.get("required");
+      JsonNode requiredArray = node.get("required");
       if (requiredArray.isArray()) {
-        for (JsonNode requiredEntry: requiredArray) {
+        for (JsonNode requiredEntry : requiredArray) {
           if (requiredEntry.isTextual()) {
             draft4RequiredProperties.add(requiredEntry.asText());
           }
@@ -85,7 +122,7 @@ public class ConstructorRule  implements Rule<JPackage, JType> {
     }
 
     NameHelper nameHelper = ruleFactory.getNameHelper();
-    for (Iterator<Entry<String, JsonNode>> properties = node.get("properties").fields(); properties.hasNext();) {
+    for (Iterator<Entry<String, JsonNode>> properties = node.get("properties").fields(); properties.hasNext(); ) {
       Map.Entry<String, JsonNode> property = properties.next();
 
       JsonNode propertyObj = property.getValue();
@@ -124,24 +161,41 @@ public class ConstructorRule  implements Rule<JPackage, JType> {
     return rtn;
   }
 
-  @Override
-  public JType apply(String nodeName, JsonNode node, JsonNode parent, JPackage _package, Schema currentSchema) {
-    GenerationConfig generationConfig = ruleFactory.getGenerationConfig();
+  private void generateFieldsBuilderConstructor(JDefinedClass builderClass, JDefinedClass instanceClass, JMethod instanceConstructor) {
+    // Locate the instance field since we'll need it to assign a value
+    JFieldVar instanceField = reflectionHelper.searchClassAndSuperClassesForField("instance", builderClass);
 
-    JDefinedClass jclass = reflectionHelper._getClass(nodeName, node, _package);
+    // Create a new method to be the builder constructor we're defining
+    JMethod builderConstructor = builderClass.constructor(JMod.PUBLIC);
+    JBlock constructorBlock = builderConstructor.body();
 
-    LinkedHashSet<String> classProperties = getConstructorProperties(node, generationConfig.isConstructorsRequiredPropertiesOnly());
-    LinkedHashSet<String> combinedSuperProperties = getSuperTypeConstructorPropertiesRecursive(node, currentSchema, generationConfig.isConstructorsRequiredPropertiesOnly());
-
-    // no properties to put in the constructor => default constructor is good enough.
-    if (classProperties.isEmpty() && combinedSuperProperties.isEmpty()) {
-      return jclass;
+    // The builder constructor should have the exact same parameters as the instanceConstructor
+    for(JVar param : instanceConstructor.params()) {
+      builderConstructor.param(param.type(), param.name());
     }
 
-    // add a no-args constructor for serialization purposes
-    JMethod noargsConstructor = jclass.constructor(JMod.PUBLIC);
-    noargsConstructor.javadoc().add("No args constructor for use in serialization");
+    // Determine if we need to invoke the super() method for our parent builder
+    JClass parentClass = builderClass._extends();
+    if (!(parentClass.isPrimitive() || reflectionHelper.isFinal(parentClass) || Objects.equals(parentClass.fullName(), "java.lang.Object"))) {
+      constructorBlock.invoke("super");
+    }
 
+    // The constructor invocation will also need all the parameters passed through
+    JInvocation instanceConstructorInvocation = JExpr._new(instanceClass);
+    for(JVar param : instanceConstructor.params()) {
+      instanceConstructorInvocation.arg(param.name());
+    }
+
+    // Only initialize the instance if the object being constructed is actually this class
+    // if it's a subtype then ignore the instance initialization since the subclass will initialize it
+    constructorBlock.directStatement("// Skip initialization when called from subclass");
+
+    JInvocation comparison = JExpr._this().invoke("getClass").invoke("equals").arg(JExpr.dotclass(builderClass));
+    JConditional ifNotSubclass = constructorBlock._if(comparison);
+    ifNotSubclass._then().assign(JExpr._this().ref(instanceField), JExpr.cast(instanceField.type(), instanceConstructorInvocation));
+  }
+
+  private JMethod generateFieldsConstructor(JDefinedClass jclass, LinkedHashSet<String> classProperties, LinkedHashSet<String> combinedSuperProperties) {
     // add the public constructor with property parameters
     JMethod fieldsConstructor = jclass.constructor(JMod.PUBLIC);
     JBlock constructorBody = fieldsConstructor.body();
@@ -165,7 +219,6 @@ public class ConstructorRule  implements Rule<JPackage, JType> {
 
     List<JVar> superConstructorParams = new ArrayList<>();
 
-
     for (String property : combinedSuperProperties) {
       JFieldVar field = reflectionHelper.searchSuperClassesForField(property, jclass);
 
@@ -187,6 +240,16 @@ public class ConstructorRule  implements Rule<JPackage, JType> {
       superInvocation.arg(param);
     }
 
-    return jclass;
+    return fieldsConstructor;
   }
+
+  private void generateNoArgsConstructor(JDefinedClass jclass) {
+    // add a no-args constructor for serialization purposes
+    JMethod noargsConstructor = jclass.constructor(JMod.PUBLIC);
+    noargsConstructor.javadoc().add("No args constructor for use in serialization");
+  }
+
+
+
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -167,7 +167,7 @@ public class ConstructorRule  implements Rule<JDefinedClass, JDefinedClass> {
     // The constructor invocation will also need all the parameters passed through
     JInvocation instanceConstructorInvocation = JExpr._new(instanceClass);
     for(JVar param : instanceConstructor.params()) {
-      instanceConstructorInvocation.arg(param.name());
+      instanceConstructorInvocation.arg(param);
     }
 
     // Only initialize the instance if the object being constructed is actually this class

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
-  Copyright Â© 2010-2017 Nokia
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
- */
 package org.jsonschema2pojo.rules;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -144,7 +144,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         if (ruleFactory.getGenerationConfig().isIncludeConstructors()) {
-            ruleFactory.getConstructorRule().apply(nodeName, node, parent, _package, schema);
+            ruleFactory.getConstructorRule().apply(nodeName, node, parent, jclass, schema);
+
         }
 
         if (ruleFactory.getGenerationConfig().isSerializable()) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jsonschema2pojo.rules;
+
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
+import static org.jsonschema2pojo.rules.PrimitiveTypes.isPrimitive;
+import static org.jsonschema2pojo.rules.PrimitiveTypes.primitiveType;
+import static org.jsonschema2pojo.util.TypeUtil.resolveType;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,38 +34,25 @@ import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JFieldRef;
 import com.sun.codemodel.JFieldVar;
-import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JOp;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
-
-import org.jsonschema2pojo.AnnotationStyle;
-import org.jsonschema2pojo.Schema;
-import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
-import org.jsonschema2pojo.exception.GenerationException;
-import org.jsonschema2pojo.util.NameHelper;
-import org.jsonschema2pojo.util.ParcelableHelper;
-import org.jsonschema2pojo.util.SerializableHelper;
-
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.apache.commons.lang3.StringUtils.substringAfter;
-import static org.apache.commons.lang3.StringUtils.substringBefore;
-import static org.jsonschema2pojo.rules.PrimitiveTypes.isPrimitive;
-import static org.jsonschema2pojo.rules.PrimitiveTypes.primitiveType;
-import static org.jsonschema2pojo.util.TypeUtil.resolveType;
+import org.jsonschema2pojo.AnnotationStyle;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
+import org.jsonschema2pojo.exception.GenerationException;
+import org.jsonschema2pojo.util.ParcelableHelper;
+import org.jsonschema2pojo.util.ReflectionHelper;
+import org.jsonschema2pojo.util.SerializableHelper;
 
 /**
  * Applies the generation steps required for schemas of type "object".
@@ -72,11 +64,13 @@ import static org.jsonschema2pojo.util.TypeUtil.resolveType;
 public class ObjectRule implements Rule<JPackage, JType> {
 
     private final RuleFactory ruleFactory;
+    private final ReflectionHelper reflectionHelper;
     private final ParcelableHelper parcelableHelper;
 
-    protected ObjectRule(RuleFactory ruleFactory, ParcelableHelper parcelableHelper) {
+    protected ObjectRule(RuleFactory ruleFactory, ParcelableHelper parcelableHelper, ReflectionHelper reflectionHelper) {
         this.ruleFactory = ruleFactory;
         this.parcelableHelper = parcelableHelper;
+        this.reflectionHelper = reflectionHelper;
     }
 
     /**
@@ -89,9 +83,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
     @Override
     public JType apply(String nodeName, JsonNode node, JsonNode parent, JPackage _package, Schema schema) {
 
-        JType superType = getSuperType(nodeName, node, _package, schema);
-
-        if (superType.isPrimitive() || isFinal(superType)) {
+        JType superType = reflectionHelper.getSuperType(nodeName, node, _package, schema);
+        if (superType.isPrimitive() || reflectionHelper.isFinal(superType)) {
             return superType;
         }
 
@@ -151,7 +144,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         if (ruleFactory.getGenerationConfig().isIncludeConstructors()) {
-            addConstructors(jclass, node, schema, ruleFactory.getGenerationConfig().isConstructorsRequiredPropertiesOnly());
+            ruleFactory.getConstructorRule().apply(nodeName, node, parent, _package, schema);
         }
 
         if (ruleFactory.getGenerationConfig().isSerializable()) {
@@ -176,74 +169,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
     }
 
-    /**
-     * Retrieve the list of properties to go in the constructor from node. This
-     * is all properties listed in node["properties"] if ! onlyRequired, and
-     * only required properties if onlyRequired.
-     *
-     * @param node
-     * @return
-     */
-    private LinkedHashSet<String> getConstructorProperties(JsonNode node, boolean onlyRequired) {
 
-        if (!node.has("properties")) {
-            return new LinkedHashSet<>();
-        }
-
-        LinkedHashSet<String> rtn = new LinkedHashSet<>();
-        Set<String> draft4RequiredProperties = new HashSet<>();
-
-        // setup the set of required properties for draft4 style "required"
-        if (onlyRequired && node.has("required")) {
-            JsonNode requiredArray =  node.get("required");
-            if (requiredArray.isArray()) {
-                for (JsonNode requiredEntry: requiredArray) {
-                    if (requiredEntry.isTextual()) {
-                        draft4RequiredProperties.add(requiredEntry.asText());
-                    }
-                }
-            }
-        }
-
-        NameHelper nameHelper = ruleFactory.getNameHelper();
-        for (Iterator<Map.Entry<String, JsonNode>> properties = node.get("properties").fields(); properties.hasNext();) {
-            Map.Entry<String, JsonNode> property = properties.next();
-
-            JsonNode propertyObj = property.getValue();
-            if (onlyRequired) {
-                // draft3 style
-                if (propertyObj.has("required") && propertyObj.get("required").asBoolean()) {
-                    rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
-                }
-
-                // draft4 style
-                if (draft4RequiredProperties.contains(property.getKey())) {
-                    rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
-                }
-            } else {
-                rtn.add(nameHelper.getPropertyName(property.getKey(), property.getValue()));
-            }
-        }
-        return rtn;
-    }
-
-    /**
-     * Recursive, walks the schema tree and assembles a list of all properties of this schema's super schemas
-     */
-    private LinkedHashSet<String> getSuperTypeConstructorPropertiesRecursive(JsonNode node, Schema schema, boolean onlyRequired) {
-        Schema superTypeSchema = getSuperSchema(node, schema, true);
-
-        if (superTypeSchema == null) {
-            return new LinkedHashSet<>();
-        }
-
-        JsonNode superSchemaNode = superTypeSchema.getContent();
-
-        LinkedHashSet<String> rtn = getConstructorProperties(superSchemaNode, onlyRequired);
-        rtn.addAll(getSuperTypeConstructorPropertiesRecursive(superSchemaNode, superTypeSchema, onlyRequired));
-
-        return rtn;
-    }
 
     /**
      * Creates a new Java class that will be generated.
@@ -304,9 +230,9 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 }
             } else {
                 if (usePolymorphicDeserialization) {
-                    newType = _package._class(JMod.PUBLIC, ruleFactory.getNameHelper().getClassName(nodeName, node, _package), ClassType.CLASS);
+                    newType = _package._class(JMod.PUBLIC, ruleFactory.getNameHelper().getUniqueClassName(nodeName, node, _package), ClassType.CLASS);
                 } else {
-                    newType = _package._class(ruleFactory.getNameHelper().getClassName(nodeName, node, _package));
+                    newType = _package._class(ruleFactory.getNameHelper().getUniqueClassName(nodeName, node, _package));
                 }
             }
         } catch (JClassAlreadyExistsException e) {
@@ -317,60 +243,6 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         return newType;
 
-    }
-
-    private boolean isFinal(JType superType) {
-        try {
-            Class<?> javaClass = Class.forName(superType.fullName());
-            return Modifier.isFinal(javaClass.getModifiers());
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
-
-    private JType getSuperType(String nodeName, JsonNode node, JPackage jPackage, Schema schema) {
-        if (node.has("extends") && node.has("extendsJavaClass")) {
-            throw new IllegalStateException("'extends' and 'extendsJavaClass' defined simultaneously");
-        }
-
-        JType superType = jPackage.owner().ref(Object.class);
-        Schema superTypeSchema = getSuperSchema(node, schema, false);
-        if (superTypeSchema != null) {
-            superType = ruleFactory.getSchemaRule().apply(nodeName + "Parent", node.get("extends"), node, jPackage, superTypeSchema);
-        } else if (node.has("extendsJavaClass")) {
-            superType = resolveType(jPackage, node.get("extendsJavaClass").asText());
-        }
-
-        return superType;
-    }
-
-    private Schema getSuperSchema(JsonNode node, Schema schema, boolean followRefs) {
-        if (node.has("extends")) {
-            String path;
-            if (schema.getId().getFragment() == null) {
-                path = "#extends";
-            } else {
-                path = "#" + schema.getId().getFragment() + "/extends";
-            }
-
-            Schema superSchema = ruleFactory.getSchemaStore().create(schema, path, ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
-
-            if (followRefs) {
-                superSchema = resolveSchemaRefsRecursive(superSchema);
-            }
-
-            return superSchema;
-        }
-        return null;
-    }
-
-    private Schema resolveSchemaRefsRecursive(Schema schema) {
-        JsonNode schemaNode = schema.getContent();
-        if (schemaNode.has("$ref")) {
-            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
-            return resolveSchemaRefsRecursive(schema);
-        }
-        return schema;
     }
 
     private void addJsonTypeInfoAnnotation(JDefinedClass jclass, JsonNode node) {
@@ -576,98 +448,6 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
 
         return filteredFields;
-    }
-
-    private void addConstructors(JDefinedClass jclass, JsonNode node, Schema schema, boolean onlyRequired) {
-
-        LinkedHashSet<String> classProperties = getConstructorProperties(node, onlyRequired);
-        LinkedHashSet<String> combinedSuperProperties = getSuperTypeConstructorPropertiesRecursive(node, schema, onlyRequired);
-
-        // no properties to put in the constructor => default constructor is good enough.
-        if (classProperties.isEmpty() && combinedSuperProperties.isEmpty()) {
-            return;
-        }
-
-        // add a no-args constructor for serialization purposes
-        JMethod noargsConstructor = jclass.constructor(JMod.PUBLIC);
-        noargsConstructor.javadoc().add("No args constructor for use in serialization");
-
-        // add the public constructor with property parameters
-        JMethod fieldsConstructor = jclass.constructor(JMod.PUBLIC);
-        JBlock constructorBody = fieldsConstructor.body();
-        JInvocation superInvocation = constructorBody.invoke("super");
-
-        Map<String, JFieldVar> fields = jclass.fields();
-        Map<String, JVar> classFieldParams = new HashMap<>();
-
-        for (String property : classProperties) {
-            JFieldVar field = fields.get(property);
-
-            if (field == null) {
-                throw new IllegalStateException("Property " + property + " hasn't been added to JDefinedClass before calling addConstructors");
-            }
-
-            fieldsConstructor.javadoc().addParam(property);
-            JVar param = fieldsConstructor.param(field.type(), field.name());
-            constructorBody.assign(JExpr._this().ref(field), param);
-            classFieldParams.put(property, param);
-        }
-
-        List<JVar> superConstructorParams = new ArrayList<>();
-
-
-        for (String property : combinedSuperProperties) {
-            JFieldVar field = searchSuperClassesForField(property, jclass);
-
-            if (field == null) {
-                throw new IllegalStateException("Property " + property + " hasn't been added to JDefinedClass before calling addConstructors");
-            }
-
-            JVar param = classFieldParams.get(property);
-
-            if (param == null) {
-                param = fieldsConstructor.param(field.type(), field.name());
-            }
-
-            fieldsConstructor.javadoc().addParam(property);
-            superConstructorParams.add(param);
-        }
-
-        for (JVar param : superConstructorParams) {
-            superInvocation.arg(param);
-        }
-    }
-
-    private static JDefinedClass definedClassOrNullFromType(JType type)
-    {
-        if (type == null || type.isPrimitive())
-        {
-            return null;
-        }
-        JClass fieldClass = type.boxify();
-        JPackage jPackage = fieldClass._package();
-        return jPackage._getClass(fieldClass.name());
-    }
-
-    /**
-     * This is recursive with searchClassAndSuperClassesForField
-     */
-    private JFieldVar searchSuperClassesForField(String property, JDefinedClass jclass) {
-        JClass superClass = jclass._extends();
-        JDefinedClass definedSuperClass = definedClassOrNullFromType(superClass);
-        if (definedSuperClass == null) {
-            return null;
-        }
-        return searchClassAndSuperClassesForField(property, definedSuperClass);
-    }
-
-    private JFieldVar searchClassAndSuperClassesForField(String property, JDefinedClass jclass) {
-        Map<String, JFieldVar> fields = jclass.fields();
-        JFieldVar field = fields.get(property);
-        if (field == null) {
-            return searchSuperClassesForField(property, jclass);
-        }
-        return field;
     }
 
     private void addEquals(JDefinedClass jclass, JsonNode node) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
@@ -93,6 +93,7 @@ public class PropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
 
     private void addOverrideBuilder(JDefinedClass thisJDefinedClass, JMethod parentBuilder, JVar parentParam) {
 
+        // Confirm that this class doesn't already have a builder method matching the same name as the parentBuilder
         if (thisJDefinedClass.getMethod(parentBuilder.name(), new JType[] {parentParam.type()}) == null) {
 
             JMethod builder = thisJDefinedClass.method(parentBuilder.mods().getValue(), thisJDefinedClass, parentBuilder.name());

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -242,16 +242,10 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
     }
 
   private JMethod addBuilder(JDefinedClass c, JFieldVar field, String jsonPropertyName, JsonNode node) {
-    // Requires one of the builder generation methods to be set to true
-    if(! ruleFactory.getGenerationConfig().isUseInnerClassBuilders() && !ruleFactory.getGenerationConfig().isChainableSettersBuilders()) {
-      throw new IllegalStateException("Both chainable setters and inner class builder method generation are disabled, but builder generation is enabled");
-    }
-
     JMethod result = null;
     if(ruleFactory.getGenerationConfig().isUseInnerClassBuilders()) {
       result = addInnerBuilder(c, field, jsonPropertyName, node);
-    }
-    if(ruleFactory.getGenerationConfig().isChainableSettersBuilders()) {
+    } else {
       result = addLegacyBuilder(c, field, jsonPropertyName, node);
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -279,7 +279,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
     JVar param = builder.param(field.type(), field.name());
     JBlock body = builder.body();
-    body.assign(JExpr._this().ref("instance").ref(field), param);
+    body.assign(JExpr.ref(JExpr.cast(c, JExpr._this().ref("instance")), field), param);
     body._return(JExpr._this());
 
     return builder;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -32,6 +32,7 @@ import com.sun.codemodel.JDocCommentable;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
+import org.jsonschema2pojo.util.ReflectionHelper;
 
 /**
  * Provides factory/creation methods for the code generation rules.
@@ -119,7 +120,17 @@ public class RuleFactory {
      * @return a schema rule that can handle the "object" declaration.
      */
     public Rule<JPackage, JType> getObjectRule() {
-        return new ObjectRule(this, new ParcelableHelper());
+        return new ObjectRule(this, new ParcelableHelper(), new ReflectionHelper(this));
+    }
+
+    /**
+     * Provides a rule instance that should be applied to add constructors to a generated type
+     *
+     * @return a schema rule that can handle the "object" declaration.
+     */
+    public Rule<JPackage, JType> getConstructorRule()
+    {
+        return new ConstructorRule(this, new ReflectionHelper(this));
     }
 
     /**
@@ -375,9 +386,8 @@ public class RuleFactory {
     }
 
     public Rule<JDefinedClass, JDefinedClass> getBuilderRule(){
-        return new BuilderRule(this);
+        return new BuilderRule(this, new ReflectionHelper(this));
     }
-
 
     public Rule<JDocCommentable, JDocComment> getJavaNameRule() {
         return new JavaNameRule();

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -374,6 +374,11 @@ public class RuleFactory {
         return new DynamicPropertiesRule(this);
     }
 
+    public Rule<JDefinedClass, JDefinedClass> getBuilderRule(){
+        return new BuilderRule(this);
+    }
+
+
     public Rule<JDocCommentable, JDocComment> getJavaNameRule() {
         return new JavaNameRule();
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -33,6 +33,7 @@ import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 import org.jsonschema2pojo.util.ReflectionHelper;
+import sun.reflect.Reflection;
 
 /**
  * Provides factory/creation methods for the code generation rules.
@@ -40,6 +41,7 @@ import org.jsonschema2pojo.util.ReflectionHelper;
 public class RuleFactory {
 
     private NameHelper nameHelper;
+    private ReflectionHelper reflectionHelper;
     private GenerationConfig generationConfig;
     private Annotator annotator;
     private SchemaStore schemaStore;
@@ -62,6 +64,7 @@ public class RuleFactory {
         this.annotator = annotator;
         this.schemaStore = schemaStore;
         this.nameHelper = new NameHelper(generationConfig);
+        this.reflectionHelper = new ReflectionHelper(this);
     }
 
     /**
@@ -120,7 +123,7 @@ public class RuleFactory {
      * @return a schema rule that can handle the "object" declaration.
      */
     public Rule<JPackage, JType> getObjectRule() {
-        return new ObjectRule(this, new ParcelableHelper(), new ReflectionHelper(this));
+        return new ObjectRule(this, new ParcelableHelper(), reflectionHelper);
     }
 
     /**
@@ -128,9 +131,9 @@ public class RuleFactory {
      *
      * @return a schema rule that can handle the "object" declaration.
      */
-    public Rule<JPackage, JType> getConstructorRule()
+    public Rule<JDefinedClass, JDefinedClass> getConstructorRule()
     {
-        return new ConstructorRule(this, new ReflectionHelper(this));
+        return new ConstructorRule(this, reflectionHelper);
     }
 
     /**
@@ -367,6 +370,11 @@ public class RuleFactory {
         return nameHelper;
     }
 
+    public ReflectionHelper getReflectionHelper()    {
+        return reflectionHelper;
+    }
+
+
     /**
      * Provides a rule instance that should be applied when a "media"
      * declaration is found in the schema.
@@ -386,7 +394,7 @@ public class RuleFactory {
     }
 
     public Rule<JDefinedClass, JDefinedClass> getBuilderRule(){
-        return new BuilderRule(this, new ReflectionHelper(this));
+        return new BuilderRule(this, reflectionHelper);
     }
 
     public Rule<JDocCommentable, JDocComment> getJavaNameRule() {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -1,17 +1,14 @@
 /**
  * Copyright © 2010-2017 Nokia
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.jsonschema2pojo.rules;
@@ -33,155 +30,145 @@ import com.sun.codemodel.JType;
 /**
  * Applies the "type" schema rule.
  *
- * @see <a href=
- *      "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1">http:/
- *      /tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1</a>
+ * @see <a href= "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1">http:/ /tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1</a>
  */
 public class TypeRule implements Rule<JClassContainer, JType> {
 
-    private static final String DEFAULT_TYPE_NAME = "any";
+  private static final String DEFAULT_TYPE_NAME = "any";
 
-    private final RuleFactory ruleFactory;
+  private final RuleFactory ruleFactory;
 
-    protected TypeRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+  protected TypeRule(RuleFactory ruleFactory) {
+    this.ruleFactory = ruleFactory;
+  }
+
+  /**
+   * Applies this schema rule to take the required code generation steps.
+   * <p>
+   * When applied, this rule reads the details of the given node to determine the appropriate Java type to return. This may be a newly generated type,
+   * it may be a primitive type or other type such as {@link java.lang.String} or {@link java.lang.Object}.
+   * <p>
+   * JSON schema types and their Java type equivalent:
+   * <ul>
+   * <li>"type":"any" =&gt; {@link java.lang.Object}
+   * <li>"type":"array" =&gt; Either {@link java.util.Set} or
+   * {@link java.util.List}, see {@link ArrayRule}
+   * <li>"type":"boolean" =&gt; <code>boolean</code>
+   * <li>"type":"integer" =&gt; <code>int</code>
+   * <li>"type":"null" =&gt; {@link java.lang.Object}
+   * <li>"type":"number" =&gt; <code>double</code>
+   * <li>"type":"object" =&gt; Generated type (see {@link ObjectRule})
+   * <li>"type":"string" =&gt; {@link java.lang.String} (or alternative based
+   * on presence of "format", see {@link FormatRule})
+   * </ul>
+   *
+   * @param nodeName the name of the node for which this "type" rule applies
+   * @param node the node for which this "type" rule applies
+   * @param parent the parent node
+   * @param jClassContainer the package into which any newly generated type may be placed
+   * @return the Java type which, after reading the details of the given schema node, most appropriately matches the "type" specified
+   */
+  @Override
+  public JType apply(String nodeName, JsonNode node, JsonNode parent, JClassContainer jClassContainer, Schema schema) {
+
+    String propertyTypeName = getTypeName(node);
+
+    JType type;
+
+    if (propertyTypeName.equals("object") || node.has("properties") && node.path("properties").size() > 0) {
+
+      type = ruleFactory.getObjectRule().apply(nodeName, node, parent, jClassContainer.getPackage(), schema);
+    } else if (node.has("existingJavaType")) {
+      String typeName = node.path("existingJavaType").asText();
+
+      if (isPrimitive(typeName, jClassContainer.owner())) {
+        type = primitiveType(typeName, jClassContainer.owner());
+      } else {
+        type = resolveType(jClassContainer, typeName);
+      }
+    } else if (propertyTypeName.equals("string")) {
+
+      type = jClassContainer.owner().ref(String.class);
+    } else if (propertyTypeName.equals("number")) {
+
+      type = getNumberType(jClassContainer.owner(), ruleFactory.getGenerationConfig());
+    } else if (propertyTypeName.equals("integer")) {
+
+      type = getIntegerType(jClassContainer.owner(), node, ruleFactory.getGenerationConfig());
+    } else if (propertyTypeName.equals("boolean")) {
+
+      type = unboxIfNecessary(jClassContainer.owner().ref(Boolean.class), ruleFactory.getGenerationConfig());
+    } else if (propertyTypeName.equals("array")) {
+
+      type = ruleFactory.getArrayRule().apply(nodeName, node, parent, jClassContainer.getPackage(), schema);
+    } else {
+
+      type = jClassContainer.owner().ref(Object.class);
     }
 
-    /**
-     * Applies this schema rule to take the required code generation steps.
-     * <p>
-     * When applied, this rule reads the details of the given node to determine
-     * the appropriate Java type to return. This may be a newly generated type,
-     * it may be a primitive type or other type such as {@link java.lang.String}
-     * or {@link java.lang.Object}.
-     * <p>
-     * JSON schema types and their Java type equivalent:
-     * <ul>
-     * <li>"type":"any" =&gt; {@link java.lang.Object}
-     * <li>"type":"array" =&gt; Either {@link java.util.Set} or
-     * {@link java.util.List}, see {@link ArrayRule}
-     * <li>"type":"boolean" =&gt; <code>boolean</code>
-     * <li>"type":"integer" =&gt; <code>int</code>
-     * <li>"type":"null" =&gt; {@link java.lang.Object}
-     * <li>"type":"number" =&gt; <code>double</code>
-     * <li>"type":"object" =&gt; Generated type (see {@link ObjectRule})
-     * <li>"type":"string" =&gt; {@link java.lang.String} (or alternative based
-     * on presence of "format", see {@link FormatRule})
-     * </ul>
-     *
-     * @param nodeName
-     *            the name of the node for which this "type" rule applies
-     * @param node
-     *            the node for which this "type" rule applies
-     * @param parent
-     *            the parent node
-     * @param jClassContainer
-     *            the package into which any newly generated type may be placed
-     * @return the Java type which, after reading the details of the given
-     *         schema node, most appropriately matches the "type" specified
-     */
-    @Override
-    public JType apply(String nodeName, JsonNode node, JsonNode parent, JClassContainer jClassContainer, Schema schema) {
-
-        String propertyTypeName = getTypeName(node);
-
-        JType type;
-
-        if (propertyTypeName.equals("object") || node.has("properties") && node.path("properties").size() > 0) {
-
-            type = ruleFactory.getObjectRule().apply(nodeName, node, parent, jClassContainer.getPackage(), schema);
-        } else if (node.has("existingJavaType")) {
-            String typeName = node.path("existingJavaType").asText();
-
-            if (isPrimitive(typeName, jClassContainer.owner())) {
-                type = primitiveType(typeName, jClassContainer.owner());
-            } else {
-                type = resolveType(jClassContainer, typeName);
-            }
-        } else if (propertyTypeName.equals("string")) {
-
-            type = jClassContainer.owner().ref(String.class);
-        } else if (propertyTypeName.equals("number")) {
-
-            type = getNumberType(jClassContainer.owner(), ruleFactory.getGenerationConfig());
-        } else if (propertyTypeName.equals("integer")) {
-
-            type = getIntegerType(jClassContainer.owner(), node, ruleFactory.getGenerationConfig());
-        } else if (propertyTypeName.equals("boolean")) {
-
-            type = unboxIfNecessary(jClassContainer.owner().ref(Boolean.class), ruleFactory.getGenerationConfig());
-        } else if (propertyTypeName.equals("array")) {
-
-            type = ruleFactory.getArrayRule().apply(nodeName, node, parent, jClassContainer.getPackage(), schema);
-        } else {
-
-            type = jClassContainer.owner().ref(Object.class);
-        }
-
-        if (!node.has("javaType") && !node.has("existingJavaType") && node.has("format")) {
-            type = ruleFactory.getFormatRule().apply(nodeName, node.get("format"), node, type, schema);
-        } else if (!node.has("javaType") && !node.has("existingJavaType") && propertyTypeName.equals("string") && node.has("media")) {
-            type = ruleFactory.getMediaRule().apply(nodeName, node.get("media"), node, type, schema);
-        }
-
-        return type;
+    if (!node.has("javaType") && !node.has("existingJavaType") && node.has("format")) {
+      type = ruleFactory.getFormatRule().apply(nodeName, node.get("format"), node, type, schema);
+    } else if (!node.has("javaType") && !node.has("existingJavaType") && propertyTypeName.equals("string") && node.has("media")) {
+      type = ruleFactory.getMediaRule().apply(nodeName, node.get("media"), node, type, schema);
     }
 
-    private String getTypeName(JsonNode node) {
-        if (node.has("type") && node.get("type").isArray() && node.get("type").size() > 0) {
-            for (JsonNode jsonNode : node.get("type")) {
-                String typeName = jsonNode.asText();
-                if (!typeName.equals("null")) {
-                    return typeName;
-                }
-            }
-        }
+    return type;
+  }
 
-        if (node.has("type") && node.get("type").isTextual()) {
-            return node.get("type").asText();
+  private String getTypeName(JsonNode node) {
+    if (node.has("type") && node.get("type").isArray() && node.get("type").size() > 0) {
+      for (JsonNode jsonNode : node.get("type")) {
+        String typeName = jsonNode.asText();
+        if (!typeName.equals("null")) {
+          return typeName;
         }
-
-        return DEFAULT_TYPE_NAME;
+      }
     }
 
-    private JType unboxIfNecessary(JType type, GenerationConfig config) {
-        if (config.isUsePrimitives()) {
-            return type.unboxify();
-        } else {
-            return type;
-        }
+    if (node.has("type") && node.get("type").isTextual()) {
+      return node.get("type").asText();
     }
 
-    /**
-     * Returns the JType for an integer field. Handles type lookup and unboxing.
-     */
-    private JType getIntegerType(JCodeModel owner, JsonNode node, GenerationConfig config) {
+    return DEFAULT_TYPE_NAME;
+  }
 
-        if (config.isUseBigIntegers()) {
-            return unboxIfNecessary(owner.ref(BigInteger.class), config);
-        } else if (config.isUseLongIntegers() ||
-                node.has("minimum") && node.get("minimum").isLong() ||
-                node.has("maximum") && node.get("maximum").isLong()) {
-            return unboxIfNecessary(owner.ref(Long.class), config);
-        } else {
-            return unboxIfNecessary(owner.ref(Integer.class), config);
-        }
+  private JType unboxIfNecessary(JType type, GenerationConfig config) {
+    if (config.isUsePrimitives()) {
+      return type.unboxify();
+    } else {
+      return type;
+    }
+  }
 
+  /**
+   * Returns the JType for an integer field. Handles type lookup and unboxing.
+   */
+  private JType getIntegerType(JCodeModel owner, JsonNode node, GenerationConfig config) {
+
+    if (config.isUseBigIntegers()) {
+      return unboxIfNecessary(owner.ref(BigInteger.class), config);
+    } else if (config.isUseLongIntegers() || node.has("minimum") && node.get("minimum").isLong() || node.has("maximum") && node.get("maximum")
+        .isLong()) {
+      return unboxIfNecessary(owner.ref(Long.class), config);
+    } else {
+      return unboxIfNecessary(owner.ref(Integer.class), config);
     }
 
-    /**
-     * Returns the JType for a number field. Handles type lookup and unboxing.
-     */
-    private JType getNumberType(JCodeModel owner, GenerationConfig config) {
+  }
 
-        if (config.isUseBigDecimals()) {
-            return unboxIfNecessary(owner.ref(BigDecimal.class), config);
-        } else if (config.isUseDoubleNumbers()) {
-            return unboxIfNecessary(owner.ref(Double.class), config);
-        } else {
-            return unboxIfNecessary(owner.ref(Float.class), config);
-        }
+  /**
+   * Returns the JType for a number field. Handles type lookup and unboxing.
+   */
+  private JType getNumberType(JCodeModel owner, GenerationConfig config) {
 
+    if (config.isUseBigDecimals()) {
+      return unboxIfNecessary(owner.ref(BigDecimal.class), config);
+    } else if (config.isUseDoubleNumbers()) {
+      return unboxIfNecessary(owner.ref(Double.class), config);
+    } else {
+      return unboxIfNecessary(owner.ref(Float.class), config);
     }
+
+  }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -16,19 +16,21 @@
 
 package org.jsonschema2pojo.util;
 
-import static java.lang.Character.*;
-import static javax.lang.model.SourceVersion.*;
-import static org.apache.commons.lang3.StringUtils.*;
+import static java.lang.Character.isDigit;
+import static java.lang.Character.toLowerCase;
+import static javax.lang.model.SourceVersion.isKeyword;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.containsAny;
+import static org.apache.commons.lang3.StringUtils.remove;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassAlreadyExistsException;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
 import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.sun.codemodel.JType;
-import org.jsonschema2pojo.rules.RuleFactory;
 
 public class NameHelper {
 
@@ -218,8 +220,12 @@ public class NameHelper {
         return jsonPropertyName;
     }
 
-    public String getBuilderClassName(JDefinedClass outterClass) {
+    public String getBuilderClassName(JClass outterClass) {
         return outterClass.name() + "Builder";
+    }
+
+    public String getUniqueClassName(String nodeName, JsonNode node, JPackage _package) {
+        return makeUnique(getClassName(nodeName, node, _package), _package);
     }
 
     public String getClassName(String nodeName, JsonNode node, JPackage _package) {
@@ -230,8 +236,7 @@ public class NameHelper {
         String fullFieldName = createFullFieldName(capitalizedFieldName, prefix, suffix);
 
         String className = replaceIllegalCharacters(fullFieldName);
-        String normalizedName = normalizeName(className);
-        return makeUnique(normalizedName, _package);
+        return normalizeName(className);
     }
 
     private String createFullFieldName(String nodeName, String prefix, String suffix) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ReflectionHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ReflectionHelper.java
@@ -13,19 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
-  Copyright Â© 2010-2017 Nokia
-
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
-  copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
-  under the License.
- */
 package org.jsonschema2pojo.util;
 
 import static org.jsonschema2pojo.util.TypeUtil.resolveType;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ReflectionHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ReflectionHelper.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright Â© 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import static org.jsonschema2pojo.util.TypeUtil.resolveType;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.rules.RuleFactory;
+
+public class ReflectionHelper {
+
+  private RuleFactory ruleFactory;
+
+  public ReflectionHelper(RuleFactory ruleFactory) {
+    this.ruleFactory = ruleFactory;
+  }
+
+  public JType getSuperType(String nodeName, JsonNode node, JPackage jPackage, Schema schema) {
+    if (node.has("extends") && node.has("extendsJavaClass")) {
+      throw new IllegalStateException("'extends' and 'extendsJavaClass' defined simultaneously");
+    }
+
+    JType superType = jPackage.owner().ref(Object.class);
+    Schema superTypeSchema = getSuperSchema(node, schema, false);
+    if (superTypeSchema != null) {
+      superType = ruleFactory.getSchemaRule().apply(nodeName + "Parent", node.get("extends"), node, jPackage, superTypeSchema);
+    } else if (node.has("extendsJavaClass")) {
+      superType = resolveType(jPackage, node.get("extendsJavaClass").asText());
+    }
+
+    return superType;
+  }
+
+  public Schema getSuperSchema(JsonNode node, Schema schema, boolean followRefs) {
+    if (node.has("extends")) {
+      String path;
+      if (schema.getId().getFragment() == null) {
+        path = "#extends";
+      } else {
+        path = "#" + schema.getId().getFragment() + "/extends";
+      }
+
+      Schema superSchema = ruleFactory.getSchemaStore().create(schema, path, ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+
+      if (followRefs) {
+        superSchema = resolveSchemaRefsRecursive(superSchema);
+      }
+
+      return superSchema;
+    }
+    return null;
+  }
+
+  private Schema resolveSchemaRefsRecursive(Schema schema) {
+    JsonNode schemaNode = schema.getContent();
+    if (schemaNode.has("$ref")) {
+      schema = ruleFactory.getSchemaStore()
+          .create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+      return resolveSchemaRefsRecursive(schema);
+    }
+    return schema;
+  }
+
+  /**
+   * This is recursive with searchClassAndSuperClassesForField
+   */
+  public JFieldVar searchSuperClassesForField(String property, JDefinedClass jclass) {
+    JClass superClass = jclass._extends();
+    JDefinedClass definedSuperClass = definedClassOrNullFromType(superClass);
+    if (definedSuperClass == null) {
+      return null;
+    }
+    return searchClassAndSuperClassesForField(property, definedSuperClass);
+  }
+
+  private JFieldVar searchClassAndSuperClassesForField(String property, JDefinedClass jclass) {
+    Map<String, JFieldVar> fields = jclass.fields();
+    JFieldVar field = fields.get(property);
+    if (field == null) {
+      return searchSuperClassesForField(property, jclass);
+    }
+    return field;
+  }
+
+  private static JDefinedClass definedClassOrNullFromType(JType type) {
+    if (type == null || type.isPrimitive()) {
+      return null;
+    }
+    JClass fieldClass = type.boxify();
+    JPackage jPackage = fieldClass._package();
+    return jPackage._getClass(fieldClass.name());
+  }
+
+  public JDefinedClass _getClass(String nodeName, JsonNode node, JPackage _package) {
+    NameHelper nameHelper = ruleFactory.getNameHelper();
+    String className = nameHelper.getClassName(nodeName, node, _package);
+
+    return _package._getClass(className);
+  }
+
+  public JDefinedClass _getClass(String name, JPackage _package) {
+    return getAllPackageClasses(_package).stream().filter(definedClass -> definedClass.name().equals(name)).findFirst()
+        .orElseThrow(() -> new NoClassDefFoundError(name));
+  }
+
+  public Collection<JDefinedClass> getAllPackageClasses(JPackage _package) {
+    LinkedList<JDefinedClass> result = new LinkedList<>();
+    StreamSupport.stream(Spliterators.spliteratorUnknownSize(_package.classes(), Spliterator.ORDERED), false)
+        .forEach(_class -> result.addAll(getAllClassClasses(_class)));
+    return result;
+  }
+
+  public Collection<JDefinedClass> getAllClassClasses(JDefinedClass _class) {
+    LinkedList<JDefinedClass> result = new LinkedList<>();
+    result.add(_class);
+
+    _class.classes().forEachRemaining(subclass -> result.add(subclass));
+    return result;
+  }
+
+
+  public boolean isFinal(JType superType) {
+    try {
+      Class<?> javaClass = Class.forName(superType.fullName());
+      return Modifier.isFinal(javaClass.getModifiers());
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/child.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/child.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://example.com/child.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description" : "A schema definition for an object which can be inherited",
+  "javaType" : "com.example.package.GeneratedChildType",
+  "type" : "object",
+  "extends" : {
+    "$ref" : "parent.json"
+  },
+  "properties" : {
+    "childProperty" : { "type" : "string" }
+  },
+  "dependencies" : {
+  }
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/parent.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/parent.json
@@ -1,0 +1,12 @@
+{
+  "$id": "https://example.com/address.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description" : "A schema definition for an object which can be inherited",
+  "javaType" : "com.example.package.GeneratedParentType",
+  "type" : "object",
+  "properties" : {
+    "parentProperty" : { "type" : "string" }
+  },
+  "dependencies" : {
+  }
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -45,6 +45,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   Class<? extends Annotator> customAnnotator
   Class<? extends RuleFactory> customRuleFactory
   boolean generateBuilders
+  boolean useInnerClassBuilders
   boolean includeGetters
   boolean includeSetters
   boolean includeAdditionalProperties
@@ -95,6 +96,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
     generateBuilders = false
+    useInnerClassBuilders = false
     usePrimitives = false
     sourceFiles = []
     targetPackage = ''
@@ -254,6 +256,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |sourceSortOrder = ${sourceSortOrder}
        |targetLanguage = ${targetLanguage}
        |formatTypeMapping = ${formatTypeMapping}
+       |useInnerClassBuilders = ${useInnerClassBuilders}
      """.stripMargin()
   }
   

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.hamcrest.Matchers.not;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+import org.apache.commons.lang.StringUtils;
+import org.hamcrest.Matcher;
+import org.jsonschema2pojo.integration.util.FileSearchMatcher;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+@SuppressWarnings("rawtypes")
+public class UseInnerClassBuildersIT {
+
+  @Rule
+  public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+  private static Matcher<File> containsText(String searchText) {
+    return new FileSearchMatcher(searchText);
+  }
+
+  /**
+   * This test asserts that no methods containing 'with' appear in the generated code using the default configuration
+   */
+  @Test
+  public void noBuilderMethodsByDefault() {
+    File outputDirectory = schemaRule.generate("/schema.useInnerClassBuilders/child.json", "com.example", config());
+
+    assertThat(outputDirectory, not(containsText("with")));
+  }
+
+  /**
+   * This method confirms that if you choose to generate builders, but don't indicate that useInnerBuilders is true, they will be generated using the
+   * chaining setters instead of the inner classes
+   */
+  @Test(expected = ClassNotFoundException.class)
+  public void defaultBuilderIsChainedSetters() throws ClassNotFoundException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true));
+
+    Class<?> childClass = resultsClassLoader.loadClass("com.example.Child");
+    boolean containsWithMethod = Stream.of(childClass.getMethods())
+        .map(Method::getName)
+        .anyMatch(methodName -> StringUtils.contains(methodName, "with"));
+
+    assertTrue("Generated class missing any builders at all", containsWithMethod);
+
+    resultsClassLoader.loadClass("com.example.Child.ChildBuilder");
+  }
+
+  /**
+   * This method confirms that if you choose to use inner class builders then the chaining setters will be removed from the generated class
+   */
+  @Test
+  public void innerBuildersRemoveChainedSetters() throws ClassNotFoundException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true, "useInnerClassBuilders", true));
+
+    Class<?> childClass = resultsClassLoader.loadClass("com.example.Child");
+    boolean containsWithMethod = Stream.of(childClass.getMethods())
+        .map(Method::getName)
+        .anyMatch(methodName -> StringUtils.contains(methodName, "with"));
+
+    assertFalse("Generated contains unexpected builders", containsWithMethod);
+
+    assertNotNull(resultsClassLoader.loadClass("com.example.Child$ChildBuilder"));
+  }
+
+  /**
+   * This methods confirms that the builders can be constructed using the empty constructor and possess a 'build' method that will return a non-null
+   * object
+   */
+  @Test
+  public void innerBuildersInvokeBuild()
+      throws ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true, "useInnerClassBuilders", true));
+
+    Class<?> builderClass = resultsClassLoader.loadClass("com.example.Child$ChildBuilder");
+    Method buildMethod = builderClass.getMethod("build");
+
+    Object builder = builderClass.newInstance();
+    assertNotNull(builder);
+
+    assertNotNull(buildMethod.invoke(builder));
+  }
+
+  /**
+   * This method walks through invoking the various incremental 'with' methods to build out an entire object, then invokes build on the constructed
+   * object and confirms all values on the object match those provided to the with methods
+   */
+  @Test
+  public void innerBuildersBuildObjectIncrementally()
+      throws ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true, "useInnerClassBuilders", true));
+
+    Class<?> builderClass = resultsClassLoader.loadClass("com.example.Child$ChildBuilder");
+    Method buildMethod = builderClass.getMethod("build");
+    Method withChildProperty = builderClass.getMethod("withChildProperty", Integer.class);
+    Method withParentProperty = builderClass.getMethod("withParentProperty", String.class);
+    Method withSharedProperty = builderClass.getMethod("withSharedProperty", String.class);
+
+    int childProperty = 1;
+    String parentProperty = "parentProperty";
+    String sharedProperty = "sharedProperty";
+
+    Object builder = builderClass.newInstance();
+    withChildProperty.invoke(builder, childProperty);
+    withParentProperty.invoke(builder, parentProperty);
+    withSharedProperty.invoke(builder, sharedProperty);
+    Object childObject = buildMethod.invoke(builder);
+
+    Class<?> childClass = resultsClassLoader.loadClass("com.example.Child");
+    Method getChildProperty = childClass.getMethod("getChildProperty");
+    Method getParentProperty = childClass.getMethod("getParentProperty");
+    Method getSharedProperty = childClass.getMethod("getSharedProperty");
+
+    assertEquals(childProperty, getChildProperty.invoke(childObject));
+    assertEquals(parentProperty, getParentProperty.invoke(childObject));
+    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+  }
+
+  /**
+   * This method confirms that by default the only constructor available to a builder is the empty argument constructor
+   */
+  @Test
+  public void innerBuilderExtraConstructorsRequireConfig() throws ClassNotFoundException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true, "useInnerClassBuilders", true));
+
+    Class<?> builderClass = resultsClassLoader.loadClass("com.example.Child$ChildBuilder");
+    assertEquals(1, builderClass.getConstructors().length);
+
+    Constructor<?> constructor = builderClass.getConstructors()[0];
+    assertEquals(0, constructor.getParameterCount());
+  }
+
+  /**
+   * This method confirms that if constructors are enabled then a builder constructor which takes all properties will be created
+   */
+  @Test
+  public void innerBuilderWithAllPropertyConstructor()
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true, "useInnerClassBuilders", true, "includeConstructors", true));
+
+    Class<?> builderClass = resultsClassLoader.loadClass("com.example.Child$ChildBuilder");
+    Constructor<?> constructor = builderClass.getConstructor(Integer.class, String.class, String.class);
+    Method buildMethod = builderClass.getMethod("build");
+
+    int childProperty = 1;
+    String parentProperty = "parentProperty";
+    String sharedProperty = "sharedProperty";
+
+    Object builder = constructor.newInstance(childProperty, sharedProperty, parentProperty);
+    Object childObject = buildMethod.invoke(builder);
+
+    Class<?> childClass = resultsClassLoader.loadClass("com.example.Child");
+    Method getChildProperty = childClass.getMethod("getChildProperty");
+    Method getParentProperty = childClass.getMethod("getParentProperty");
+    Method getSharedProperty = childClass.getMethod("getSharedProperty");
+
+    assertEquals(childProperty, getChildProperty.invoke(childObject));
+    assertEquals(parentProperty, getParentProperty.invoke(childObject));
+    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+  }
+
+  /**
+   * This method confirms that if constructors are enabled and constructorsRequiredPropertiesOnly is set to true then a only a builder constructor
+   * with the required properties will be created
+   */
+  @Test
+  public void innerBuilderWithRequiredPropertyConstructor()
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+        config("generateBuilders", true, "useInnerClassBuilders", true, "includeConstructors", true, "constructorsRequiredPropertiesOnly", true));
+
+    Class<?> builderClass = resultsClassLoader.loadClass("com.example.Child$ChildBuilder");
+    Constructor<?> constructor = builderClass.getConstructor(String.class);
+    Method buildMethod = builderClass.getMethod("build");
+    Method withChildProperty = builderClass.getMethod("withChildProperty", Integer.class);
+    Method withSharedProperty = builderClass.getMethod("withSharedProperty", String.class);
+
+    int childProperty = 1;
+    String parentProperty = "parentProperty";
+    String sharedProperty = "sharedProperty";
+
+    Object builder = constructor.newInstance(parentProperty);
+    withChildProperty.invoke(builder, childProperty);
+    withSharedProperty.invoke(builder, sharedProperty);
+    Object childObject = buildMethod.invoke(builder);
+
+    Class<?> childClass = resultsClassLoader.loadClass("com.example.Child");
+    Method getChildProperty = childClass.getMethod("getChildProperty");
+    Method getParentProperty = childClass.getMethod("getParentProperty");
+    Method getSharedProperty = childClass.getMethod("getSharedProperty");
+
+    assertEquals(childProperty, getChildProperty.invoke(childObject));
+    assertEquals(parentProperty, getParentProperty.invoke(childObject));
+    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema.useInnerClassBuilders/child.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema.useInnerClassBuilders/child.json
@@ -1,0 +1,10 @@
+{
+  "type" : "object",
+  "extends" : {
+    "$ref" : "parent.json"
+  },
+  "properties" : {
+    "childProperty" : { "type" : "integer"},
+    "sharedProperty" : { "type" : "string" }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema.useInnerClassBuilders/parent.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema.useInnerClassBuilders/parent.json
@@ -1,0 +1,8 @@
+{
+  "type" : "object",
+  "properties" : {
+    "parentProperty" : { "type" : "string" },
+    "sharedProperty" : { "type" : "string" }
+  },
+  "required" : ["parentProperty"]
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -746,6 +746,21 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private Map<String, String> formatTypeMapping = new HashMap<>();
 
     /**
+     * @parameter property="jsonschema2pojo.chainableSetters"
+     *            default-value="true"
+     * @since 1.0.0
+     */
+    private boolean chainableSetters = true;
+
+    /**
+     * @parameter property="jsonschema2pojo.useInnerClassBuilders"
+     *            default-value="false"
+     * @since 1.0.0
+     */
+    private boolean useInnerClassBuilders = false;
+
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -1158,5 +1173,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public Map<String, String> getFormatTypeMapping() {
         return formatTypeMapping;
+    }
+
+    @Override
+    public boolean isChainableSettersBuilders() {
+        return chainableSetters;
+    }
+
+    @Override
+    public boolean isUseInnerClassBuilders() {
+        return useInnerClassBuilders;
     }
 }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -746,13 +746,6 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private Map<String, String> formatTypeMapping = new HashMap<>();
 
     /**
-     * @parameter property="jsonschema2pojo.chainableSetters"
-     *            default-value="true"
-     * @since 1.0.0
-     */
-    private boolean chainableSetters = true;
-
-    /**
      * @parameter property="jsonschema2pojo.useInnerClassBuilders"
      *            default-value="false"
      * @since 1.0.0
@@ -1173,11 +1166,6 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public Map<String, String> getFormatTypeMapping() {
         return formatTypeMapping;
-    }
-
-    @Override
-    public boolean isChainableSettersBuilders() {
-        return chainableSetters;
     }
 
     @Override


### PR DESCRIPTION
Adds support for using the https://en.wikipedia.org/wiki/Builder_pattern instead of just chainable setters. This commit maintains full backwards compatibility with existing capabilities, but enables the selection of a more robust builder pattern if desired (for example if you want to have immutable objects).

This pull request also includes multiple refactoring changes to avoid duplicate code wherever possible. Specifically, when implementing the builder mechanisms several capabilities which were already implemented in the code needed to be migrated into more accessible places.