### PR TITLE
Fix singularization for "slaves"

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
@@ -99,7 +99,8 @@ public class Inflector {
             .singular("men$", "man")
             .singular("(.+)list$", "$1")
             .singular("specimen", "specimen")
-            .singular("status$", "status");
+            .singular("status$", "status")
+            .singular("(slave)s$", "$1");
 
         builder.irregular("curve", "curves")
             .irregular("leaf", "leaves")

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
@@ -64,6 +64,7 @@ public class InflectorTest {
         assertThat(Inflector.getInstance().singularize("LineItemTaxes"), is("LineItemTax"));
         assertThat(Inflector.getInstance().singularize("WidgetList"), is("Widget"));
 
+        assertThat(Inflector.getInstance().singularize("slaves"), is("slave"));
     }
 
     @Test


### PR DESCRIPTION
Previously, another rule incorrectly caused slaves to be singularized as
"slafe"