### PR TITLE
Fix raw type warnings when extending a builder

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.StreamSupport;
-import org.apache.commons.collections15.CollectionUtils;
+
 import org.jsonschema2pojo.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -213,7 +213,7 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
     }
 
     private String getBuilderClassName(JDefinedClass c) {
-        return ruleFactory.getNameHelper().getBuilderClassName(c);
+        return ruleFactory.getNameHelper().getBaseBuilderClassName(c);
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -48,24 +48,33 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
   public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass instanceClass, Schema currentSchema) {
 
     // Create the inner class for the builder
+    JDefinedClass concreteBuilderClass;
     JDefinedClass builderClass;
 
     try {
-      String builderName = ruleFactory.getNameHelper().getBuilderClassName(instanceClass);
-      builderClass = instanceClass._class(JMod.PUBLIC + JMod.STATIC, builderName);
+
+      String concreteBuilderClassName = ruleFactory.getNameHelper().getBuilderClassName(instanceClass);
+      String builderClassName = ruleFactory.getNameHelper().getBaseBuilderClassName(instanceClass);
+
+      builderClass = instanceClass._class(JMod.ABSTRACT + JMod.PUBLIC + JMod.STATIC, builderClassName);
+
+      concreteBuilderClass = instanceClass._class(JMod.PUBLIC + JMod.STATIC, concreteBuilderClassName);
+      concreteBuilderClass._extends(builderClass.narrow(instanceClass));
+
     } catch (JClassAlreadyExistsException e) {
       return e.getExistingClass();
     }
 
-    // Determine which builder (if any) this builder should inherit from
+    // Determine which base builder (if any) this builder should inherit from
     JClass parentBuilderClass = null;
     JClass parentClass = instanceClass._extends();
     if (!(parentClass.isPrimitive() || reflectionHelper.isFinal(parentClass) || Objects.equals(parentClass.fullName(), "java.lang.Object"))) {
-      parentBuilderClass = reflectionHelper.getBuilderClass(parentClass);
+      parentBuilderClass = reflectionHelper.getBaseBuilderClass(parentClass);
     }
 
-    // Determine the generic type 'T' that the builder will create instances of
-    JTypeVar instanceType = builderClass.generify("T", instanceClass);
+    // Determine the generic type name and that the builder will create instances of
+    String builderTypeParameterName = ruleFactory.getNameHelper().getBuilderTypeParameterName(instanceClass);
+    JTypeVar instanceType = builderClass.generify(builderTypeParameterName, instanceClass);
 
     // For new builders we need to create an instance variable and 'build' method
     // for inheriting builders we'll receive these from the superType
@@ -83,31 +92,50 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
       body.assign(JExpr._this().ref(instanceField), JExpr._null());
       body._return(result);
 
-      // Create the noargs builder constructor
-      generateNoArgsBuilderConstructor(instanceClass, builderClass);
+      // Create the noargs builder constructors
+      generateNoArgsBuilderConstructors(instanceClass, builderClass, concreteBuilderClass);
     } else {
       // Declare the inheritance
-      builderClass._extends(parentBuilderClass);
-      
+      builderClass._extends(parentBuilderClass.narrow(parentBuilderClass.owner().ref(builderTypeParameterName)));
+
       JMethod buildMethod = builderClass.method(JMod.PUBLIC, instanceType, "build");
       buildMethod.annotate(Override.class);
 
       JBlock body = buildMethod.body();
-      body._return(JExpr.cast(instanceType, JExpr._super().invoke("build")));
+      body._return(JExpr._super().invoke("build"));
 
-      // Create the noargs builder constructor
-      generateNoArgsBuilderConstructor(instanceClass, builderClass);
+      // Create the noargs builder constructors
+      generateNoArgsBuilderConstructors(instanceClass, builderClass, concreteBuilderClass);
     }
 
     return builderClass;
   }
 
