### PR TITLE
bugfix: 'java.lang.IllegalArgumentException: protocol = http host = n…

### DIFF
--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -803,7 +803,13 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         } else if (!isEmpty(sourcePaths)) {
             // verify individual source paths
             for (int i = 0; i < sourcePaths.length; i++) {
-                sourcePaths[i] = FilenameUtils.normalize(sourcePaths[i]);
+                switch (URLUtil.parseProtocol(sourcePaths[i])) {
+                    case HTTP:
+                    case HTTPS:
+                        break;
+                    default:
+                        sourcePaths[i] = FilenameUtils.normalize(sourcePaths[i]);
+                }
                 try {
                     URLUtil.parseURL(sourcePaths[i]);
                 } catch (IllegalArgumentException e) {


### PR DESCRIPTION
java.lang.IllegalArgumentException: protocol = http host = null' will throw when source path is a http/https url