### PR TITLE
#975 add enum documentation

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -134,6 +134,14 @@ public class EnumRule implements Rule<JClassContainer, JType> {
         addEnumConstants(node.path("enum"), _enum, node.path("javaEnumNames"), backingType);
         addFactoryMethod(_enum, backingType);
 
+        if (node.has("title")) {
+            ruleFactory.getTitleRule().apply(nodeName, node.get("title"), node, _enum, schema);
+        }
+
+        if (node.has("description")) {
+            ruleFactory.getDescriptionRule().apply(nodeName, node.get("description"), node, _enum, schema);
+        }
+
         return _enum;
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/*
+  Enums are treated differently to schemas of type object and we want to ensure that a description
+  added to root-level enums is added to the javadoc.
+ */
+public class DescriptionEnumIT {
+
+    @ClassRule public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    private static JavaClass classWithDescription;
+
+    @BeforeClass
+    public static void generateClasses() throws IOException {
+
+        schemaRule.generateAndCompile("/schema/description/descriptionEnum.json", "com.example");
+        File generatedJavaFile = schemaRule.generated("com/example/DescriptionEnum.java");
+
+        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        javaDocBuilder.addSource(generatedJavaFile);
+
+        classWithDescription = javaDocBuilder.getClassByName("com.example.DescriptionEnum");
+    }
+
+    @Test
+    public void descriptionAppearsInEnumJavadoc() {
+
+        String javaDocComment = classWithDescription.getComment();
+
+        assertThat(javaDocComment, containsString("A description for this enum"));
+
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/*
+  Enums are treated differently to schemas of type object and we want to ensure that a title
+  added to root-level enums is added to the javadoc.
+ */
+public class TitleEnumIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static JavaClass classWithTitle;
+
+    @BeforeClass
+    public static void generateClasses() throws IOException {
+
+        classSchemaRule.generateAndCompile("/schema/title/titleEnum.json", "com.example");
+        File generatedJavaFile = classSchemaRule.generated("com/example/TitleEnum.java");
+
+        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        javaDocBuilder.addSource(generatedJavaFile);
+
+        classWithTitle = javaDocBuilder.getClassByName("com.example.TitleEnum");
+    }
+
+    @Test
+    public void descriptionAppearsInEnumJavadoc() {
+
+        String javaDocComment = classWithTitle.getComment();
+
+        assertThat(javaDocComment, containsString("A title for this enum"));
+
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/description/descriptionEnum.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/description/descriptionEnum.json
@@ -1,0 +1,5 @@
+{
+    "description" : "A description for this enum",
+    "type":"string",
+    "enum": ["one", "two"]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/title/titleEnum.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/title/titleEnum.json
@@ -1,0 +1,5 @@
+{
+    "title" : "A title for this enum",
+    "type":"string",
+    "enum": ["one", "two"]
+}


### PR DESCRIPTION
Add support for titles and descriptions within Javadocs for root-level enums.