### PR TITLE
Feature/no more casting for builders

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -87,6 +87,12 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
     } else {
       // Declare the inheritance
       builderClass._extends(parentBuilderClass);
+      
+      JMethod buildMethod = builderClass.method(JMod.PUBLIC, instanceType, "build");
+      buildMethod.annotate(Override.class);
+
+      JBlock body = buildMethod.body();
+      body._return(JExpr.cast(instanceType, JExpr._super().invoke("build")));
 
       // Create the noargs builder constructor
       generateNoArgsBuilderConstructor(instanceClass, builderClass);


### PR DESCRIPTION
The previous implementation required every call to build() on an inherited builder to cast the results or else store them in the base class. This change will add an overridden build() method to the children which casts the result of the original parent's build method.