### PR TITLE
Add package when javaType is not a fully qualified name

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -219,6 +219,11 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 }
 
                 int index = fqn.lastIndexOf(".") + 1;
+                if(index == 0){ //Actually not a fully qualified name
+                    fqn = _package.name() + "." + fqn;
+                    index = fqn.lastIndexOf(".") + 1;
+                }
+
                 if (index >= 0 && index < fqn.length()) {
                     fqn = fqn.substring(0, index) + ruleFactory.getGenerationConfig().getClassNamePrefix() + fqn.substring(index) + ruleFactory.getGenerationConfig().getClassNameSuffix();
                 }

--- a/jsonschema2pojo-core/src/test/resources/AuthorizeRequest_v1p0.json
+++ b/jsonschema2pojo-core/src/test/resources/AuthorizeRequest_v1p0.json
@@ -1,0 +1,133 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "urn:OCPP:Cp:2:2018:4:AuthorizeRequest",
+  "comment": "OCPP 2.0 - v1p0",
+  "definitions": {
+    "HashAlgorithmEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "SHA256",
+        "SHA384",
+        "SHA512"
+      ]
+    },
+    "IdTokenEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "Central",
+        "eMAID",
+        "ISO14443",
+        "KeyCode",
+        "Local",
+        "NoAuthorization",
+        "ISO15693"
+      ]
+    },
+    "AdditionalInfoType": {
+      "javaType": "AdditionalInfo",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalIdToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "type": "string",
+          "maxLength": 50
+        }
+      },
+      "required": [
+        "additionalIdToken",
+        "type"
+      ]
+    },
+    "IdTokenType": {
+      "javaType": "IdToken",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalInfo": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/AdditionalInfoType"
+          },
+          "minItems": 1
+        },
+        "idToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "$ref": "#/definitions/IdTokenEnumType"
+        }
+      },
+      "required": [
+        "idToken",
+        "type"
+      ]
+    },
+    "OCSPRequestDataType": {
+      "javaType": "OCSPRequestData",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "hashAlgorithm": {
+          "$ref": "#/definitions/HashAlgorithmEnumType"
+        },
+        "issuerNameHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "issuerKeyHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "serialNumber": {
+          "type": "string",
+          "maxLength": 20
+        },
+        "responderURL": {
+          "type": "string",
+          "maxLength": 512
+        }
+      },
+      "required": [
+        "hashAlgorithm",
+        "issuerNameHash",
+        "issuerKeyHash",
+        "serialNumber"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "15118CertificateHashData": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "$ref": "#/definitions/OCSPRequestDataType"
+      },
+      "minItems": 1,
+      "maxItems": 4
+    },
+    "idToken": {
+      "$ref": "#/definitions/IdTokenType"
+    },
+    "evseId": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "idToken"
+  ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/AuthorizeRequest_v1p0.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/AuthorizeRequest_v1p0.json
@@ -1,0 +1,133 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "urn:OCPP:Cp:2:2018:4:AuthorizeRequest",
+  "comment": "OCPP 2.0 - v1p0",
+  "definitions": {
+    "HashAlgorithmEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "SHA256",
+        "SHA384",
+        "SHA512"
+      ]
+    },
+    "IdTokenEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "Central",
+        "eMAID",
+        "ISO14443",
+        "KeyCode",
+        "Local",
+        "NoAuthorization",
+        "ISO15693"
+      ]
+    },
+    "AdditionalInfoType": {
+      "javaType": "com.apetecan.javaname.AdditionalInfo",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalIdToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "type": "string",
+          "maxLength": 50
+        }
+      },
+      "required": [
+        "additionalIdToken",
+        "type"
+      ]
+    },
+    "IdTokenType": {
+      "javaType": "IdToken",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalInfo": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/AdditionalInfoType"
+          },
+          "minItems": 1
+        },
+        "idToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "$ref": "#/definitions/IdTokenEnumType"
+        }
+      },
+      "required": [
+        "idToken",
+        "type"
+      ]
+    },
+    "OCSPRequestDataType": {
+      "javaType": "OCSPRequestData",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "hashAlgorithm": {
+          "$ref": "#/definitions/HashAlgorithmEnumType"
+        },
+        "issuerNameHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "issuerKeyHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "serialNumber": {
+          "type": "string",
+          "maxLength": 20
+        },
+        "responderURL": {
+          "type": "string",
+          "maxLength": 512
+        }
+      },
+      "required": [
+        "hashAlgorithm",
+        "issuerNameHash",
+        "issuerKeyHash",
+        "serialNumber"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "15118CertificateHashData": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "$ref": "#/definitions/OCSPRequestDataType"
+      },
+      "minItems": 1,
+      "maxItems": 4
+    },
+    "idToken": {
+      "$ref": "#/definitions/IdTokenType"
+    },
+    "evseId": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "idToken"
+  ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/AuthorizeRequest_v1p0_2.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/AuthorizeRequest_v1p0_2.json
@@ -45,7 +45,7 @@
       ]
     },
     "IdTokenType": {
-      "javaType": "IdToken",
+      "javaType": "com.apetecan.javaname.IdToken",
       "type": "object",
       "additionalProperties": true,
       "properties": {


### PR DESCRIPTION
I am working in a POC with OCPP 1.6/2.0 that use json schemas with a not fully qualified javatype (example attacched). May be useful check if a specified javatype is fqn or not and hence add the package name if needed.