### PR TITLE
Add support to specify custom collection types for Set and List

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -190,6 +190,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private String refFragmentPathDelimiters = "#/.";
 
+    private String listType;
+
+    private String setType;
+
     private SourceSortOrder sourceSortOrder = SourceSortOrder.OS;
 
     private Language targetLanguage = Language.JAVA;
@@ -1299,6 +1303,16 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public String getRefFragmentPathDelimiters() {
         return refFragmentPathDelimiters;
     }
+
+    @Override
+    public String getListType() {
+        return listType;
+    }
+
+	@Override
+	public String getSetType() {
+		return setType;
+	}
 
     @Override
     public SourceSortOrder getSourceSortOrder() {

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -600,6 +600,30 @@
     <td align="center" valign="top">No (default none)</td>
   </tr>
   <tr>
+    <td valign="top">listType</td>
+    <td valign="top">The java type to use instead of <code>java.util.List</code> when adding
+      list fields to generated Java types. Does not work with default collection initialization
+      since there is no simple way to know how to create an instance - thus custom
+      lists are always left uninitialized.
+      <ul>
+        <li><code>*anything*</code> (no compile time check)</li>
+      </ul>
+    </td>
+    <td align="center" valign="top">No</td>
+  </tr>
+  <tr>
+    <td valign="top">setType</td>
+    <td valign="top">The java type to use instead of <code>java.util.Set</code> when adding
+      set fields to generated Java types. Does not work with default collection initialization
+      since there is no simple way to know how to create an instance - thus custom
+      sets are always left uninitialized.
+      <ul>
+        <li><code>*anything*</code> (no compile time check)</li>
+      </ul>
+    </td>
+    <td align="center" valign="top">No</td>
+  </tr>
+  <tr>
     <td valign="top">refFragmentPathDelimiters</td>
     <td valign="top">A string containing any characters that should act as path delimiters when
       resolving $ref

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -233,6 +233,12 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = {"-rpd", "--ref-fragment-path-delimiters"}, description = "A string containing any characters that should act as path delimiters when resolving $ref fragments. By default, #, / and . are used in an attempt to support JSON Pointer and JSON Path.")
     private String refFragmentPathDelimiters = "#/.";
 
+    @Parameter(names = { "-lt", "--list-class" }, description = "Specify list class")
+    private String listType;
+
+	@Parameter(names = { "-st", "--set-class" }, description = "Specify set class")
+	private String setType;
+
     @Parameter(names = { "-sso", "--source-sort-order" }, description = "The sort order to be applied to the source files.  Available options are: OS, FILES_FIRST or SUBDIRS_FIRST")
     private SourceSortOrder sourceSortOrder = SourceSortOrder.OS;
 