-  private void generateNoArgsBuilderConstructor(JDefinedClass instanceClass, JDefinedClass builderClass) {
-    JMethod noargsConstructor = builderClass.constructor(JMod.PUBLIC);
-    JAnnotationUse warningSuppression = noargsConstructor.annotate(SuppressWarnings.class);
+  private void generateNoArgsBuilderConstructors(JDefinedClass instanceClass, JDefinedClass baseBuilderClass, JDefinedClass builderClass) {
+
+    generateNoArgsBaseBuilderConstructor(instanceClass, baseBuilderClass, builderClass);
+    generateNoArgsBuilderConstructor(instanceClass, baseBuilderClass, builderClass);
+  }
+
+  private void generateNoArgsBuilderConstructor(JDefinedClass instanceClass, JDefinedClass baseBuilderClass, JDefinedClass builderClass) {
+
+    // Add the constructor to builder.
+    JMethod noArgsConstructor = builderClass.constructor(JMod.PUBLIC);
+    JBlock constructorBlock = noArgsConstructor.body();
+
+    // Determine if we need to invoke the super() method for our parent builder
+    if (!(baseBuilderClass.isPrimitive() || reflectionHelper.isFinal(baseBuilderClass) || Objects.equals(baseBuilderClass.fullName(), "java.lang.Object"))) {
+      constructorBlock.invoke("super");
+    }
+  }
+
+  private void generateNoArgsBaseBuilderConstructor(JDefinedClass instanceClass, JDefinedClass builderClass, JDefinedClass concreteBuilderClass) {
+
+    JMethod noArgsConstructor = builderClass.constructor(JMod.PUBLIC);
+    JAnnotationUse warningSuppression = noArgsConstructor.annotate(SuppressWarnings.class);
     warningSuppression.param("value", "unchecked");
 
-    JBlock constructorBlock = noargsConstructor.body();
+    JBlock constructorBlock = noArgsConstructor.body();
 
     JFieldVar instanceField = reflectionHelper.searchClassAndSuperClassesForField("instance", builderClass);
 
@@ -120,9 +148,8 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
     // Only initialize the instance if the object being constructed is actually this class
     // if it's a subtype then ignore the instance initialization since the subclass will initialize it
     constructorBlock.directStatement("// Skip initialization when called from subclass");
-    JInvocation comparison = JExpr._this().invoke("getClass").invoke("equals").arg(JExpr.dotclass(builderClass));
+    JInvocation comparison = JExpr._this().invoke("getClass").invoke("equals").arg(JExpr.dotclass(concreteBuilderClass));
     JConditional ifNotSubclass = constructorBlock._if(comparison);
     ifNotSubclass._then().assign(JExpr._this().ref(instanceField), JExpr.cast(instanceField.type(), JExpr._new(instanceClass)));
   }
-
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -262,7 +262,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
   }
 
   private JMethod addInnerBuilderMethod(JDefinedClass c, JFieldVar field, String jsonPropertyName, JsonNode node)    {
-    JDefinedClass builderClass = ruleFactory.getReflectionHelper().getBuilderClass(c);
+    JDefinedClass builderClass = ruleFactory.getReflectionHelper().getBaseBuilderClass(c);
 
     JMethod builderMethod = builderClass.method(JMod.PUBLIC, builderClass, getBuilderName(jsonPropertyName, node));
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -42,6 +42,10 @@ public class NameHelper {
         this.generationConfig = generationConfig;
     }
 
+    public String getBuilderTypeParameterName(JDefinedClass instanceClass) {
+        return "T";
+    }
+
     public String replaceIllegalCharacters(String name) {
         return name.replaceAll(ILLEGAL_CHARACTER_REGEX, "_");
     }
@@ -220,8 +224,20 @@ public class NameHelper {
         return jsonPropertyName;
     }
 
-    public String getBuilderClassName(JClass outterClass) {
-        return outterClass.name() + "Builder";
+    public String getBaseBuilderClassName(JClass outerClass) {
+        return outerClass.name() + getBuilderClassNameSuffix(outerClass) + getBaseBuilderClassNameSuffix(outerClass);
+    }
+
+    public String getBaseBuilderClassNameSuffix(JClass outerClass) {
+        return "Base";
+    }
+
+    public String getBuilderClassName(JClass outerClass) {
+        return outerClass.name() + getBuilderClassNameSuffix(outerClass);
+    }
+
+    public String getBuilderClassNameSuffix(JClass outerClass) {
+        return "Builder";
     }
 
     public String getUniqueClassName(String nodeName, JsonNode node, JPackage _package) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ReflectionHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/ReflectionHelper.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.StreamSupport;
@@ -90,15 +91,28 @@ public class ReflectionHelper {
     return searchClassAndSuperClassesForField(property, definedSuperClass);
   }
 
-  public JDefinedClass getBuilderClass(JDefinedClass target) {
+  public JDefinedClass getConcreteBuilderClass(JDefinedClass instanceClass) {
+    String builderClassname = ruleFactory.getNameHelper().getBuilderClassName(instanceClass);
+
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(instanceClass.classes(), Spliterator.ORDERED), false)
+            .filter(definedClass -> definedClass.name().equals(builderClassname)).findFirst().orElse(null);
+  }
+
+  public JDefinedClass getConcreteBuilderClass(JClass target) {
     String builderClassname = ruleFactory.getNameHelper().getBuilderClassName(target);
+    return getAllPackageClasses(target._package()).stream().filter(definedClass -> definedClass.name().equals(builderClassname)).findFirst()
+            .orElse(null);
+  }
+
+  public JDefinedClass getBaseBuilderClass(JDefinedClass target) {
+    String builderClassname = ruleFactory.getNameHelper().getBaseBuilderClassName(target);
 
     return StreamSupport.stream(Spliterators.spliteratorUnknownSize(target.classes(), Spliterator.ORDERED), false)
         .filter(definedClass -> definedClass.name().equals(builderClassname)).findFirst().orElse(null);
   }
 
-  public JDefinedClass getBuilderClass(JClass target) {
-    String builderClassname = ruleFactory.getNameHelper().getBuilderClassName(target);
+  public JDefinedClass getBaseBuilderClass(JClass target) {
+    String builderClassname = ruleFactory.getNameHelper().getBaseBuilderClassName(target);
     return getAllPackageClasses(target._package()).stream().filter(definedClass -> definedClass.name().equals(builderClassname)).findFirst()
         .orElse(null);
   }
@@ -127,7 +141,20 @@ public class ReflectionHelper {
     }
     JClass fieldClass = type.boxify();
     JPackage jPackage = fieldClass._package();
-    return this._getClass(fieldClass.name(), jPackage);
+    try
+    {
+      return this._getClass(fieldClass.name(), jPackage);
+    } catch (NoClassDefFoundError error) {
+      String name = fieldClass.name();
+      String erasureName = fieldClass.erasure().name();
+
+      if(!Objects.equals(name, erasureName)) {
+        ruleFactory.getLogger().debug("Could not get class for type with name: " + name + " trying " + erasureName + " instead.");
+        return this._getClass(erasureName, jPackage);
+      } else {
+        throw error;
+      }
+    }
   }
 
   private JDefinedClass _getClass(String name, JPackage _package) {


### PR DESCRIPTION
Existing inner class builders did not define a type so they could be inherited but whenever you use the builder you would get a IDE/code scanner warning about using a raw type.

This makes the existing builder abstract and adds Base to the end.  All classes extending this class would inherit from this "Base" builder.

A concrete builder is created which extends the "Base" builder and resolves the generic type.