### PR TITLE
977 add digits rule

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
@@ -36,17 +36,12 @@ public class DigitsRule implements Rule<JFieldVar, JFieldVar> {
     public JFieldVar apply(String nodeName, JsonNode node, JsonNode parent, JFieldVar field, Schema currentSchema) {
 
         if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()
-            && node.has("digits")) {
+            && node.has("integerDigits") && node.has("fractionalDigits")) {
 
             JAnnotationUse annotation = field.annotate(Digits.class);
 
-            if (node.get("digits").get("integerDigits") == null ||
-                node.get("digits").get("fractionalDigits") == null) {
-                throw new NoSuchElementException("Cannot find both 'integerDigits' and 'fractionalDigits' declared within 'digits' constraint." );
-            }
-
-            annotation.param("integer", node.get("digits").get("integerDigits").asInt());
-            annotation.param("fraction", node.get("digits").get("fractionalDigits").asInt());
+            annotation.param("integer", node.get("integerDigits").asInt());
+            annotation.param("fraction", node.get("fractionalDigits").asInt());
         }
 
         return field;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JFieldVar;
+import org.jsonschema2pojo.Schema;
+
+import javax.validation.constraints.Digits;
+import java.util.NoSuchElementException;
+
+public class DigitsRule implements Rule<JFieldVar, JFieldVar> {
+
+    private final RuleFactory ruleFactory;
+
+    protected DigitsRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    @Override
+    public JFieldVar apply(String nodeName, JsonNode node, JsonNode parent, JFieldVar field, Schema currentSchema) {
+
+        if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()
+            && node.has("digits")) {
+
+            JAnnotationUse annotation = field.annotate(Digits.class);
+
+            if (node.get("digits").get("integerDigits") == null ||
+                node.get("digits").get("fractionalDigits") == null) {
+                throw new NoSuchElementException("Cannot find both 'integerDigits' and 'fractionalDigits' declared within 'digits' constraint." );
+            }
+
+            annotation.param("integer", node.get("digits").get("integerDigits").asInt());
+            annotation.param("fraction", node.get("digits").get("fractionalDigits").asInt());
+        }
+
+        return field;
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -111,6 +111,8 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
         ruleFactory.getMinLengthMaxLengthRule().apply(nodeName, node, parent, field, schema);
 
+        ruleFactory.getDigitsRule().apply(nodeName, node, parent, field, schema);
+
         if (isObject(node) || isArray(node)) {
             ruleFactory.getValidRule().apply(nodeName, node, parent, field, schema);
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -273,6 +273,17 @@ public class RuleFactory {
     }
 
     /**
+     * Provides a rule instance that should be applied when a property
+     * declaration is found in the schema, to assign he digits validation
+     * on that property.
+     *
+     * @return a schema rule that can handle the "digits" declaration.
+     */
+    public Rule<JFieldVar, JFieldVar> getDigitsRule() {
+        return new DigitsRule(this);
+    }
+
+    /**
      * Provides a rule instance that should be applied when a "pattern"
      * declaration is found in the schema for a property.
      *

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
@@ -68,6 +68,8 @@ public class RuleFactoryImplTest {
         
         assertThat(ruleFactory.getValidRule(), notNullValue());
 
+        assertThat(ruleFactory.getDigitsRule(), notNullValue());
+
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -25,6 +25,7 @@ import java.beans.PropertyDescriptor;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -221,6 +222,46 @@ public class IncludeJsr303AnnotationsIT {
         Object invalidInstance = createInstanceWithPropertyValue(generatedType, "maxLength", "Tooooo long");
 
         assertNumberOfConstraintViolationsOn(invalidInstance, is(1));
+    }
+
+    @Test
+    public void jsr303DigitsValidationIsAddedForSchemaRuleDigits() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/digits.json", "com.example",
+            config("includeJsr303Annotations", true, "useBigDecimals", true));
+
+        Class generatedType = resultsClassLoader.loadClass("com.example.Digits");
+
+        // positive value
+        Object validInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("12345.1234567890"));
+
+        assertNumberOfConstraintViolationsOn(validInstance, is(0));
+
+        // negative value
+        validInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("-12345.1234567890"));
+
+        assertNumberOfConstraintViolationsOn(validInstance, is(0));
+
+        // zero value
+        validInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("0.0"));
+
+        assertNumberOfConstraintViolationsOn(validInstance, is(0));
+
+        // too many integer digits
+        Object invalidInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("123456.1234567890"));
+
+        assertNumberOfConstraintViolationsOn(invalidInstance, is(1));
+
+        // too many fractional digits
+        invalidInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("12345.12345678901"));
+
+        assertNumberOfConstraintViolationsOn(invalidInstance, is(1));
+
+        // too many integer & fractional digits
+        invalidInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("123456.12345678901"));
+
+        assertNumberOfConstraintViolationsOn(invalidInstance, is(1));
+
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -238,7 +238,7 @@ public class IncludeJsr303AnnotationsIT {
         assertNumberOfConstraintViolationsOn(validInstance, is(0));
 
         // negative value
-        validInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("-12345.1234567890"));
+        validInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("-12345.0123456789"));
 
         assertNumberOfConstraintViolationsOn(validInstance, is(0));
 
@@ -248,7 +248,7 @@ public class IncludeJsr303AnnotationsIT {
         assertNumberOfConstraintViolationsOn(validInstance, is(0));
 
         // too many integer digits
-        Object invalidInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("123456.1234567890"));
+        Object invalidInstance = createInstanceWithPropertyValue(generatedType, "decimal", new BigDecimal("123456.0123456789"));
 
         assertNumberOfConstraintViolationsOn(invalidInstance, is(1));
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/digits.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/digits.json
@@ -1,0 +1,12 @@
+{
+    "type" : "object",
+    "properties" : {
+        "decimal" : {
+            "type" : "number",
+            "digits" : {
+                "integerDigits": 5,
+                "fractionalDigits": 10
+            }
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/digits.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/digits.json
@@ -1,12 +1,10 @@
 {
-    "type" : "object",
-    "properties" : {
-        "decimal" : {
-            "type" : "number",
-            "digits" : {
-                "integerDigits": 5,
-                "fractionalDigits": 10
-            }
-        }
+  "type": "object",
+  "properties": {
+    "decimal": {
+      "type": "number",
+      "integerDigits": 5,
+      "fractionalDigits": 10
     }
+  }
 }


### PR DESCRIPTION
Fix to #977.

Implementation notes:

Requires use of a `digits` field that is associated with a property, which in turn requires `integerDigits` and `fractionalDigits` to be set within that `digits` field.

For example (this assumes that the config option of `isUseBigDecimals()` returns true).

```
{
    "type" : "object",
    "properties" : {
        "decimal" : {
            "type" : "number",
            "digits" : {
                "integerDigits": 5,
                "fractionalDigits": 10
            }
        }
    }
}
```
Validation of `integerDigits` and `fractionalDigits` is currently restricted to only checking that they exist.  In the event that either does not, DigitsRule will throw an `NoSuchElementException`.