### PR TITLE
Prevent single letter fields from always becoming lower case

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -89,6 +89,9 @@ public class NameHelper {
     }
 
     private String makeLowerCamelCase(String name) {
+        if (name.length() == 1) {
+            return name;
+        }
         return toLowerCase(name.charAt(0)) + name.substring(1);
     }
 


### PR DESCRIPTION
Say you have the following JSON and you're generating from JSON files:
```
{
  "ticker": "AAPL",
  "status": "OK",
  "adjusted": true,
  "queryCount": 55,
  "resultsCount": 2,
  "results": [
    {
      "T": "AAPL",
      "v": 31315282,
      "o": 102.87,
      "c": 103.74,
      "h": 103.82,
      "l": 102.65,
      "t": 1549314000000,
      "n": 4
    }
  ]
}
```
There is an upper case "T" and a lower case "t" in the "results" array. Even with propertyWordDelimiters being empty, the first "T" becomes lower case and conflicts with the second "t" causing a name conflict error which `JDefinedClass` so kindly throws: `IllegalArgumentException: trying to create the same field twice: t`
This is a huge issue for JSON Schemas/Sources that are "compressed" you could say.
This PR simply modifies the `makeLowerCamelCase()` method in `NameHelper` to instantly return names with one letter.