### PR TITLE
Optionally exclude the timezone from the generated @JsonFormat annotation for date-time fields

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -127,6 +127,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private String outputEncoding = "UTF-8";
 
+    private boolean excludeTimezoneFromDateTimeFormat = false;
+
     private boolean useJodaDates = false;
 
     private boolean useJodaLocalDates = false;
@@ -668,6 +670,16 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     /**
+     * Sets the 'excludeTimezoneFromDateTimeFormat' property of this class
+     *
+     * @param excludeTimezoneFromDateTimeFormat
+     *            Whether to exclude the timezone from the date-time format annotations
+     */
+    public void setExcludeTimezoneFromDateTimeFormat(boolean excludeTimezoneFromDateTimeFormat) {
+        this.excludeTimezoneFromDateTimeFormat = excludeTimezoneFromDateTimeFormat;
+    }
+
+    /**
      * Sets the 'useJodaDates' property of this class
      *
      * @param useJodaDates
@@ -951,7 +963,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public void setSourceSortOrder(SourceSortOrder sourceSortOrder) {
         this.sourceSortOrder = sourceSortOrder;
     }
-    
+
     public void setTargetLanguage(Language targetLanguage) {
         this.targetLanguage = targetLanguage;
     }
@@ -1120,6 +1132,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public String getOutputEncoding() {
         return outputEncoding;
+    }
+
+    @Override
+    public boolean isExcludeTimezoneFromDateTimeFormat() {
+        return excludeTimezoneFromDateTimeFormat;
     }
 
     @Override

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -470,6 +470,12 @@
     <td align="center" valign="top">No (default <code>false</code>)</td>
   </tr>
   <tr>
+    <td valign="top">excludeTimezoneFromDateTimeFormat</td>
+    <td valign="top">Whether to exclude the timezone from the date-time format annotations
+    </td>
+    <td align="center" valign="top">No (default <code>false</code>)</td>
+  </tr>
+  <tr>
     <td valign="top">useJodaDates</td>
     <td valign="top">Whether to use <code>org.joda.time.DateTime</code> instead of <code>java.util.Date</code>
       when

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -147,6 +147,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-e", "--output-encoding" }, description = "The character encoding that should be used when writing the generated Java source files.")
     private String outputEncoding = "UTF-8";
 
+    @Parameter(names = { "-etz", "--exclude-time-zone-from-date-time-format" }, description = "Whether to exclude the time zone from the generated format annotations for date-time")
+    private boolean excludeTimezoneFromDateTimeFormat = false;
+
     @Parameter(names = { "-j", "--joda-dates" }, description = "Whether to use org.joda.time.DateTime instead of java" + ".util.Date when adding date-time type fields to generated Java types.")
     private boolean useJodaDates = false;
 
@@ -398,6 +401,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public String getOutputEncoding() {
         return outputEncoding;
+    }
+
+    @Override
+    public boolean isExcludeTimezoneFromDateTimeFormat() {
+        return excludeTimezoneFromDateTimeFormat;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -204,6 +204,11 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return false;
     }
 
+    @Override
+    public boolean isExcludeTimezoneFromDateTimeFormat() {
+        return false;
+    }
+
     /**
      * @return false
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -290,6 +290,13 @@ public interface GenerationConfig {
   String getOutputEncoding();
 
   /**
+   * Gets the 'excludeTimezoneFromDateTimeFormat' configuration option.
+   *
+   * @return Whether to exclude the timezone from the date-time format annotations
+   */
+  boolean isExcludeTimezoneFromDateTimeFormat();
+
+  /**
    * Gets the 'useJodaDates' configuration option.
    *
    * @return Whether to use {@link org.joda.time.DateTime} instead of

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -213,7 +213,10 @@ public class Jackson2Annotator extends AbstractTypeInfoAwareAnnotator {
         }
 
         if (pattern != null && !field.type().fullName().equals("java.lang.String")) {
-            field.annotate(JsonFormat.class).param("shape", JsonFormat.Shape.STRING).param("pattern", pattern).param("timezone", timezone);
+            JAnnotationUse annotationUse = field.annotate(JsonFormat.class).param("shape", JsonFormat.Shape.STRING).param("pattern", pattern);
+            if (!getGenerationConfig().isExcludeTimezoneFromDateTimeFormat()) {
+                annotationUse.param("timezone", timezone);
+            }
         }
     }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/Jackson2AnnotatorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/Jackson2AnnotatorTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.sun.codemodel.*;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class Jackson2AnnotatorTest {
+
+    @Test
+    public void shouldIncludeTimeZoneByDefault() throws Exception {
+        GenerationConfig generationConfig = new DefaultGenerationConfig() {
+            @Override
+            public boolean isFormatDateTimes() {
+                return true;
+            }
+        };
+        Jackson2Annotator annotator = new Jackson2Annotator(generationConfig);
+        JDefinedClass clazz = new JCodeModel()._class("com.example.Test");
+        JFieldVar field = clazz.field(0, java.util.Date.class, "myDateTime");
+        JsonNode jsonNode = new TextNode("");
+        assertTrue(field.annotations().isEmpty());
+        annotator.dateTimeField(field, clazz, jsonNode);
+        assertEquals(1, field.annotations().size());
+        JAnnotationUse annotation = field.annotations().iterator().next();
+        Map<String, JAnnotationValue> annotationMembers = annotation.getAnnotationMembers();
+        JAnnotationValue timezoneAnnotation = annotationMembers.get("timezone");
+        final AtomicReference<String> value = new AtomicReference<>();
+        timezoneAnnotation.generate(new JFormatter(new Writer() {
+            @Override
+            public void write(char[] cbuf, int off, int len) throws IOException {
+                value.set(new String(cbuf, off, len));
+            }
+
+            @Override
+            public void flush() throws IOException {
+
+            }
+
+            @Override
+            public void close() throws IOException {
+
+            }
+        }));
+        assertEquals("\"UTC\"", value.get());
+    }
+
+    @Test
+    public void shouldExcludeTimeZoneWhenSpecified() throws Exception {
+        GenerationConfig generationConfig = new DefaultGenerationConfig() {
+            @Override
+            public boolean isFormatDateTimes() {
+                return true;
+            }
+
+            @Override
+            public boolean isExcludeTimezoneFromDateTimeFormat() {
+                return true;
+            }
+        };
+        Jackson2Annotator annotator = new Jackson2Annotator(generationConfig);
+        JDefinedClass clazz = new JCodeModel()._class("com.example.Test");
+        JFieldVar field = clazz.field(0, java.util.Date.class, "myDateTime");
+        JsonNode jsonNode = new TextNode("");
+        assertTrue(field.annotations().isEmpty());
+        annotator.dateTimeField(field, clazz, jsonNode);
+        assertEquals(1, field.annotations().size());
+        JAnnotationUse annotation = field.annotations().iterator().next();
+        Map<String, JAnnotationValue> annotationMembers = annotation.getAnnotationMembers();
+        JAnnotationValue timezoneAnnotation = annotationMembers.get("timezone");
+        assertNull(timezoneAnnotation);
+    }
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -77,6 +77,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean useCommonsLang3
   boolean useDoubleNumbers
   boolean useBigDecimals
+  boolean excludeTimezoneFromDateTimeFormat
   boolean useJodaDates
   boolean useJodaLocalDates
   boolean useJodaLocalTimes

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -408,6 +408,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String outputEncoding = "UTF-8";
 
     /**
+     * Whether to exclude the timezone from the date-time format annotations.
+     *
+     * @parameter property="jsonschema2pojo.excludeTimezoneFromDateTimeFormat"
+     *            default-value="false"
+     * @since 1.0.2
+     */
+    private boolean excludeTimezoneFromDateTimeFormat = false;
+
+    /**
      * Whether to use {@link org.joda.time.DateTime} instead of
      * {@link java.util.Date} when adding date type fields to generated Java
      * types.
@@ -1035,6 +1044,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public String getOutputEncoding() {
         return outputEncoding;
+    }
+
+    @Override
+    public boolean isExcludeTimezoneFromDateTimeFormat() {
+        return excludeTimezoneFromDateTimeFormat;
     }
 
     @Override


### PR DESCRIPTION
By default, when enabling formatting for fields with "type: date-time", the time-zone is *always* forced to UTC. This feature adds a flag where this can be disabled, which means that there will be no time-zone specified in the `@JsonFormat` annotation, which means that when we produce json from an object with jackson, it uses whatever timezone the date was in already. This is only really worthwhile when not using java.util.Date, such as for example java.time.ZonedDateTime.

NOTE: The integration tests I wrote work fine in IntelliJ IDEA, but they don't generate any annotations when run through maven. I'm not quite sure why this is, or if it is just a local issue for me. It would be nice if someone else could verify this and possibly help me resolve it, if it is indeed an issue for others.