@@ -576,6 +582,16 @@ public class Arguments implements GenerationConfig {
     public String getRefFragmentPathDelimiters() {
         return refFragmentPathDelimiters;
     }
+
+    @Override
+    public String getListType() {
+        return listType;
+    }
+
+	@Override
+	public String getSetType() {
+		return setType;
+	}
 
     @Override
     public String getCustomDatePattern() {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -435,6 +435,16 @@ public class DefaultGenerationConfig implements GenerationConfig {
     }
 
     @Override
+    public String getListType() {
+        return null;
+    }
+
+	@Override
+	public String getSetType() {
+		return null;
+	}
+
+    @Override
     public String getCustomDatePattern() {
         return null;
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -576,6 +576,34 @@ public interface GenerationConfig {
   String getRefFragmentPathDelimiters();
 
   /**
+   * Gets the `listType` configuration option.
+   * <p>
+   * Example values:
+   * <ul>
+   * <li><code>*anything*</code> (no compile time check)</li>
+   * <li><code>null</code> (default behavior)</li>
+   * </ul>
+   *
+   * @return The java type to use instead of java.util.List when adding list type
+   *         fields to generated Java types.
+   */
+  String getListType();
+
+  /**
+   * Gets the `setType` configuration option.
+   * <p>
+   * Example values:
+   * <ul>
+   * <li><code>*anything*</code> (no compile time check)</li>
+   * <li><code>null</code> (default behavior)</li>
+   * </ul>
+   *
+   * @return The java type to use instead of java.util.Set when adding set type
+   *         fields to generated Java types.
+   */
+  String getSetType();
+
+  /**
    * Gets the 'sourceSortOrder' configuration option.
    *
    * @return

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.Inflector;
 import com.sun.codemodel.JClass;
@@ -87,9 +88,13 @@ public class ArrayRule implements Rule<JPackage, JClass> {
 
         JClass arrayType;
         if (uniqueItems) {
-            arrayType = jpackage.owner().ref(Set.class).narrow(itemType);
+            final String setClass = ruleFactory.getGenerationConfig().getSetType();
+
+            arrayType = jpackage.owner().ref(StringUtils.isBlank(setClass) ? Set.class.getName() : setClass).narrow(itemType);
         } else {
-            arrayType = jpackage.owner().ref(List.class).narrow(itemType);
+            final String listClass = ruleFactory.getGenerationConfig().getListType();
+
+            arrayType = jpackage.owner().ref(StringUtils.isBlank(listClass) ? List.class.getName() : listClass).narrow(itemType);
         }
 
         if (rootSchemaIsArray) {
@@ -102,5 +107,4 @@ public class ArrayRule implements Rule<JPackage, JClass> {
     private String makeSingular(String nodeName) {
         return Inflector.getInstance().singularize(nodeName);
     }
-
 }

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -94,6 +94,8 @@ public class JsonSchemaExtension implements GenerationConfig {
   String customTimePattern
   String customDateTimePattern
   String refFragmentPathDelimiters
+  String listType
+  String setType
   SourceSortOrder sourceSortOrder
   Language targetLanguage
   Map<String, String> formatTypeMapping
@@ -154,6 +156,8 @@ public class JsonSchemaExtension implements GenerationConfig {
     formatTimes = false
     formatDateTimes = false
     refFragmentPathDelimiters = "#/."
+    listType = null
+    setType = null
     sourceSortOrder = SourceSortOrder.OS
     formatTypeMapping = Collections.emptyMap()
   }
@@ -280,6 +284,8 @@ public class JsonSchemaExtension implements GenerationConfig {
        |customTimePattern = ${customTimePattern}
        |customDateTimePattern = ${customDateTimePattern}
        |refFragmentPathDelimiters = ${refFragmentPathDelimiters}
+       |listType = ${listType}
+       |setType = ${setType}
        |sourceSortOrder = ${sourceSortOrder}
        |targetLanguage = ${targetLanguage}
        |formatTypeMapping = ${formatTypeMapping}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomArraysIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomArraysIT.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2010-2017 Nokia
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertThat;
+
+public class CustomArraysIT {
+
+	@Rule
+	public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+	@Test
+	public void defaultTypesAreNotCustom() throws IntrospectionException, ClassNotFoundException {
+
+		ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example");
+
+		Class<?> classWithArrayProperties = resultsClassLoader.loadClass("com.example.TypeWithArrayProperties");
+
+		List<String[]> defaultTypes = Arrays.asList(
+				new String[]{"nonUniqueArray", "java.util.List"},
+				new String[]{"uniqueArray", "java.util.Set"},
+				new String[]{"nonUniqueArrayByDefault", "java.util.List"},
+				new String[]{"complexTypesArray", "java.util.List"},
+				new String[]{"defaultTypesArray", "java.util.List"},
+				new String[]{"multiDimensionalArray", "java.util.List"},
+				new String[]{"refToArray1", "java.util.List"}
+		);
+
+		for (String[] defaultType : defaultTypes) {
+			assertTypeIsExpected(classWithArrayProperties, defaultType[0], defaultType[1]);
+		}
+	}
+
+	@Test
+	public void listTypeCausesCustomListType() throws IntrospectionException, ClassNotFoundException {
+		String clazz = scala.collection.immutable.List.class.getName();
+		ClassLoader classLoader = schemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example",
+				config("listType", clazz));
+		Class<?> classWithArray = classLoader.loadClass("com.example.TypeWithArrayProperties");
+		assertTypeIsExpected(classWithArray, "nonUniqueArray", clazz);
+	}
+
+	@Test
+	public void disablingListTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
+		ClassLoader classLoader = schemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example",
+				config("listType", null));
+		Class<?> classWithDate = classLoader.loadClass("com.example.TypeWithArrayProperties");
+		assertTypeIsExpected(classWithDate, "nonUniqueArray", "java.util.List");
+	}
+
+	@Test
+	public void setTypeCausesCustomSetType() throws IntrospectionException, ClassNotFoundException {
+		String clazz = scala.collection.immutable.Set.class.getName();
+		ClassLoader classLoader = schemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example",
+				config("setType", clazz));
+		Class<?> classWithArray = classLoader.loadClass("com.example.TypeWithArrayProperties");
+		assertTypeIsExpected(classWithArray, "uniqueArray", clazz);
+	}
+
+	@Test
+	public void disablingSetTypeCausesDefault() throws ClassNotFoundException, IntrospectionException {
+		ClassLoader classLoader = schemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example",
+				config("setType", null));
+		Class<?> classWithDate = classLoader.loadClass("com.example.TypeWithArrayProperties");
+		assertTypeIsExpected(classWithDate, "uniqueArray", "java.util.Set");
+	}
+
+	private void assertTypeIsExpected(Class<?> classInstance, String propertyName, String expectedType)
+			throws IntrospectionException {
+		Method getter = new PropertyDescriptor(propertyName, classInstance).getReadMethod();
+		assertThat(getter.getReturnType().getName(), is(expectedType));
+	}
+
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -741,6 +741,24 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      */
     private String refFragmentPathDelimiters = "#/.";
 
+    /**
+     * What type to use instead of java.util.List when adding list type fields
+     * to generated Java types.
+     *
+     * @parameter property="jsonschema2pojo.listType"
+     * @since 1.0.3
+     */
+    private String listType = null;
+
+	/**
+	 * What type to use instead of java.util.Set when adding set type fields
+	 * to generated Java types.
+	 *
+	 * @parameter property="jsonschema2pojo.setType"
+	 * @since 1.0.3
+	 */
+	private String setType = null;
+
     private FileFilter fileFilter = new AllFileFilter();
 
     /**
@@ -1227,6 +1245,16 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     public String getRefFragmentPathDelimiters() {
         return refFragmentPathDelimiters;
     }
+
+    @Override
+	public String getListType() {
+		return listType;
+	}
+
+	@Override
+	public String getSetType() {
+		return setType;
+	}
 
     @Override
     public SourceSortOrder getSourceSortOrder() {


### PR DESCRIPTION
Added option to specify custom List and Set types. I really wanted fully immutable POJO classes and this was blocking me, had to basically copy ArrayRule with little changes outside of this project. In my opinion it would be nice if library allowed it.

I know it does not provide as much functionality as java.util collections (mostly default initialization), but it's better than nothing.