### PR TITLE
Support for specifying extension keywords (properties) with an "x-" prefix

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson1Annotator.java
@@ -40,6 +40,9 @@ import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
 
+import static org.jsonschema2pojo.util.ExtensionsHelper.getExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.hasExtensionProperty;
+
 /**
  * Annotates generated Java types using the Jackson 1.x mapping annotations.
  *
@@ -97,9 +100,9 @@ public class Jackson1Annotator extends AbstractTypeInfoAwareAnnotator {
             field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
         }
 
-        if (propertyNode.has("javaJsonView")) {
+        if (hasExtensionProperty(propertyNode, "javaJsonView")) {
             field.annotate(JsonView.class).param(
-                    "value", field.type().owner().ref(propertyNode.get("javaJsonView").asText()));
+                    "value", field.type().owner().ref(getExtensionProperty(propertyNode, "javaJsonView").asText()));
         }
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jackson2Annotator.java
@@ -17,6 +17,8 @@
 package org.jsonschema2pojo;
 
 import static org.apache.commons.lang3.StringUtils.*;
+import static org.jsonschema2pojo.util.ExtensionsHelper.getExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.hasExtensionProperty;
 
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -105,9 +107,9 @@ public class Jackson2Annotator extends AbstractTypeInfoAwareAnnotator {
             field.annotate(JsonDeserialize.class).param("as", LinkedHashSet.class);
         }
 
-        if (propertyNode.has("javaJsonView")) {
+        if (hasExtensionProperty(propertyNode, "javaJsonView")) {
             field.annotate(JsonView.class).param(
-                    "value", field.type().owner().ref(propertyNode.get("javaJsonView").asText()));
+                    "value", field.type().owner().ref(getExtensionProperty(propertyNode, "javaJsonView").asText()));
         }
 
         if (propertyNode.has("description")) {
@@ -163,10 +165,10 @@ public class Jackson2Annotator extends AbstractTypeInfoAwareAnnotator {
     public void dateField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
 
         String pattern = null;
-        if (node.has("customDatePattern")) {
-            pattern = node.get("customDatePattern").asText();
-        } else if (node.has("customPattern")) {
-            pattern = node.get("customPattern").asText();
+        if (hasExtensionProperty(node, "customDatePattern")) {
+            pattern = getExtensionProperty(node, "customDatePattern").asText();
+        } else if (hasExtensionProperty(node, "customPattern")) {
+            pattern = getExtensionProperty(node, "customPattern").asText();
         } else if (isNotEmpty(getGenerationConfig().getCustomDatePattern())) {
             pattern = getGenerationConfig().getCustomDatePattern();
         } else if (getGenerationConfig().isFormatDates()) {
@@ -182,10 +184,10 @@ public class Jackson2Annotator extends AbstractTypeInfoAwareAnnotator {
     public void timeField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
 
         String pattern = null;
-        if (node.has("customTimePattern")) {
-            pattern = node.get("customTimePattern").asText();
-        } else if (node.has("customPattern")) {
-            pattern = node.get("customPattern").asText();
+        if (hasExtensionProperty(node, "customTimePattern")) {
+            pattern = getExtensionProperty(node, "customTimePattern").asText();
+        } else if (hasExtensionProperty(node, "customPattern")) {
+            pattern = getExtensionProperty(node, "customPattern").asText();
         } else if (isNotEmpty(getGenerationConfig().getCustomTimePattern())) {
             pattern = getGenerationConfig().getCustomTimePattern();
         } else if (getGenerationConfig().isFormatDates()) {
@@ -199,13 +201,13 @@ public class Jackson2Annotator extends AbstractTypeInfoAwareAnnotator {
 
     @Override
     public void dateTimeField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
-        String timezone = node.has("customTimezone") ? node.get("customTimezone").asText() : "UTC";
+        String timezone = hasExtensionProperty(node, "customTimezone") ? getExtensionProperty(node, "customTimezone").asText() : "UTC";
 
         String pattern = null;
-        if (node.has("customDateTimePattern")) {
-            pattern = node.get("customDateTimePattern").asText();
-        } else if (node.has("customPattern")) {
-            pattern = node.get("customPattern").asText();
+        if (hasExtensionProperty(node, "customDateTimePattern")) {
+            pattern = getExtensionProperty(node, "customDateTimePattern").asText();
+        } else if (hasExtensionProperty(node, "customPattern")) {
+            pattern = getExtensionProperty(node, "customPattern").asText();
         } else if (isNotEmpty(getGenerationConfig().getCustomDateTimePattern())) {
             pattern = getGenerationConfig().getCustomDateTimePattern();
         } else if (getGenerationConfig().isFormatDateTimes()) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/model/EnumDefinition.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/model/EnumDefinition.java
@@ -12,8 +12,8 @@ import java.util.Collections;
  *
  * The definition of the enum can be decided by:
  *    "enum" (JSON-Schema)
- *    "enum" and "javaEnums" (JSON-Schema + jsonschema2pojo extension)
- *    "enum" and "javaEnumNames" (JSON-Schema + jsonschema2pojo extension)
+ *    "enum" and "x-javaEnums" (JSON-Schema + jsonschema2pojo extension)
+ *    "enum" and "x-javaEnumNames" (JSON-Schema + jsonschema2pojo extension)
  */
 public class EnumDefinition {
   private final JType backingType;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -19,6 +19,9 @@ import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.jsonschema2pojo.rules.PrimitiveTypes.isPrimitive;
 import static org.jsonschema2pojo.rules.PrimitiveTypes.primitiveType;
+import static org.jsonschema2pojo.util.ExtensionsHelper.getExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.hasExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.pathExtensionProperty;
 import static org.jsonschema2pojo.util.TypeUtil.resolveType;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -114,8 +117,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), node, jclass, schema);
 
