### PR TITLE
Check schema required array before is required flag

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -21,8 +21,6 @@ import com.sun.codemodel.*;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
-
 
 /**
  * Applies the schema rules that represent a property definition.

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -122,9 +122,9 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         return false;
     }
 
-    private boolean hasFlag(JsonNode node, String flatName) {
-        if (node.has(flatName)) {
-            final JsonNode requiredNode = node.get(flatName);
+    private boolean hasFlag(JsonNode node, String fieldName) {
+        if (node.has(fieldName)) {
+            final JsonNode requiredNode = node.get(fieldName);
             return requiredNode.asBoolean();
         }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PropertyRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PropertyRuleTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JType;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaStore;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PropertyRuleTest {
+    private static final String TARGET_CLASS_NAME = PropertyRuleTest.class.getName() + ".DummyClass";
+
+    private static final String internalFieldName = "internalRequired";
+    private static final String targetFieldName = "requiredFoo";
+
+    private final GenerationConfig config = mock(GenerationConfig.class);
+    private final PropertyRule rule = new PropertyRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void setup() {
+        mapper = new ObjectMapper();
+
+        when(config.isIncludeGetters()).thenReturn(true);
+        when(config.isUseOptionalForGetters()).thenReturn(true);
+    }
+
+    private String getGeneratedMethodTypeName(JDefinedClass jclass) {
+        return jclass.getMethod("getRequiredFoo", new JType[] {}).type().name();
+    }
+
+    private Schema getMockedSchema(ObjectNode parentNode) {
+        Schema schema = mock(Schema.class);
+        when(schema.getContent()).thenReturn(parentNode);
+        when(schema.deriveChildSchema(any())).thenReturn(schema);
+        return schema;
+    }
+
+    private JDefinedClass applyRule(ObjectNode propertyNode, ObjectNode parentNode) throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+        return rule.apply(targetFieldName, propertyNode, parentNode, jclass, getMockedSchema(parentNode));
+    }
+
+    @Test
+    public void applyRequiredByTopArray() throws JClassAlreadyExistsException {
+        ObjectNode propertyNode = mapper.createObjectNode();
+        propertyNode.set("required", mapper.createArrayNode().add(internalFieldName));
+        propertyNode.set("properties", mapper.createObjectNode().set(internalFieldName, mapper.createObjectNode()));
+
+        ObjectNode parentNode = mapper.createObjectNode();
+        parentNode.set("required", mapper.createArrayNode().add(targetFieldName));
+        parentNode.set("properties", mapper.createObjectNode().set(targetFieldName, propertyNode));
+
+        JDefinedClass jclass = applyRule(propertyNode, parentNode);
+
+        assertThat(jclass, notNullValue());
+        assertThat(getGeneratedMethodTypeName(jclass), is("RequiredFoo"));
+    }
+
+    @Test
+    public void applyNotRequiredByTopArray() throws JClassAlreadyExistsException {
+        ObjectNode propertyNode = mapper.createObjectNode();
+        propertyNode.set("required", mapper.createArrayNode().add(internalFieldName));
+        propertyNode.set("properties", mapper.createObjectNode().set(internalFieldName, mapper.createObjectNode()));
+
+        ObjectNode parentNode = mapper.createObjectNode();
+        parentNode.set("properties", mapper.createObjectNode().set(targetFieldName, propertyNode));
+
+        JDefinedClass jclass = applyRule(propertyNode, parentNode);
+
+        assertThat(jclass, notNullValue());
+        assertThat(getGeneratedMethodTypeName(jclass), is("Optional<RequiredFoo>"));
+    }
+
+    @Test
+    public void applyRequiredByFlag() throws JClassAlreadyExistsException {
+        ObjectNode propertyNode = mapper.createObjectNode();
+        propertyNode.set("required", BooleanNode.TRUE);
+        propertyNode.set("properties", mapper.createObjectNode().set(internalFieldName, mapper.createObjectNode()));
+
+        ObjectNode parentNode = mapper.createObjectNode();
+        parentNode.set("properties", mapper.createObjectNode().set(targetFieldName, propertyNode));
+
+        JDefinedClass jclass = applyRule(propertyNode, parentNode);
+
+        assertThat(jclass, notNullValue());
+        assertThat(getGeneratedMethodTypeName(jclass), is("RequiredFoo"));
+    }
+
+    @Test
+    public void applyNotRequiredByFlag() throws JClassAlreadyExistsException {
+        ObjectNode propertyNode = mapper.createObjectNode();
+        propertyNode.set("properties", mapper.createObjectNode().set(internalFieldName, mapper.createObjectNode()));
+
+        ObjectNode parentNode = mapper.createObjectNode();
+        parentNode.set("properties", mapper.createObjectNode().set(targetFieldName, propertyNode));
+
+        JDefinedClass jclass = applyRule(propertyNode, parentNode);
+
+        assertThat(jclass, notNullValue());
+        assertThat(getGeneratedMethodTypeName(jclass), is("Optional<RequiredFoo>"));
+    }
+}


### PR DESCRIPTION
Hi,

The generated code is incorrect when a required field is an object, and it has required internal fields. It because of wrong algorithm checks is required flag of the field previously than tests a top defined required fields list. I've changed the checking order.

I mean the case where is the top schema follows:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": ["object", "null"],
  "required": [
    "payment_type",
    "change_alignment",
    "billing_alignment"
  ],
  "properties": {
    "payment_type": {
      "type": "object",
      "$ref": "payment_type.json"
    },
    "change_alignment": {
      "type": "object",
      "$ref": "change_alignment.json"
    },
    "billing_alignment": {
      "type": "object",
      "$ref": "billing_alignment.json"
    }
  }
}
```

and `billing_alignment.json` is:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [
    "date_type"
  ],
  "properties": {
    "date_type": {
      "type": "string",
      "enum": [
        "activation",
        "anniversary"
      ]
    },
    "day": {
      "type": "integer",
      "minimum": 1,
      "maximum": 28
    }
  }
}
```

For this example, the wrong plugin with `useOptionalForGetters=true` generates `Optional<BillingAlignment>` type of `getBillingAlignment` method instead of just `BillingAlignment`.
I've fixed it and now the type is `BillingAlignment`.