### PR TITLE
Add option to use java.util.Optional for non required reference fields

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -120,6 +120,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean useOptionalForGetters;
 
+    private boolean useOptionalForFields;
+
     private SourceType sourceType = SourceType.JSONSCHEMA;
 
     private Path classpath;
@@ -617,6 +619,18 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         this.useOptionalForGetters = useOptionalForGetters;
     }
 
+
+    /**
+     * Sets the 'useOptionalForFields' property of this class
+     *
+     * @param useOptionalForFields
+     *         Whether to use {@link java.util.Optional} as field type for
+     *         non-required fields.
+     */
+    public void setUseOptionalForFields(boolean useOptionalForFields) {
+        this.useOptionalForFields = useOptionalForFields;
+    }
+
     /**
      * Sets the 'sourceType' property of this class
      *
@@ -954,7 +968,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public void setSourceSortOrder(SourceSortOrder sourceSortOrder) {
         this.sourceSortOrder = sourceSortOrder;
     }
-    
+
     public void setTargetLanguage(Language targetLanguage) {
         this.targetLanguage = targetLanguage;
     }
@@ -1085,6 +1099,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseOptionalForGetters() {
         return useOptionalForGetters;
+    }
+
+    @Override
+    public boolean isUseOptionalForFields() {
+        return useOptionalForFields;
     }
 
     @Override
@@ -1304,7 +1323,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public SourceSortOrder getSourceSortOrder() {
         return sourceSortOrder;
     }
-    
+
     @Override
     public Language getTargetLanguage() {
         return targetLanguage;

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -346,6 +346,14 @@
     <td align="center" valign="top">No (default <code>false</code>)</td>
   </tr>
   <tr>
+    <td valign="top">useOptionalForFields</td>
+    <td valign="top">Whether to use <a
+        href="https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html">Optional</a> as
+      type for non-required fields.
+    </td>
+    <td align="center" valign="top">No (default <code>false</code>)</td>
+  </tr>
+  <tr>
     <td valign="top">includeToString</td>
     <td valign="top">Whether to use include a <code>toString</code> method in generated Java types.
     </td>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -112,7 +112,7 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-S", "--omit-tostring" }, description = "Omit the toString method in the generated Java types")
     private boolean omitToString = false;
-    
+
     @Parameter(names = { "-tse", "--tostring-excludes" }, description = "The fields that should be excluded from generated toString methods")
     private String toStringExcludes = "";
 
@@ -139,6 +139,9 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-o", "--use-optional-for-getters"}, description = "Use Optional for getters of non-required fields.")
     private boolean useOptionalForGetters = false;
+
+    @Parameter(names = { "-of", "--use-optional-for-fields"}, description = "Use Optional for non-required fields.")
+    private boolean useOptionalForFields = false;
 
     @Parameter(names = { "-T", "--source-type" })
     private SourceType sourceType = SourceType.JSONSCHEMA;
@@ -357,7 +360,7 @@ public class Arguments implements GenerationConfig {
     public String[] getToStringExcludes() {
         return defaultString(toStringExcludes).split(" ");
     }
-    
+
     @Override
     public AnnotationStyle getAnnotationStyle() {
         return annotationStyle;
@@ -395,6 +398,9 @@ public class Arguments implements GenerationConfig {
 
     @Override
     public boolean isUseOptionalForGetters() { return useOptionalForGetters; }
+
+    @Override
+    public boolean isUseOptionalForFields() { return useOptionalForFields; }
 
     @Override
     public SourceType getSourceType() {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -119,7 +119,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isIncludeToString() {
         return true;
     }
-    
+
     /**
      * @return no exclusions
      */
@@ -180,6 +180,9 @@ public class DefaultGenerationConfig implements GenerationConfig {
 
     @Override
     public boolean isUseOptionalForGetters() { return false; }
+
+    @Override
+    public boolean isUseOptionalForFields() { return false; }
 
     /**
      * @return {@link SourceType#JSONSCHEMA}
@@ -456,7 +459,7 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public SourceSortOrder getSourceSortOrder() {
         return SourceSortOrder.OS;
     }
-    
+
     /**
      * @return {@link Language#JAVA}
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -257,6 +257,13 @@ public interface GenerationConfig {
   boolean isUseOptionalForGetters();
 
   /**
+   * Gets the 'useOptionalForFields' configuration option.
+   *
+   * @return Whether to use {@link java.util.Optional} as type and return type for non-required fields.
+   */
+  boolean isUseOptionalForFields();
+
+  /**
    * Gets the 'sourceType' configuration option.
    *
    * @return The type of input documents that will be read

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -64,6 +64,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean includeJsr303Annotations
   boolean includeJsr305Annotations
   boolean useOptionalForGetters
+  boolean useOptionalForFields
   boolean includeToString
   String[] toStringExcludes
   boolean initializeCollections
@@ -126,6 +127,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeJsr303Annotations = false
     includeJsr305Annotations = false
     useOptionalForGetters = false
+    useOptionalForFields = false
     sourceType = SourceType.JSONSCHEMA
     outputEncoding = 'UTF-8'
     useJodaDates = false
@@ -251,6 +253,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeJsr303Annotations = ${includeJsr303Annotations}
        |includeJsr305Annotations = ${includeJsr305Annotations}
        |useOptionalForGetters = ${useOptionalForGetters}
+       |useOptionalForFields = ${useOptionalForFields}
        |sourceType = ${sourceType.toString().toLowerCase()}
        |removeOldOutput = ${removeOldOutput}
        |outputEncoding = ${outputEncoding}
@@ -287,7 +290,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeConstructorPropertiesAnnotation = ${includeConstructorPropertiesAnnotation}
      """.stripMargin()
   }
-  
+
   public boolean isFormatDateTimes() {
     return formatDateTimes
   }

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -364,6 +364,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      private boolean useOptionalForGetters = false;
 
     /**
+     * Whether to use {@link java.util.Optional} as type for
+     * non-required fields.
+     *
+     * @parameter property="jsonschema2pojo.useOptionalForGetters"
+     *            default-value="false"
+     */
+     private boolean useOptionalForFields = false;
+
+    /**
      * The type of input documents that will be read
      * <p>
      * Supported values:
@@ -1024,6 +1033,9 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
 
     @Override
     public boolean isUseOptionalForGetters() { return useOptionalForGetters; }
+
+    @Override
+    public boolean isUseOptionalForFields() { return useOptionalForFields; }
 
     @Override
     public SourceType getSourceType() {


### PR DESCRIPTION
I have added an option to use Optional for non required fields, similar to the option that exists for returning Optional on the getters of non required fields.
Although it's not recommended to use Optional for fields, it's supported by default by Jackson >=2.8.5 and it's the easiest way to differentiate between a field not being present in the json document, and the field being present but with a value of null.