### PR TITLE
Update license plugin to fix corrupted character before copyright symbol

### DIFF
--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package org.jsonschema2pojo.integration;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;

--- a/license-plugin-definition.xml
+++ b/license-plugin-definition.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<additionalHeaders>
+	<java_style>
+		<firstLine>/**</firstLine>
+		<beforeEachLine> * </beforeEachLine>
+		<endLine> */EOL</endLine>
+		<afterEachLine> </afterEachLine>
+		<firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
+		<lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>
+		<allowBlankLines>false</allowBlankLines>
+		<isMultiline>true</isMultiline>
+		<padLines>false</padLines>
+	</java_style>
+</additionalHeaders>

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
                             <pluginExecutions>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
-                                        <groupId>com.mycila.maven-license-plugin</groupId>
-                                        <artifactId>maven-license-plugin</artifactId>
+                                        <groupId>com.mycila</groupId>
+                                        <artifactId>license-maven-plugin</artifactId>
                                         <versionRange>[0.0,)</versionRange>
                                         <goals>
                                              <goal>format</goal>
@@ -131,9 +131,9 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
-                <version>1.8.0</version>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>3.0</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <encoding>UTF-8</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -142,10 +142,16 @@
                     </excludes>
                     <failIfMissing>true</failIfMissing>
                     <header>NOTICE</header>
+                    <headerDefinitions>
+                        <headerDefinition>license-plugin-definition.xml</headerDefinition>
+                    </headerDefinitions>
                     <includes>
                         <include>**/src/main/java/**</include>
                         <include>**/src/test/java/**</include>
                     </includes>
+                    <mapping>
+                        <java>JAVA_STYLE</java>
+                    </mapping>
                     <skipExistingHeaders>false</skipExistingHeaders>
                     <strictCheck>true</strictCheck>
                 </configuration>


### PR DESCRIPTION
This problem happens on windows and usually I have to revert the corrupted character out of copyright notice before committing.