-        if (node.has("javaInterfaces")) {
-            addInterfaces(jclass, node.get("javaInterfaces"));
+        if (hasExtensionProperty(node, "javaInterfaces")) {
+            addInterfaces(jclass, getExtensionProperty(node, "javaInterfaces"));
         }
 
         ruleFactory.getAdditionalPropertiesRule().apply(nodeName, node.get("additionalProperties"), node, jclass, schema);
@@ -194,21 +197,21 @@ public class ObjectRule implements Rule<JPackage, JType> {
         Annotator annotator = ruleFactory.getAnnotator();
 
         try {
-            if (node.has("existingJavaType")) {
-                String fqn = substringBefore(node.get("existingJavaType").asText(), "<");
+            if (hasExtensionProperty(node, "existingJavaType")) {
+                String fqn = substringBefore(getExtensionProperty(node, "existingJavaType").asText(), "<");
 
                 if (isPrimitive(fqn, _package.owner())) {
                     throw new ClassAlreadyExistsException(primitiveType(fqn, _package.owner()));
                 }
 
-                JClass existingClass = resolveType(_package, fqn + (node.get("existingJavaType").asText().contains("<") ? "<" + substringAfter(node.get("existingJavaType").asText(), "<") : ""));
+                JClass existingClass = resolveType(_package, fqn + (getExtensionProperty(node, "existingJavaType").asText().contains("<") ? "<" + substringAfter(getExtensionProperty(node, "existingJavaType").asText(), "<") : ""));
                 throw new ClassAlreadyExistsException(existingClass);
             }
 
             boolean usePolymorphicDeserialization = annotator.isPolymorphicDeserializationSupported(node);
 
-            if (node.has("javaType")) {
-                String fqn = node.path("javaType").asText();
+            if (hasExtensionProperty(node, "javaType")) {
+                String fqn = pathExtensionProperty(node, "javaType").asText();
 
                 if (isPrimitive(fqn, _package.owner())) {
                     throw new GenerationException("javaType cannot refer to a primitive type (" + fqn + "), did you mean to use existingJavaType?");
@@ -421,8 +424,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
         JsonNode properties = node.get("properties");
 
         if (properties != null) {
-            if (node.has("excludedFromEqualsAndHashCode")) {
-                JsonNode excludedArray = node.get("excludedFromEqualsAndHashCode");
+            if (hasExtensionProperty(node, "excludedFromEqualsAndHashCode")) {
+                JsonNode excludedArray = getExtensionProperty(node, "excludedFromEqualsAndHashCode");
 
                 for (Iterator<JsonNode> iterator = excludedArray.elements(); iterator.hasNext(); ) {
                     String excludedPropertyName = iterator.next().asText();
@@ -436,8 +439,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 String propertyName = entry.getKey();
                 JsonNode propertyNode = entry.getValue();
 
-                if (propertyNode.has("excludedFromEqualsAndHashCode") &&
-                        propertyNode.get("excludedFromEqualsAndHashCode").asBoolean()) {
+                if (hasExtensionProperty(propertyNode, "excludedFromEqualsAndHashCode") &&
+                        getExtensionProperty(propertyNode, "excludedFromEqualsAndHashCode").asBoolean()) {
                     filteredFields.remove(ruleFactory.getNameHelper().getPropertyName(propertyName, propertyNode));
                 }
             }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -29,6 +29,9 @@ import com.sun.codemodel.JVar;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 
+import static org.jsonschema2pojo.util.ExtensionsHelper.getExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.hasExtensionProperty;
+
 
 /**
  * Applies the schema rules that represent a property definition.
@@ -158,8 +161,8 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
             ruleFactory.getTitleRule().apply(nodeName, node.get("title"), node, generatedJavaConstruct, schema);
         }
 
-        if (node.has("javaName")) {
-            ruleFactory.getJavaNameRule().apply(nodeName, node.get("javaName"), node, generatedJavaConstruct, schema);
+        if (hasExtensionProperty(node, "javaName")) {
+            ruleFactory.getJavaNameRule().apply(nodeName, getExtensionProperty(node, "javaName"), node, generatedJavaConstruct, schema);
         }
 
         if (node.has("description")) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -14,6 +14,8 @@
 package org.jsonschema2pojo.rules;
 
 import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
+import static org.jsonschema2pojo.util.ExtensionsHelper.hasExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.pathExtensionProperty;
 import static org.jsonschema2pojo.util.TypeUtil.*;
 
 import java.math.BigDecimal;
@@ -78,8 +80,8 @@ public class TypeRule implements Rule<JClassContainer, JType> {
     if (propertyTypeName.equals("object") || node.has("properties") && node.path("properties").size() > 0) {
 
       type = ruleFactory.getObjectRule().apply(nodeName, node, parent, jClassContainer.getPackage(), schema);
-    } else if (node.has("existingJavaType")) {
-      String typeName = node.path("existingJavaType").asText();
+    } else if (hasExtensionProperty(node, "existingJavaType")) {
+      String typeName = pathExtensionProperty(node, "existingJavaType").asText();
 
       if (isPrimitive(typeName, jClassContainer.owner())) {
         type = primitiveType(typeName, jClassContainer.owner());
@@ -106,9 +108,9 @@ public class TypeRule implements Rule<JClassContainer, JType> {
       type = jClassContainer.owner().ref(Object.class);
     }
 
-    if (!node.has("javaType") && !node.has("existingJavaType") && node.has("format")) {
+    if (!hasExtensionProperty(node, "javaType") && !hasExtensionProperty(node, "existingJavaType") && node.has("format")) {
       type = ruleFactory.getFormatRule().apply(nodeName, node.get("format"), node, type, schema);
-    } else if (!node.has("javaType") && !node.has("existingJavaType") && propertyTypeName.equals("string") && node.has("media")) {
+    } else if (!hasExtensionProperty(node, "javaType") && !hasExtensionProperty(node, "existingJavaType") && propertyTypeName.equals("string") && node.has("media")) {
       type = ruleFactory.getMediaRule().apply(nodeName, node.get("media"), node, type, schema);
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ExtensionsHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ExtensionsHelper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Class for working with json-schema keyword extensions. I.e. processing of any node properties that are not
+ * strictly a part of the json-schema specification.
+ *
+ * This was driven largely out of a need to maintain compatibility with existing schemas defined using keyword
+ * extensions that were not prefixed with "x-" before support was added to use the prefix instead.
+ */
+public class ExtensionsHelper {
+
+    /** Prefix for keyword extensions of the json schema */
+    public static final String X_PREFIX = "x-";
+
+    /**
+     * Get node.has(property), for property or "x-" + property with the given arguments.
+     *
+     * @param node  Node on which to retrieve a property.
+     * @param property Property to test for existence of it or the prefixed variant.
+     * @return Node has one of the property or x-property.
+     * @throws IllegalStateException if both 'property' and 'x-property' are found on the node.
+     */
+    public static boolean hasExtensionProperty(JsonNode node, String property) throws IllegalStateException {
+        boolean hasWithoutX = node.has(property);
+        boolean hasWithX = node.has(X_PREFIX + property);
+        if (hasWithoutX && hasWithX) {
+            throw new IllegalStateException("Define only one of '" + property + "' or 'x-" + property + "' (preferred)");
+        }
+        return hasWithoutX || hasWithX;
+
+    }
+
+    /**
+     * Get node.get(property), for property or "x-" + property with the given arguments.
+     *
+     * @param node  Node on which to retrieve a property.
+     * @param property Property to retrieve if exists, and fall back to 'x-' if not.
+     * @return Found property.
+     */
+    public static JsonNode getExtensionProperty(JsonNode node, String property) {
+        return node.has(property) ? node.get(property) : node.get(X_PREFIX + property);
+    }
+
+    /**
+     * Get node.path(property), for property or "x-" + property with the given arguments.
+     *
+     * @param node  Node on which to retrieve a property.
+     * @param property Property to retrieve if exists, and fall back to 'x-' if not.
+     * @return Found property.
+     */
+    public static JsonNode pathExtensionProperty(JsonNode node, String property) {
+        return node.has(property) ? node.path(property) : node.path(X_PREFIX + property);
+    }
+
+    /**
+     * Assuming that the provided node has one of either property or "x-"+property, return the name of which one it
+     * actually has. Appropriate behavior is only guaranteed if {@link #hasExtensionProperty(JsonNode, String)} is true
+     * for the given property value.
+     *
+     * @param node Node to check
+     * @param property Property for which to discover if it or x-property is used.
+     * @return one of property or x-property.
+     */
+    public static String getExtensionPropertyNameUsed(JsonNode node, String property) {
+        return node.has(property) ? property : X_PREFIX + property;
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -22,6 +22,8 @@ import static javax.lang.model.SourceVersion.isKeyword;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.containsAny;
 import static org.apache.commons.lang3.StringUtils.remove;
+import static org.jsonschema2pojo.util.ExtensionsHelper.getExtensionProperty;
+import static org.jsonschema2pojo.util.ExtensionsHelper.hasExtensionProperty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JClass;
@@ -165,8 +167,8 @@ public class NameHelper {
      */
     public String getFieldName(String propertyName, JsonNode node) {
 
-        if (node != null && node.has("javaName")) {
-            propertyName = node.get("javaName").textValue();
+        if (node != null && hasExtensionProperty(node, "javaName")) {
+            propertyName = getExtensionProperty(node, "javaName").textValue();
         }
 
         return propertyName;
@@ -175,8 +177,8 @@ public class NameHelper {
     public String getClassName(String propertyName, JsonNode node) {
 
         if (node != null) {
-            if (node.has("javaName")) {
-                propertyName = node.get("javaName").textValue();
+            if (hasExtensionProperty(node, "javaName")) {
+                propertyName = getExtensionProperty(node, "javaName").textValue();
             } else if (generationConfig.isUseTitleAsClassname() && node.has("title")) {
                 String title = node.get("title").textValue();
                 propertyName = WordUtils.capitalize(title).replaceAll(" ", "");

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SourceSortOrderTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SourceSortOrderTest.java
@@ -24,7 +24,7 @@ import java.util.Comparator;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class SourceSortOrderTest {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -26,7 +26,7 @@ import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -61,7 +61,7 @@ public class EnumRuleTest {
     public void applyGeneratesUniqueEnumNamesForMultipleEnumNodesWithSameName() {
 
         Answer<String> firstArgAnswer = new FirstArgAnswer<>();
-        when(nameHelper.getClassName(anyString(), Matchers.any(JsonNode.class))).thenAnswer(firstArgAnswer);
+        when(nameHelper.getClassName(anyString(), ArgumentMatchers.any(JsonNode.class))).thenAnswer(firstArgAnswer);
         when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
         when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -76,7 +76,7 @@ public class TypeRuleTest {
 
         JType mockDateType = mock(JType.class);
         FormatRule mockFormatRule = mock(FormatRule.class);
-        when(mockFormatRule.apply(eq("fooBar"), eq(formatNode), any(), Mockito.isA(JType.class), isNull(Schema.class))).thenReturn(mockDateType);
+        when(mockFormatRule.apply(eq("fooBar"), eq(formatNode), any(), Mockito.isA(JType.class), isNull())).thenReturn(mockDateType);
         when(ruleFactory.getFormatRule()).thenReturn(mockFormatRule);
 
         JType result = rule.apply("fooBar", objectNode, null, jpackage, null);
@@ -561,7 +561,7 @@ public class TypeRuleTest {
 
         JType result = rule.apply("fooBar", objectNode, null, jpackage, null);
 
-        assertThat(result, is((JType) mockArrayType));
+        assertThat(result, is(mockArrayType));
     }
 
     @Test
@@ -579,7 +579,7 @@ public class TypeRuleTest {
 
         JType result = rule.apply("fooBar", objectNode, null, jpackage, null);
 
-        assertThat(result, is((JType) mockObjectType));
+        assertThat(result, is(mockObjectType));
     }
 
     @Test

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
@@ -17,6 +17,7 @@
 package org.jsonschema2pojo.util;
 
 import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.util.ExtensionsHelper.X_PREFIX;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -63,6 +64,8 @@ public class NameHelperTest {
         assertThat(nameHelper.getClassName("foo", node("title", "bar")), is("foo"));
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar")), is("bar"));
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar").put("title", "abc")), is("bar"));
+        assertThat(nameHelper.getClassName("foo", node(X_PREFIX + "javaName", "bar")), is("bar"));
+        assertThat(nameHelper.getClassName("foo", node(X_PREFIX + "javaName", "bar").put("title", "abc")), is("bar"));
 
         // TITLE_ATTRIBUTE
         NameHelper nameHelper = helper(true);
@@ -70,6 +73,8 @@ public class NameHelperTest {
         assertThat(nameHelper.getClassName("foo", node("title", "i am bar")), is("IAmBar"));
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar")), is("bar"));
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar").put("title", "abc")), is("bar"));
+        assertThat(nameHelper.getClassName("foo", node(X_PREFIX + "javaName", "bar")), is("bar"));
+        assertThat(nameHelper.getClassName("foo", node(X_PREFIX + "javaName", "bar").put("title", "abc")), is("bar"));
     }
 
     private NameHelper helper(boolean useTitleAsClassname) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -119,6 +119,17 @@ public class CustomDateTimeFormatIT {
     }
 
     @Test
+    public void testDefaultWithXCustomTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception {
+
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setDefaultFormatCustomTZX", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"defaultFormatCustomTZX\":\"2001-09-08T18:46:39.999-07:00\"}"));
+    }
+
+    @Test
     public void testCustomDateTimePatternWithDefaultTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception {
         final Object instance = classWhenFormatDatesTrue.newInstance();
         classWhenFormatDatesTrue.getMethod("setCustomFormatDefaultTZ", Date.class).invoke(instance, new Date(999999999999L));
@@ -129,6 +140,26 @@ public class CustomDateTimeFormatIT {
     }
 
     @Test
+    public void testXCustomDateTimePatternWithDefaultTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatDefaultTZX", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatDefaultTZX\":\"2001-09-09T01:46:39\"}"));
+    }
+
+    @Test
+    public void testXCustomPatternWithDefaultTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatDefaultTZXcP", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatDefaultTZXcP\":\"2001-09-09T01:46:39\"}"));
+    }
+
+    @Test
     public void testCustomDateTimePatternWithCustomTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception{
         final Object instance = classWhenFormatDatesTrue.newInstance();
         classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTZ", Date.class).invoke(instance, new Date(999999999999L));
@@ -136,6 +167,16 @@ public class CustomDateTimeFormatIT {
         final String json = new ObjectMapper().writeValueAsString(instance);
 
         assertThat(json, is("{\"customFormatCustomTZ\":\"2001-09-08T18:46:39\"}"));
+    }
+
+    @Test
+    public void testXCustomDateTimePatternWithXCustomTimezoneWhenFormatDateTimesConfigIsTrue() throws Exception{
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTZX", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatCustomTZX\":\"2001-09-08T18:46:39\"}"));
     }
 
     @Test
@@ -219,6 +260,26 @@ public class CustomDateTimeFormatIT {
     }
 
     @Test
+    public void testXCustomDatePattern() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatCustomDateX", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatCustomDateX\":\"09-09-2001\"}"));
+    }
+
+    @Test
+    public void testXCustomPatternOnDate() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatCustomDateXcP", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatCustomDateXcP\":\"09-09-2001\"}"));
+    }
+
+    @Test
     public void testCustomTimePattern() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
         final Object instance = classWhenFormatDatesTrue.newInstance();
         classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTime", Date.class).invoke(instance, new Date(999999999999L));
@@ -226,5 +287,25 @@ public class CustomDateTimeFormatIT {
         final String json = new ObjectMapper().setLocale(Locale.ENGLISH).writeValueAsString(instance);
 
         assertThat(json, is("{\"customFormatCustomTime\":\"1:46 AM\"}"));
+    }
+
+    @Test
+    public void testXCustomTimePattern() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTimeX", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().setLocale(Locale.ENGLISH).writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatCustomTimeX\":\"1:46 AM\"}"));
+    }
+
+    @Test
+    public void testXCustomPatternOnTime() throws ReflectiveOperationException, SecurityException, JsonProcessingException {
+        final Object instance = classWhenFormatDatesTrue.newInstance();
+        classWhenFormatDatesTrue.getMethod("setCustomFormatCustomTimeXcP", Date.class).invoke(instance, new Date(999999999999L));
+
+        final String json = new ObjectMapper().setLocale(Locale.ENGLISH).writeValueAsString(instance);
+
+        assertThat(json, is("{\"customFormatCustomTimeXcP\":\"1:46 AM\"}"));
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -283,12 +283,61 @@ public class EnumIT {
 
     @Test
     @SuppressWarnings({ "unchecked" })
+    public void enumWithCustomXJavaNames() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, IOException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithCustomXJavaNames.json", "com.example");
+
+        Class<?> typeWithEnumProperty = resultsClassLoader.loadClass("com.example.EnumWithCustomXJavaNames");
+        Class<Enum> enumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.EnumWithCustomXJavaNames$EnumProperty");
+
+        Object valueWithEnumProperty = typeWithEnumProperty.newInstance();
+        Method enumSetter = typeWithEnumProperty.getMethod("setEnumProperty", enumClass);
+        enumSetter.invoke(valueWithEnumProperty, enumClass.getEnumConstants()[2]);
+        assertThat(enumClass.getEnumConstants()[0].name(), is("ONE"));
+        assertThat(enumClass.getEnumConstants()[1].name(), is("TWO"));
+        assertThat(enumClass.getEnumConstants()[2].name(), is("THREE"));
+        assertThat(enumClass.getEnumConstants()[3].name(), is("FOUR"));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String jsonString = objectMapper.writeValueAsString(valueWithEnumProperty);
+        JsonNode jsonTree = objectMapper.readTree(jsonString);
+
+        assertThat(jsonTree.size(), is(1));
+        assertThat(jsonTree.has("enum_Property"), is(true));
+        assertThat(jsonTree.get("enum_Property").isTextual(), is(true));
+        assertThat(jsonTree.get("enum_Property").asText(), is("3"));
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
     public void enumWithJavaEnumsExtension() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, IOException {
 
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithJavaEnumsExtension.json", "com.example");
 
         Class<?> typeWithEnumProperty = resultsClassLoader.loadClass("com.example.EnumWithJavaEnumsExtension");
         Class<Enum> enumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.EnumWithJavaEnumsExtension$EnumProperty");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        assertThat(enumClass.getEnumConstants()[0].name(), is("ONE"));
+        checkValueOfEnum(typeWithEnumProperty, enumClass, 0, "1", objectMapper);
+        assertThat(enumClass.getEnumConstants()[1].name(), is("TWO"));
+        checkValueOfEnum(typeWithEnumProperty, enumClass, 1, "2", objectMapper);
+        assertThat(enumClass.getEnumConstants()[2].name(), is("THREE"));
+        checkValueOfEnum(typeWithEnumProperty, enumClass, 2, "3", objectMapper);
+        assertThat(enumClass.getEnumConstants()[3].name(), is("FOUR"));
+        checkValueOfEnum(typeWithEnumProperty, enumClass, 3, "4", objectMapper);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void enumWithXJavaEnumsExtension() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, IOException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/enum/enumWithXJavaEnumsExtension.json", "com.example");
+
+        Class<?> typeWithEnumProperty = resultsClassLoader.loadClass("com.example.EnumWithXJavaEnumsExtension");
+        Class<Enum> enumClass = (Class<Enum>) resultsClassLoader.loadClass("com.example.EnumWithXJavaEnumsExtension$EnumProperty");
 
         ObjectMapper objectMapper = new ObjectMapper();
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
@@ -21,27 +21,46 @@ import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
+@RunWith(Parameterized.class)
 public class ExcludedFromEqualsAndHashCodeIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
-    private static Class<?> clazz;
+    private static ClassLoader resultsClassLoader;
 
     @BeforeClass
-    public static void generateAndCompileEnum() throws ClassNotFoundException {
+    public static void generateAndCompileEnum() {
+        classSchemaRule.generate("/schema/excludedFromEqualsAndHashCode/excludedFromEqualsAndHashCode.json", "com.example");
+        classSchemaRule.generate("/schema/excludedFromEqualsAndHashCode/x-excludedFromEqualsAndHashCode.json", "com.example");
+        resultsClassLoader = classSchemaRule.compile();
+    }
 
-        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/excludedFromEqualsAndHashCode/excludedFromEqualsAndHashCode.json", "com.example");
+    @Parameterized.Parameters(name="{0}")
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                /* { className } */
+                { "com.example.ExcludedFromEqualsAndHashCode" },
+                { "com.example.XExcludedFromEqualsAndHashCode" },
+        });
+    }
 
-        clazz = resultsClassLoader.loadClass("com.example.ExcludedFromEqualsAndHashCode");
+    private Class<?> clazz;
+
+    public ExcludedFromEqualsAndHashCodeIT(String className) throws ClassNotFoundException {
+        this.clazz = resultsClassLoader.loadClass(className);
     }
 
     @Test
@@ -90,7 +109,7 @@ public class ExcludedFromEqualsAndHashCodeIT {
     }
 
     @Test
-    public void exludedByPropertyTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+    public void excludedByPropertyTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
         Object instanceOne = clazz.newInstance();
         Object instanceTwo = clazz.newInstance();
 
@@ -108,7 +127,7 @@ public class ExcludedFromEqualsAndHashCodeIT {
     }
 
     @Test
-    public void exludedByArrayTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+    public void excludedByArrayTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
         Object instanceOne = clazz.newInstance();
         Object instanceTwo = clazz.newInstance();
 
@@ -144,7 +163,7 @@ public class ExcludedFromEqualsAndHashCodeIT {
     }
 
     @Test
-    public void notExludedByPropertyTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+    public void notExcludedByPropertyTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
         Object instanceOne = clazz.newInstance();
         Object instanceTwo = clazz.newInstance();
 
@@ -161,7 +180,7 @@ public class ExcludedFromEqualsAndHashCodeIT {
         assertThat(instanceOne.equals(instanceTwo), is(false));
     }
 
-    private static void setProperty(Object instance, String property, String value) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+    private void setProperty(Object instance, String property, String value) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         new PropertyDescriptor(property, clazz).getWriteMethod().invoke(instance, value);
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -23,19 +23,40 @@ import static org.junit.Assert.*;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class ExtendsIT {
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Parameterized.Parameters(name="{0}")
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                /* { schemaDir } */
+                { "/schema/extends/" },
+                { "/schema/x-extends/" },
+        });
+    }
+
+    private final String schemaDir;
+
+    public ExtendsIT(String schemaDir) {
+        this.schemaDir = schemaDir;
+    }
+
 
     @Test
     @SuppressWarnings("rawtypes")
     public void extendsWithEmbeddedSchemaGeneratesParentType() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsEmbeddedSchema.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "extendsEmbeddedSchema.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.ExtendsEmbeddedSchema");
         Class supertype = resultsClassLoader.loadClass("com.example.ExtendsEmbeddedSchemaParent");
@@ -48,7 +69,7 @@ public class ExtendsIT {
     @SuppressWarnings("rawtypes")
     public void extendsWithRefToAnotherSchema() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfA.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfA.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.A");
@@ -61,7 +82,7 @@ public class ExtendsIT {
     @SuppressWarnings("rawtypes")
     public void extendsWithRefToAnotherSchemaThatIsAlreadyASubtype() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfSubtypeOfA.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfA");
@@ -73,7 +94,7 @@ public class ExtendsIT {
     @Test(expected = ClassNotFoundException.class)
     public void extendsStringCausesNoNewTypeToBeGenerated() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsString.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "extendsString.json", "com.example");
         resultsClassLoader.loadClass("com.example.ExtendsString");
 
     }
@@ -81,7 +102,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings("rawtypes")
     public void extendsEquals() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example2");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfSubtypeOfA.json", "com.example2");
 
         Class generatedType = resultsClassLoader.loadClass("com.example2.SubtypeOfSubtypeOfA");
         Object instance = generatedType.newInstance();
@@ -100,7 +121,7 @@ public class ExtendsIT {
     @SuppressWarnings("rawtypes")
     public void extendsSchemaWithinDefinitions() throws Exception {
 
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsSchemaWithinDefinitions.json", "com.example");
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "extendsSchemaWithinDefinitions.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.Child");
         assertNotNull("no propertyOfChild field", subtype.getDeclaredField("propertyOfChild"));
@@ -114,7 +135,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void constructorHasParentsProperties() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfB.json", "com.example", config("includeConstructors", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfB.json", "com.example", config("includeConstructors", true));
 
         Class type = resultsClassLoader.loadClass("com.example.SubtypeOfB");
         Class supertype = resultsClassLoader.loadClass("com.example.B");
@@ -140,7 +161,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void constructorHasParentsParentProperties() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfB.json", "com.example", config("includeConstructors", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfSubtypeOfB.json", "com.example", config("includeConstructors", true));
 
         Class type = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfB");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfB");
@@ -172,7 +193,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void constructorHasParentsParentPropertiesInCorrectOrder() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfBDifferentType.json", "com.example", config("includeConstructors", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfSubtypeOfBDifferentType.json", "com.example", config("includeConstructors", true));
 
         Class type = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfBDifferentType");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfB");
@@ -204,7 +225,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void constructorDoesNotDuplicateArgsFromDuplicatedParentProperties() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfC.json", "com.example", config("includeConstructors", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfSubtypeOfC.json", "com.example", config("includeConstructors", true));
 
         Class type = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfC");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfC");
@@ -236,7 +257,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings("rawtypes")
     public void extendsBuilderMethods() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfSubtypeOfA.json", "com.example", config("generateBuilders", true));
 
         Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfSubtypeOfA");
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfA");
@@ -247,7 +268,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings("rawtypes")
     public void builderMethodsOnChildWithProperties() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfB.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfB.json", "com.example", config("generateBuilders", true));
 
         Class type = resultsClassLoader.loadClass("com.example.SubtypeOfB");
         Class supertype = resultsClassLoader.loadClass("com.example.B");
@@ -258,7 +279,7 @@ public class ExtendsIT {
     @Test
     @SuppressWarnings("rawtypes")
     public void builderMethodsOnChildWithNoProperties() throws Exception {
-        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfBWithNoProperties.json", "com.example", config("generateBuilders", true));
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile(schemaDir + "subtypeOfBWithNoProperties.json", "com.example", config("generateBuilders", true));
 
         Class type = resultsClassLoader.loadClass("com.example.SubtypeOfBWithNoProperties");
         Class supertype = resultsClassLoader.loadClass("com.example.B");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
@@ -23,23 +23,43 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class GenericTypeIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
-    private static Class<?> classWithGenericTypes;
+    private static ClassLoader classLoader;
 
     @BeforeClass
-    public static void generateAndCompileClass() throws ClassNotFoundException {
+    public static void generateAndCompileClass() {
+        classSchemaRule.generate("/schema/type/genericJavaType.json", "com.example");
+        classSchemaRule.generate("/schema/type/x-genericJavaType.json", "com.example");
+        classLoader = classSchemaRule.compile();
+    }
 
-        classWithGenericTypes = classSchemaRule.generateAndCompile("/schema/type/genericJavaType.json", "com.example").loadClass("com.example.GenericJavaType");
+    @Parameterized.Parameters(name="{0}")
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                /* { className } */
+                { "com.example.GenericJavaType" },
+                { "com.example.XGenericJavaType" },
+        });
+    }
 
+    private Class<?> classWithGenericTypes;
+
+    public GenericTypeIT(String className) throws ClassNotFoundException {
+        classWithGenericTypes = classLoader.loadClass(className);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
@@ -22,13 +22,35 @@ import static org.junit.Assert.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class JacksonViewIT {
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Parameterized.Parameters(name="{0}")
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                /* { schemaFile, className } */
+                { "/schema/views/views.json", "com.example.Views" },
+                { "/schema/views/x-views.json", "com.example.XViews" },
+        });
+    }
+
+    private String schemaFile;
+    private String className;
+
+    public JacksonViewIT(String schemaFile, String className) {
+        this.schemaFile = schemaFile;
+        this.className = className;
+    }
 
     @Test
     public void javaJsonViewWithJackson1x() throws Exception {
@@ -51,11 +73,11 @@ public class JacksonViewIT {
 
     private Annotation jsonViewTest(String annotationStyle, Class<? extends Annotation> annotationType) throws ClassNotFoundException, NoSuchFieldException {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile(
-                "/schema/views/views.json",
+                schemaFile,
                 "com.example",
                 config("annotationStyle", annotationStyle));
 
-        Class<?> generatedType = resultsClassLoader.loadClass("com.example.Views");
+        Class<?> generatedType = resultsClassLoader.loadClass(className);
         Field fieldInView = generatedType.getDeclaredField("inView");
         assertThat(fieldInView.getAnnotation(annotationType), notNullValue());
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -25,9 +25,10 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -36,26 +37,37 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.qdox.JavaDocBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
  * Created by cmb on 31.01.16.
  */
+@RunWith(Parameterized.class)
 public class JavaNameIT {
 
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();
+    @Parameterized.Parameters(name="{0}")
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                /* { schemaDir } */
+                { "/schema/javaName/" },
+                { "/schema/x-javaName/" },
+        });
+    }
 
-    @BeforeClass
-    public static void generateAndCompileClass() {
+    private final String schemaDir;
 
-
+    public JavaNameIT(String schemaDir) {
+        this.schemaDir = schemaDir;
     }
 
     @Test
     public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "javaName.json", "com.example.javaname");
         Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
         Object instance = classWithJavaNames.newInstance();
 
@@ -71,7 +83,7 @@ public class JavaNameIT {
     @Test
     public void propertiesHaveCorrectTypes() throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchFieldException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "javaName.json", "com.example.javaname");
         Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
 
         classWithJavaNames.newInstance();
@@ -86,7 +98,7 @@ public class JavaNameIT {
     @Test
     public void gettersHaveCorrectNames() throws NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "javaName.json", "com.example.javaname");
         Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
 
         classWithJavaNames.getMethod("getJavaProperty");
@@ -101,7 +113,7 @@ public class JavaNameIT {
     @Test
     public void settersHaveCorrectNamesAndArgumentTypes() throws NoSuchMethodException, ClassNotFoundException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "javaName.json", "com.example.javaname");
         Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
 
         classWithJavaNames.getMethod("setJavaProperty", String.class);
@@ -118,7 +130,7 @@ public class JavaNameIT {
     @Test
     public void serializedPropertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException, ClassNotFoundException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "javaName.json", "com.example.javaname");
         Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
         Object instance = classWithJavaNames.newInstance();
 
@@ -135,7 +147,7 @@ public class JavaNameIT {
     @Test
     public void originalPropertyNamesAppearInJavaDoc() throws IOException {
 
-        schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
+        schemaRule.generateAndCompile(schemaDir + "javaName.json", "com.example.javaname");
         File generatedJavaFile = schemaRule.generated("com/example/javaname/JavaName.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
@@ -157,21 +169,21 @@ public class JavaNameIT {
     @Test(expected = IllegalArgumentException.class)
     public void doesNotAllowDuplicateNames() {
 
-        schemaRule.generateAndCompile("/schema/javaName/duplicateName.json", "com.example");
+        schemaRule.generateAndCompile(schemaDir + "duplicateName.json", "com.example");
 
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void doesNotAllowDuplicateDefaultNames() {
 
-        schemaRule.generateAndCompile("/schema/javaName/duplicateDefaultName.json", "com.example");
+        schemaRule.generateAndCompile(schemaDir + "duplicateDefaultName.json", "com.example");
 
     }
 
     @Test
     public void arrayRequiredAppearsInFieldJavadoc() throws IOException {
 
-        schemaRule.generateAndCompile("/schema/javaName/javaNameWithRequiredProperties.json", "com.example.required");
+        schemaRule.generateAndCompile(schemaDir + "javaNameWithRequiredProperties.json", "com.example.required");
         File generatedJavaFileWithRequiredProperties = schemaRule.generated("com/example/required/JavaNameWithRequiredProperties.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
@@ -189,7 +201,7 @@ public class JavaNameIT {
     @Test
     public void inlineRequiredAppearsInFieldJavadoc() throws IOException {
 
-        schemaRule.generateAndCompile("/schema/javaName/javaNameWithRequiredProperties.json", "com.example.required");
+        schemaRule.generateAndCompile(schemaDir + "javaNameWithRequiredProperties.json", "com.example.required");
         File generatedJavaFileWithRequiredProperties = schemaRule.generated("com/example/required/JavaNameWithRequiredProperties.java");
 
         JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
@@ -207,7 +219,7 @@ public class JavaNameIT {
     @Test
     public void generateClassInTargetPackage() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "AuthorizeRequest_v1p0.json", "com.example.javaname");
         Class<?> classWithTargetPackage = javaNameClassLoader.loadClass("com.example.javaname.OCSPRequestData");
 
         assertEquals("com.example.javaname.OCSPRequestData", classWithTargetPackage.getName());
@@ -216,7 +228,7 @@ public class JavaNameIT {
     @Test
     public void generateClassInJavaTypePackage() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "AuthorizeRequest_v1p0.json", "com.example.javaname");
         Class<?> classWithJavaTypePackage = javaNameClassLoader.loadClass("com.apetecan.javaname.AdditionalInfo");
 
         assertEquals("com.apetecan.javaname.AdditionalInfo", classWithJavaTypePackage.getName());
@@ -225,7 +237,7 @@ public class JavaNameIT {
     @Test
     public void generateClassInTargetPackageReferencingClassInJavaTypePackage() throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchFieldException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0_2.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "AuthorizeRequest_v1p0_2.json", "com.example.javaname");
         Class<?> classWithTargetPackage = javaNameClassLoader.loadClass("com.example.javaname.AuthorizeRequestV1p02");
 
         assertEquals("com.example.javaname.AuthorizeRequestV1p02", classWithTargetPackage.getName());
@@ -238,7 +250,7 @@ public class JavaNameIT {
     @Test
     public void generateReferencedClassUsesParentClassPackage() throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchFieldException {
 
-        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0_2.json", "com.example.javaname");
+        ClassLoader javaNameClassLoader = schemaRule.generateAndCompile(schemaDir + "AuthorizeRequest_v1p0_2.json", "com.example.javaname");
         Class<?> classWithJavaTypePackage = javaNameClassLoader.loadClass("com.apetecan.javaname.IdToken");
 
         assertEquals("com.apetecan.javaname.IdToken", classWithJavaTypePackage.getName());

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/KeywordExtensionsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/KeywordExtensionsIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Small test for checking that the "x-" and regular variants of non-spec keyword extensions cannot be used at the same time.
+ */
+public class KeywordExtensionsIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @Rule public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void testKeywordExtensionCollision() {
+        expectedEx.expect(IllegalStateException.class);
+        expectedEx.expectMessage("Define only one of 'extends' or 'x-extends' (preferred)");
+
+        schemaRule.generate("/schema/keywordExtensions/keywordExtensionsCollisions.json", "com.example");
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeMiscIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeMiscIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TypeMiscIT {
+    
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void maximumGreaterThanIntegerMaxCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMaximumAsLong.json", "com.example")
+                .loadClass("com.example.IntegerWithLongMaximumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void maximumGreaterThanIntegerMaxCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMaximumAsLong.json", "com.example", config("usePrimitives", true))
+                .loadClass("com.example.IntegerWithLongMaximumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+
+    }
+
+    @Test
+    public void minimumLessThanIntegerMinCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMinimumAsLong.json", "com.example")
+                .loadClass("com.example.IntegerWithLongMinimumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void minimumLessThanIntegerMinCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerWithLongMinimumAsLong.json", "com.example", config("usePrimitives", true))
+                .loadClass("com.example.IntegerWithLongMinimumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+
+    }
+
+    @Test
+    public void useLongIntegersParameterCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true))
+                .loadClass("com.example.IntegerAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void useLongIntegersParameterCausesPrimitiveIntsToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/type/integerAsLong.json", "com.example", config("useLongIntegers", true, "usePrimitives", true))
+                .loadClass("com.example.IntegerAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+    }
+
+    @Test
+    public void useDoubleNumbersFalseCausesNumbersToBecomeFloats() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithDoubleProperty = schemaRule.generateAndCompile("/schema/type/numberAsFloat.json", "com.example", config("useDoubleNumbers", false))
+                .loadClass("com.example.NumberAsFloat");
+
+        Method getterMethod = classWithDoubleProperty.getMethod("getFloatProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Float"));
+
+    }
+
+    @Test
+    public void useDoubleNumbersFalseCausesPrimitiveNumbersToBecomeFloats() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithDoubleProperty = schemaRule.generateAndCompile("/schema/type/numberAsFloat.json", "com.example", config("useDoubleNumbers", false, "usePrimitives", true))
+                .loadClass("com.example.NumberAsFloat");
+
+        Method getterMethod = classWithDoubleProperty.getMethod("getFloatProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("float"));
+    }
+
+    @Test
+    public void unionTypesChooseFirstTypePresent() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        Class<?> classWithUnionProperties = schemaRule.generateAndCompile("/schema/type/unionTypes.json", "com.example").loadClass("com.example.UnionTypes");
+
+        Method booleanGetter = classWithUnionProperties.getMethod("getBooleanProperty");
+
+        assertThat(booleanGetter.getReturnType().getName(), is("java.lang.Boolean"));
+
+        Method stringGetter = classWithUnionProperties.getMethod("getStringProperty");
+
+        assertThat(stringGetter.getReturnType().getName(), is("java.lang.String"));
+
+        Method integerGetter = classWithUnionProperties.getMethod("getIntegerProperty");
+
+        assertThat(integerGetter.getReturnType().getName(), is("java.lang.Integer"));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void typeNameConflictDoesNotCauseTypeReuse() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithNameConflict = schemaRule.generateAndCompile("/schema/type/typeNameConflict.json", "com.example").loadClass("com.example.TypeNameConflict");
+
+        Method getterMethod = classWithNameConflict.getMethod("getTypeNameConflict");
+
+        assertThat((Class) getterMethod.getReturnType(), is(not((Class) classWithNameConflict)));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlTypeMiscIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlTypeMiscIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2010-2017 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.yaml;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertThat;
+
+public class YamlTypeMiscIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void maximumGreaterThanIntegerMaxCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/yaml/type/integerWithLongMaximumAsLong.yaml", "com.example", config("sourceType", "yamlschema"))
+                .loadClass("com.example.IntegerWithLongMaximumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void maximumGreaterThanIntegerMaxCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/yaml/type/integerWithLongMaximumAsLong.yaml", "com.example", config("usePrimitives", true, "sourceType", "yamlschema"))
+                .loadClass("com.example.IntegerWithLongMaximumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+
+    }
+
+    @Test
+    public void minimumLessThanIntegerMinCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/yaml/type/integerWithLongMinimumAsLong.yaml", "com.example", config("sourceType", "yamlschema"))
+                .loadClass("com.example.IntegerWithLongMinimumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void minimumLessThanIntegerMinCausesIntegersToBecomePrimitiveLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/yaml/type/integerWithLongMinimumAsLong.yaml", "com.example", config("usePrimitives", true, "sourceType", "yamlschema"))
+                .loadClass("com.example.IntegerWithLongMinimumAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+
+    }
+
+    @Test
+    public void useLongIntegersParameterCausesIntegersToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/yaml/type/integerAsLong.yaml", "com.example", config("useLongIntegers", true, "sourceType", "yamlschema"))
+                .loadClass("com.example.IntegerAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Long"));
+
+    }
+
+    @Test
+    public void useLongIntegersParameterCausesPrimitiveIntsToBecomeLongs() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithLongProperty = schemaRule.generateAndCompile("/schema/yaml/type/integerAsLong.yaml", "com.example", config("useLongIntegers", true, "usePrimitives", true, "sourceType", "yamlschema"))
+                .loadClass("com.example.IntegerAsLong");
+
+        Method getterMethod = classWithLongProperty.getMethod("getLongProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("long"));
+    }
+
+    @Test
+    public void useDoubleNumbersFalseCausesNumbersToBecomeFloats() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithDoubleProperty = schemaRule.generateAndCompile("/schema/yaml/type/numberAsFloat.yaml", "com.example", config("useDoubleNumbers", false, "sourceType", "yamlschema"))
+                .loadClass("com.example.NumberAsFloat");
+
+        Method getterMethod = classWithDoubleProperty.getMethod("getFloatProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("java.lang.Float"));
+
+    }
+
+    @Test
+    public void useDoubleNumbersFalseCausesPrimitiveNumbersToBecomeFloats() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithDoubleProperty = schemaRule.generateAndCompile("/schema/yaml/type/numberAsFloat.yaml", "com.example", config("useDoubleNumbers", false, "usePrimitives", true, "sourceType", "yamlschema"))
+                .loadClass("com.example.NumberAsFloat");
+
+        Method getterMethod = classWithDoubleProperty.getMethod("getFloatProperty");
+
+        assertThat(getterMethod.getReturnType().getName(), is("float"));
+    }
+
+    @Test
+    public void unionTypesChooseFirstTypePresent() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        Class<?> classWithUnionProperties = schemaRule.generateAndCompile("/schema/yaml/type/unionTypes.yaml", "com.example", config("sourceType", "yamlschema")).loadClass("com.example.UnionTypes");
+
+        Method booleanGetter = classWithUnionProperties.getMethod("getBooleanProperty");
+
+        assertThat(booleanGetter.getReturnType().getName(), is("java.lang.Boolean"));
+
+        Method stringGetter = classWithUnionProperties.getMethod("getStringProperty");
+
+        assertThat(stringGetter.getReturnType().getName(), is("java.lang.String"));
+
+        Method integerGetter = classWithUnionProperties.getMethod("getIntegerProperty");
+
+        assertThat(integerGetter.getReturnType().getName(), is("java.lang.Integer"));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void typeNameConflictDoesNotCauseTypeReuse() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+        Class<?> classWithNameConflict = schemaRule.generateAndCompile("/schema/yaml/type/typeNameConflict.yaml", "com.example", config("sourceType", "yamlschema")).loadClass("com.example.TypeNameConflict");
+
+        Method getterMethod = classWithNameConflict.getMethod("getTypeNameConflict");
+
+        assertThat((Class) getterMethod.getReturnType(), is(not((Class) classWithNameConflict)));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/doubleEnumAsRoot.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/doubleEnumAsRoot.json
@@ -2,5 +2,5 @@
     "javaType" : "com.example.enums.DoubleEnumAsRoot",
     "type" : "number",
     "enum" : [1.0, 2.5, 3],
-    "javaEnumNames" : ["One", "TwoAndAHalf", "Three"]
+    "x-javaEnumNames" : ["One", "TwoAndAHalf", "Three"]
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumWithCustomXJavaNames.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumWithCustomXJavaNames.json
@@ -1,0 +1,10 @@
+{
+    "type" : "object",
+    "properties" : {
+        "enum_Property" : {
+            "type" : "string",
+            "enum" : ["1", "2", "3", "4"],
+            "x-javaEnumNames" : ["ONE","TWO","THREE", "FOUR"]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumWithXJavaEnumsExtension.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumWithXJavaEnumsExtension.json
@@ -1,0 +1,29 @@
+{
+    "type" : "object",
+    "properties" : {
+        "enumProperty" : {
+            "type" : "string",
+            "enum" : ["1", "2", "3", "4"],
+            "x-javaEnums" : [
+                {
+                    "name": "ONE",
+                    "title": "The first number.",
+                    "description": "1 (one, also called unit, unity, and (multiplicative) identity) is a number, and a numerical digit used to represent that number in numerals. (https://en.wikipedia.org/wiki/1)"
+                },
+                {
+                    "name": "TWO",
+                    "title": "The second number.",
+                    "description": "2 (two) is a number, numeral, and glyph. \n\nIt is the natural number following 1 and preceding 3. (https://en.wikipedia.org/wiki/2)"
+                },{
+                    "name": "THREE",
+                    "title": "The third number.",
+                    "description": "3 (three) is a number, numeral, and glyph. It is the natural number following 2 and preceding 4. (https://en.wikipedia.org/wiki/3)"
+                },{
+                    "name": "FOUR",
+                    "title": "The fourth number.",
+                    "description": "4 (four) is a number, numeral, and glyph. It is the natural number following 3 and preceding 5. (https://en.wikipedia.org/wiki/4)"
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/integerEnumAsRoot.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/integerEnumAsRoot.json
@@ -2,5 +2,5 @@
     "javaType" : "com.example.enums.IntegerEnumAsRoot",
     "type" : "integer",
     "enum" : [1, 2, 3],
-    "javaEnumNames" : ["One", "Two", "Three"]
+    "x-javaEnumNames" : ["One", "Two", "Three"]
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/integerEnumToSerialize.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/integerEnumToSerialize.json
@@ -4,7 +4,7 @@
        "testEnum" : { 
           "type" : "integer",
           "enum" : [1, 2, 3],
-          "javaEnumNames" : ["One", "Two", "Three"]
+          "x-javaEnumNames" : ["One", "Two", "Three"]
       }
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/excludedFromEqualsAndHashCode/x-excludedFromEqualsAndHashCode.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/excludedFromEqualsAndHashCode/x-excludedFromEqualsAndHashCode.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "x-excludedFromEqualsAndHashCode" : [ "excludedByArray" ],
+  "properties": {
+    "notExcluded" : {
+      "type" : "string"
+    },
+    "excludedByProperty" : {
+      "type" : "string",
+      "x-excludedFromEqualsAndHashCode" : true
+    },
+    "notExcludedByProperty" : {
+      "type" : "string",
+      "x-excludedFromEqualsAndHashCode" : false
+    },
+    "excludedByArray" : {
+      "type" : "string"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/format/customDateTimeFormat.json
@@ -10,16 +10,37 @@
             "format" : "date-time",
             "customTimezone" : "PST"
         },
+        "defaultFormatCustomTZX" : {
+            "type" : "string",
+            "format" : "date-time",
+            "x-customTimezone" : "PST"
+        },
         "customFormatDefaultTZ" : {
             "type" : "string",
             "format" : "date-time",
             "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss"
+        },
+        "customFormatDefaultTZX" : {
+            "type" : "string",
+            "format" : "date-time",
+            "x-customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss"
+        },
+        "customFormatDefaultTZXcP" : {
+            "type" : "string",
+            "format" : "date-time",
+            "x-customPattern" : "yyyy-MM-dd'T'HH:mm:ss"
         },
         "customFormatCustomTZ" : {
             "type" : "string",
             "format" : "date-time",
             "customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss",
             "customTimezone" : "PST"
+        },
+        "customFormatCustomTZX" : {
+            "type" : "string",
+            "format" : "date-time",
+            "x-customDateTimePattern" : "yyyy-MM-dd'T'HH:mm:ss",
+            "x-customTimezone" : "PST"
         },
         "defaultFormatDate" : {
             "type" : "string",
@@ -34,10 +55,30 @@
             "format" : "date",
             "customDatePattern" : "dd-MM-yyyy"
         },
+        "customFormatCustomDateX" : {
+            "type" : "string",
+            "format" : "date",
+            "x-customDatePattern" : "dd-MM-yyyy"
+        },
+        "customFormatCustomDateXcP" : {
+            "type" : "string",
+            "format" : "date",
+            "x-customPattern" : "dd-MM-yyyy"
+        },
         "customFormatCustomTime" : {
             "type" : "string",
             "format" : "time",
             "customTimePattern" : "H:mm a"
+        },
+        "customFormatCustomTimeX" : {
+            "type" : "string",
+            "format" : "time",
+            "x-customTimePattern" : "H:mm a"
+        },
+        "customFormatCustomTimeXcP" : {
+            "type" : "string",
+            "format" : "time",
+            "x-customPattern" : "H:mm a"
         }
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/keywordExtensions/keywordExtensionsCollisions.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/keywordExtensions/keywordExtensionsCollisions.json
@@ -1,0 +1,24 @@
+{
+  "type" : "object",
+  "properties" : {
+    "propertyOfChild" : {
+      "type" : "string"
+    }
+  },
+  "extends" : {
+    "type" : "object",
+    "properties" : {
+      "propertyOfParent" : {
+        "type" : "string"
+      }
+    }
+  },
+ "x-extends" : {
+    "type" : "object",
+    "properties" : {
+      "propertyOfParent" : {
+        "type" : "string"
+      }
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/type/x-genericJavaType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/type/x-genericJavaType.json
@@ -1,0 +1,26 @@
+{
+    "type" : "object",
+    "properties" : {
+        "a" : {
+            "type": "object",
+            "x-existingJavaType" : "java.util.Map<String,Integer>"
+        },
+        "b" : {
+            "type" : "object",
+            "x-existingJavaType" : "java.util.Map<java.util.Map<String,Integer>, java.util.List<java.util.List<Boolean>>>"
+        },
+        "c" : {
+            "type" : "object",
+            "x-existingJavaType" : "java.util.Map<String, String[][]>"
+        },
+        "d" : {
+            "x-existingJavaType" : "java.util.Map<String,Double>"
+        },
+        "e" : {
+            "x-existingJavaType" : "java.util.Map<String,?>"
+        },
+        "f" : {
+            "x-existingJavaType" : "java.util.Map<String,? extends Number>"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/type/x-types.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/type/x-types.json
@@ -1,0 +1,98 @@
+{
+    "type" : "object",
+    "properties" : {
+        "booleanProperty" : {
+            "type" : "boolean"
+        },
+        "stringProperty" : {
+            "type" : "string"
+        },
+        "integerProperty" : {
+            "type" : "integer"
+        },
+        "numberProperty" : {
+            "type" : "number"
+        },
+        "arrayProperty" : {
+            "type" : "array"
+        },
+        "nullProperty" : {
+            "type" : "null"
+        },
+        "anyProperty" : {
+            "type" : "any"
+        },
+        "objectProperty" : {
+            "type" : "object",
+            "properties" : {
+                "property" : {
+                    "type" : "string"
+                }
+            }
+        },
+        "defaultProperty" : {
+        },
+        "impliedObjectProperty" : {
+            "properties" : {
+                "property" : {
+                    "type" : "string"
+                }
+            }
+        },
+        "unknownProperty" : {
+            "type" : "some-unknown-type"
+        },
+        "reusedClasspathType" : {
+            "type" : "object",
+            "x-existingJavaType" : "java.util.Locale"
+        },
+        "reusedGeneratedType" : {
+            "type" : "object",
+            "x-javaType" : "com.example.ObjectProperty"
+        },
+        "primitiveJavaType" : {
+            "type" : "object",
+            "x-existingJavaType" : "long"
+        },
+        "integerWithJavaType" : {
+          "type" : "integer",
+          "x-existingJavaType" : "java.math.BigDecimal"
+        },
+        "numberWithJavaType" : {
+          "type" : "number",
+          "x-existingJavaType" : "java.util.UUID"
+        },
+        "stringWithJavaType" : {
+          "type" : "string",
+          "x-existingJavaType" : "java.lang.Boolean"
+        },
+        "booleanWithJavaType" : {
+          "type" : "boolean",
+          "x-existingJavaType" : "long"
+        },
+        "dateWithJavaType" : {
+          "type" : "string",
+          "format" : "date-time",
+          "x-existingJavaType" : "int"
+        },
+        "typeWithInterfaces" : {
+            "type" : "object",
+            "x-javaInterfaces" : ["java.io.Serializable", "Cloneable"]
+        },
+        "typeWithGenericInterface" : {
+            "type" : "object",
+            "x-javaInterfaces" : ["org.jsonschema2pojo.integration.TypeIT.InterfaceWithGenerics<String,Integer,Boolean>"]
+        },
+        "typeWithInheritedClass" : {
+            "type" : "object",
+            "x-extendsJavaClass" : "org.jsonschema2pojo.integration.TypeIT.InheritedClass"
+        },
+        "typeWithInheritedClassWithGenerics" : {
+            "type" : "object",
+            "x-extendsJavaClass" : "org.jsonschema2pojo.integration.TypeIT.InheritedClassWithGenerics<String,Integer,Boolean>"
+        },
+        "nullableStringProperty" : {
+          "type" : ["null", "string"]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/views/x-views.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/views/x-views.json
@@ -1,0 +1,12 @@
+{
+    "type" : "object",
+    "properties" : {
+        "notInView": {
+            "type": "string"
+        },
+        "inView": {
+            "type": "string",
+            "x-javaJsonView": "com.example.MyJsonViewClass"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/a.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/a.json
@@ -1,0 +1,3 @@
+{
+    "type" : "object"
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/b.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/b.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "parentProperty": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/c.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/c.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "properties": {
+        "duplicatedProp": {
+            "type": "string"
+        },
+        "cProp": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/extendsEmbeddedSchema.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/extendsEmbeddedSchema.json
@@ -1,0 +1,16 @@
+{
+    "type" : "object",
+    "properties" : {
+        "propertyOfChild" : {
+            "type" : "string"
+        }
+    },
+    "x-extends" : {
+        "type" : "object",
+        "properties" : {
+            "propertyOfParent" : {
+                "type" : "string"
+            }
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/extendsSchemaWithinDefinitions.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/extendsSchemaWithinDefinitions.json
@@ -1,0 +1,25 @@
+{
+  "definitions": {
+    "parent": {
+      "type": "object",
+      "properties": {
+        "propertyOfParent": {
+          "type": "string"
+        }
+      }
+    },
+    "child": {
+      "type": "object",
+      "x-extends": {"$ref": "#/definitions/parent"},
+      "properties": {
+        "propertyOfChild": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "child": {"$ref": "#/definitions/child"}
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/extendsString.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/extendsString.json
@@ -1,0 +1,6 @@
+{
+    "type" : "object",
+    "x-extends" : {
+        "type" : "string"
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfA.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfA.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "a.json"
+    },
+    "properties": {
+        "parent": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfB.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfB.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "b.json"
+    },
+    "properties": {
+        "childProperty": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfBWithNoProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfBWithNoProperties.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "b.json"
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfC.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfC.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "c.json"
+    },
+    "properties": {
+        "duplicatedProp": {
+            "type": "string"
+        },
+        "cSubtypeProp": {
+            "type": "boolean"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfA.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfA.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "subtypeOfA.json"
+    },
+    "properties": {
+        "parent" : {
+            "type": "string"
+        },
+        "child": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfB.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfB.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "subtypeOfB.json"
+    },
+    "properties": {
+        "childChildProperty": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfBDifferentType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfBDifferentType.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "subtypeOfB.json"
+    },
+    "properties": {
+        "childChildProperty": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfC.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-extends/subtypeOfSubtypeOfC.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "x-extends": {
+        "$ref": "subtypeOfC.json"
+    },
+    "properties": {
+        "duplicatedProp": {
+            "type": "string"
+        },
+        "cSubtypeSubtypeProp": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/AuthorizeRequest_v1p0.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/AuthorizeRequest_v1p0.json
@@ -1,0 +1,133 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "urn:OCPP:Cp:2:2018:4:AuthorizeRequest",
+  "comment": "OCPP 2.0 - v1p0",
+  "definitions": {
+    "HashAlgorithmEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "SHA256",
+        "SHA384",
+        "SHA512"
+      ]
+    },
+    "IdTokenEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "Central",
+        "eMAID",
+        "ISO14443",
+        "KeyCode",
+        "Local",
+        "NoAuthorization",
+        "ISO15693"
+      ]
+    },
+    "AdditionalInfoType": {
+      "x-javaType": "com.apetecan.javaname.AdditionalInfo",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalIdToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "type": "string",
+          "maxLength": 50
+        }
+      },
+      "required": [
+        "additionalIdToken",
+        "type"
+      ]
+    },
+    "IdTokenType": {
+      "x-javaType": "IdToken",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalInfo": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/AdditionalInfoType"
+          },
+          "minItems": 1
+        },
+        "idToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "$ref": "#/definitions/IdTokenEnumType"
+        }
+      },
+      "required": [
+        "idToken",
+        "type"
+      ]
+    },
+    "OCSPRequestDataType": {
+      "x-javaType": "OCSPRequestData",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "hashAlgorithm": {
+          "$ref": "#/definitions/HashAlgorithmEnumType"
+        },
+        "issuerNameHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "issuerKeyHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "serialNumber": {
+          "type": "string",
+          "maxLength": 20
+        },
+        "responderURL": {
+          "type": "string",
+          "maxLength": 512
+        }
+      },
+      "required": [
+        "hashAlgorithm",
+        "issuerNameHash",
+        "issuerKeyHash",
+        "serialNumber"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "15118CertificateHashData": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "$ref": "#/definitions/OCSPRequestDataType"
+      },
+      "minItems": 1,
+      "maxItems": 4
+    },
+    "idToken": {
+      "$ref": "#/definitions/IdTokenType"
+    },
+    "evseId": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "idToken"
+  ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/AuthorizeRequest_v1p0_2.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/AuthorizeRequest_v1p0_2.json
@@ -1,0 +1,133 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "urn:OCPP:Cp:2:2018:4:AuthorizeRequest",
+  "comment": "OCPP 2.0 - v1p0",
+  "definitions": {
+    "HashAlgorithmEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "SHA256",
+        "SHA384",
+        "SHA512"
+      ]
+    },
+    "IdTokenEnumType": {
+      "type": "string",
+      "additionalProperties": true,
+      "enum": [
+        "Central",
+        "eMAID",
+        "ISO14443",
+        "KeyCode",
+        "Local",
+        "NoAuthorization",
+        "ISO15693"
+      ]
+    },
+    "AdditionalInfoType": {
+      "x-javaType": "AdditionalInfo",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalIdToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "type": "string",
+          "maxLength": 50
+        }
+      },
+      "required": [
+        "additionalIdToken",
+        "type"
+      ]
+    },
+    "IdTokenType": {
+      "x-javaType": "com.apetecan.javaname.IdToken",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "additionalInfo": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/AdditionalInfoType"
+          },
+          "minItems": 1
+        },
+        "idToken": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "type": {
+          "$ref": "#/definitions/IdTokenEnumType"
+        }
+      },
+      "required": [
+        "idToken",
+        "type"
+      ]
+    },
+    "OCSPRequestDataType": {
+      "x-javaType": "OCSPRequestData",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "hashAlgorithm": {
+          "$ref": "#/definitions/HashAlgorithmEnumType"
+        },
+        "issuerNameHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "issuerKeyHash": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "serialNumber": {
+          "type": "string",
+          "maxLength": 20
+        },
+        "responderURL": {
+          "type": "string",
+          "maxLength": 512
+        }
+      },
+      "required": [
+        "hashAlgorithm",
+        "issuerNameHash",
+        "issuerKeyHash",
+        "serialNumber"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "15118CertificateHashData": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "$ref": "#/definitions/OCSPRequestDataType"
+      },
+      "minItems": 1,
+      "maxItems": 4
+    },
+    "idToken": {
+      "$ref": "#/definitions/IdTokenType"
+    },
+    "evseId": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "idToken"
+  ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/duplicateDefaultName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/duplicateDefaultName.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "one": {
+      "type": "string"
+    },
+    "two": {
+      "type": "string",
+      "x-javaName": "one"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/duplicateName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/duplicateName.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "one": {
+      "type": "string",
+      "x-javaName": "three"
+    },
+    "two": {
+      "type": "string",
+      "x-javaName": "three"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/javaName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/javaName.json
@@ -1,0 +1,26 @@
+{
+  "type" : "object",
+  "properties" : {
+    "propertyWithJavaName" : {
+      "x-javaName" : "javaProperty",
+      "type" : "string"
+    },
+    "propertyWithoutJavaName" : {
+      "type" : "string"
+    },
+    "enumWithJavaName" : {
+      "x-javaName" : "javaEnum",
+      "enum" : [ "a", "b" ]
+    },
+    "enumWithoutJavaName" : {
+      "enum" : [ "c", "d" ]
+    },
+    "objectWithJavaName" : {
+      "x-javaName" : "javaObject",
+      "type" : "object"
+    },
+    "objectWithoutJavaName" : {
+      "type" : "object"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/javaNameWithRequiredProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/x-javaName/javaNameWithRequiredProperties.json
@@ -1,0 +1,29 @@
+{
+  "type" : "object",
+  "required" : [ "requiredPropertyWithJavaName", "requiredPropertyWithoutJavaName" ],
+  "properties" : {
+    "notRequiredPropertyWithJavaName" : {
+      "x-javaName" : "notRequiredJavaProperty",
+      "type" : "string"
+    },
+    "notRequiredPropertyWithoutJavaName" : {
+      "type" : "string"
+    },
+    "requiredPropertyWithJavaName" : {
+      "x-javaName" : "requiredJavaProperty",
+      "type" : "string"
+    },
+    "requiredPropertyWithoutJavaName" : {
+      "type" : "string"
+    },
+    "inlineRequiredPropertyWithJavaName" : {
+      "x-javaName" : "inlineRequiredJavaProperty",
+      "type" : "string",
+      "required" : true
+    },
+    "inlineRequiredPropertyWithoutJavaName" : {
+      "type" : "string",
+      "required" : true
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/yaml/type/x-types.yaml
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/yaml/type/x-types.yaml
@@ -1,0 +1,72 @@
+properties:
+  anyProperty:
+    type: any
+  arrayProperty:
+    type: array
+  booleanProperty:
+    type: boolean
+  booleanWithJavaType:
+    x-existingJavaType: long
+    type: boolean
+  dateWithJavaType:
+    format: date-time
+    x-existingJavaType: int
+    type: string
+  defaultProperty: {}
+  impliedObjectProperty:
+    properties:
+      property:
+        type: string
+  integerProperty:
+    type: integer
+  integerWithJavaType:
+    x-existingJavaType: java.math.BigDecimal
+    type: integer
+  nullProperty:
+    type: 'null'
+  nullableStringProperty:
+    type:
+    - 'null'
+    - string
+  numberProperty:
+    type: number
+  numberWithJavaType:
+    x-existingJavaType: java.util.UUID
+    type: number
+  objectProperty:
+    properties:
+      property:
+        type: string
+    type: object
+  primitiveJavaType:
+    x-existingJavaType: long
+    type: object
+  reusedClasspathType:
+    x-existingJavaType: java.util.Locale
+    type: object
+  reusedGeneratedType:
+    x-javaType: com.example.ObjectProperty
+    type: object
+  stringProperty:
+    type: string
+  stringWithJavaType:
+    x-existingJavaType: java.lang.Boolean
+    type: string
+  typeWithGenericInterface:
+    x-javaInterfaces:
+    - org.jsonschema2pojo.integration.yaml.YamlTypeIT.InterfaceWithGenerics<String,Integer,Boolean>
+    type: object
+  typeWithInheritedClass:
+    x-extendsJavaClass: org.jsonschema2pojo.integration.yaml.YamlTypeIT.InheritedClass
+    type: object
+  typeWithInheritedClassWithGenerics:
+    x-extendsJavaClass: org.jsonschema2pojo.integration.yaml.YamlTypeIT.InheritedClassWithGenerics<String,Integer,Boolean>
+    type: object
+  typeWithInterfaces:
+    x-javaInterfaces:
+    - java.io.Serializable
+    - Cloneable
+    type: object
+  unknownProperty:
+    type: some-unknown-type
+type: object


### PR DESCRIPTION
Extensions to the json-schema specification, like the "javaType" keyword property, can trip up json schema validator tools that don't recognize the keywords and thus report errors. By convention, though, validator tools will ignore any keywords prefixed with "x-". Thus, any keyword extension to the specification should really be a keyword that begins with "x-".

In order to support "x-" prefixed versions of existing keyword extensions, while maintaining backward compatibility, the following change are made:

Change all references to node properties that are extensions to the specification such that they use helper methods (`ExtensionsHelper.java`) that will work on both the original extension name (e.g. "javaType") and also that name prefixed with 'x-' (e.g. `x-javaType`). The following keywords are affected:

- `extends`, `javaType`, `existingJavaType`, `extendsJavaClass`, `javaInterfaces`, `javaEnumNames`, `javaEnums`, `javaJsonView`, `javaName`, `customPattern`, `customTimezone`, `customDatePattern`, `customTimePattern`, `customDateTimePattern`, `excludedFromEqualsAndHashCode`

Update all message text references to any of the above to use "x-".

Duplicate existing test schema files & directories that exercise the above keywords and either duplicate the unit tests that use them (to use the new schemas) or parameterize the test suites that use them to operate on both the original test schema and the new "x-" variant.

Further test update details:

Due to a mix of tests in TypeIT.java, break out the tests from TypeIT.java that didn't use the common schema with many types to a separate test class, TypeMiscIT.java. (and the same for YamlTypeIT.java). This allowed parameterizing TypeIT.java without running some tests twice on the same input.

Update some other test schemas that use extension keywords (but don't explicitly validate them) to use the new "x-" variant as this should be the preferred variant for reasons stated above.

While here, add test variants of each of the above 'custom*Patterns' that use the x-customPattern alias (no tests had existed for the 'customPattern' alias)