### PR TITLE
Recursive schemas with relative paths can generate the same class twice with "__1" in the name

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -55,7 +55,7 @@ public class SchemaStore {
 
         if (!schemas.containsKey(id)) {
 
-            URI baseId = removeFragment(id);
+            URI baseId = removeFragment(id).normalize();
             JsonNode baseContent = contentResolver.resolve(baseId);
             Schema baseSchema = new Schema(baseId, baseContent, null);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
@@ -21,11 +21,12 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Test;
-
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JType;
 
@@ -60,6 +61,26 @@ public class SchemaStoreTest {
         assertThat(enumSchema.getId(), is(equalTo(URI.create(expectedUri))));
         assertThat(enumSchema.getContent().has("enum"), is(true));
 
+    }
+
+    @Test
+    public void createWithRelativeSegmentsInPath() throws URISyntaxException {
+
+        //Get to the directory of the module jsonschema2pojo-core
+        Path basePath = Paths.get(getClass().getResource("/schema/person.json").toURI()).getParent().getParent().getParent().getParent();
+
+        //Now load the resource with a relative path segment
+        File relativePath = new File(Paths.get(basePath.toString(),"target", "..", "src", "test", "resources", "schema", "person.json").toString());
+        //Now load the resource with the same path minus the relative segment
+        File nonRelativePath = new File(Paths.get(basePath.toString(), "src", "test", "resources", "schema", "person.json").toString());
+
+        SchemaStore schemaStore = new SchemaStore();
+
+        Schema schemaWithRelativeSegment = schemaStore.create(relativePath.toURI(), "#/.");
+        Schema schemaWithoutRelativeSegment = schemaStore.create(nonRelativePath.toURI(), "#/.");
+
+        //Both schema objects should have the same Id value since their URI's point to the same resource
+        assertThat(schemaWithoutRelativeSegment.getId(), is(schemaWithRelativeSegment.getId()));
     }
 
     @Test

--- a/jsonschema2pojo-core/src/test/resources/schema/person.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/person.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://example.com/person.json",
+  "type": "object",
+  "title": "Person",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lastName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "middleInitial": {
+      "type": "string"
+    },
+    "suffix": {
+      "type": "string"
+    },
+    "children": {
+      "$ref":"person.json"
+    }
+  }
+}


### PR DESCRIPTION
Added a unit test to show how URIs with relative path segments will cause a recursive schema model to generate two classes with a difference in name only. Also added a fix for the code as well

 #1075