### PR TITLE
Add configuration map (customRuleFactoryConfiguration) for Custom Rule Factories

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -114,6 +114,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private Class<? extends RuleFactory> customRuleFactory = RuleFactory.class;
 
+    private Map<String, String> customRuleFactoryConfiguration = new HashMap<>();
+
     private boolean includeJsr303Annotations = false;
 
     private boolean includeJsr305Annotations = false;
@@ -577,6 +579,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
         } else {
             this.customRuleFactory = RuleFactory.class;
         }
+    }
+
+    public void setCustomRuleFactoryConfiguration(Map<String, String> formatTypeMapping) {
+        this.formatTypeMapping = formatTypeMapping;
     }
 
     /**
@@ -1070,6 +1076,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public Class<? extends RuleFactory> getCustomRuleFactory() {
         return customRuleFactory;
+    }
+
+    @Override
+    public Map<String, String> getCustomRuleFactoryConfiguration() {
+        return customRuleFactoryConfiguration;
     }
 
     @Override

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -131,6 +131,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-F", "--custom-rule-factory" }, description = "The fully qualified class name of referring to a custom rule factory class that extends org.jsonschema2pojo.rules.RuleFactory " + "to create custom rules for code generation.", converter = ClassConverter.class)
     private Class<? extends RuleFactory> customRuleFactory = RuleFactory.class;
 
+    @Parameter(names = { "-crfc", "--custom-rule-factory-configuration" }, description = "Custom configuration for Custom Rule Factory: <parameter>:<value>.", variableArity = true)
+    private List<String> customRuleFactoryConfiguration = new ArrayList<>();
+
     @Parameter(names = { "-303", "--jsr303-annotations" }, description = "Add JSR-303/349 annotations to generated Java types.")
     private boolean includeJsr303Annotations = false;
 
@@ -381,6 +384,13 @@ public class Arguments implements GenerationConfig {
     @Override
     public Class<? extends RuleFactory> getCustomRuleFactory() {
         return customRuleFactory;
+    }
+
+    @Override
+    public Map<String, String> getCustomRuleFactoryConfiguration() {
+        return customRuleFactoryConfiguration
+                .stream()
+                .collect(Collectors.toMap(m -> m.split(":")[0], m -> m.split(":")[1]));
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -165,6 +165,11 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return RuleFactory.class;
     }
 
+    @Override
+    public Map<String, String> getCustomRuleFactoryConfiguration() {
+        return Collections.emptyMap();
+    }
+
     /**
      * @return <code>false</code>
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -232,6 +232,12 @@ public interface GenerationConfig {
   Class<? extends RuleFactory> getCustomRuleFactory();
 
   /**
+   * Gets the 'customRuleFactoryConfiguration' configuration option.
+   * @return A map of custom properties to be used in custom rule factory.
+   */
+  Map<String, String> getCustomRuleFactoryConfiguration();
+
+  /**
    * Gets the 'includeJsr303Annotations' configuration option.
    *
    * @return Whether to include

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AbstractRuleFactoryRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AbstractRuleFactoryRule.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import org.jsonschema2pojo.GenerationConfig;
+
+public abstract class AbstractRuleFactoryRule<T, R>
+		implements Rule<T, R>
+{
+	protected final RuleFactory ruleFactory;
+
+	public AbstractRuleFactoryRule(RuleFactory ruleFactory) {
+		this.ruleFactory = ruleFactory;
+	}
+
+	public GenerationConfig getGenerationConfig() {
+		if (ruleFactory == null) {
+			throw new RuntimeException("Rule does not have rule factory; unable to get generation config.");
+		}
+
+		return ruleFactory.getGenerationConfig();
+	}
+
+	public RuleFactory getRuleFactory() {
+		return ruleFactory;
+	}
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -45,12 +45,10 @@ import com.sun.codemodel.JVar;
  *      "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.6">http:/
  *      /tools.ietf.org/html/draft-zyp-json-schema-03#section-5.6</a>
  */
-public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
-
-    private final RuleFactory ruleFactory;
+public class AdditionalPropertiesRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
     protected AdditionalPropertiesRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
@@ -34,12 +34,10 @@ import com.sun.codemodel.JType;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.15">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.15</a>
  */
-public class ArrayRule implements Rule<JPackage, JClass> {
-
-    private final RuleFactory ruleFactory;
+public class ArrayRule extends AbstractRuleFactoryRule<JPackage, JClass> {
 
     protected ArrayRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -34,13 +34,12 @@ import java.util.Objects;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.ReflectionHelper;
 
-public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
+public class BuilderRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
-  private RuleFactory ruleFactory;
   private ReflectionHelper reflectionHelper;
 
   BuilderRule(RuleFactory ruleFactory, ReflectionHelper reflectionHelper) {
-    this.ruleFactory = ruleFactory;
+    super(ruleFactory);
     this.reflectionHelper = reflectionHelper;
   }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -46,13 +46,12 @@ import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
 import org.jsonschema2pojo.util.ReflectionHelper;
 
-public class ConstructorRule implements Rule<JDefinedClass, JDefinedClass> {
+public class ConstructorRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
-  private final RuleFactory ruleFactory;
   private final ReflectionHelper reflectionHelper;
 
   ConstructorRule(RuleFactory ruleFactory, ReflectionHelper reflectionHelper) {
-    this.ruleFactory = ruleFactory;
+    super(ruleFactory);
     this.reflectionHelper = reflectionHelper;
   }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
@@ -53,12 +53,10 @@ import scala.annotation.meta.field;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.20">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.20</a>
  */
-public class DefaultRule implements Rule<JFieldVar, JFieldVar> {
-
-    private final RuleFactory ruleFactory;
+public class DefaultRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
 
     public DefaultRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DescriptionRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DescriptionRule.java
@@ -28,9 +28,18 @@ import com.sun.codemodel.JDocCommentable;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.22">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.22</a>
  */
-public class DescriptionRule implements Rule<JDocCommentable, JDocComment> {
+public class DescriptionRule extends AbstractRuleFactoryRule<JDocCommentable, JDocComment> {
 
+    /**
+     * @deprecated Please switch to {@link DescriptionRule(RuleFactory)}
+     */
+    @Deprecated
     protected DescriptionRule() {
+        super(null);
+    }
+
+    protected DescriptionRule(RuleFactory ruleFactory) {
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
@@ -23,12 +23,10 @@ import org.jsonschema2pojo.Schema;
 
 import javax.validation.constraints.Digits;
 
-public class DigitsRule implements Rule<JFieldVar, JFieldVar> {
-
-    private final RuleFactory ruleFactory;
+public class DigitsRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
 
     protected DigitsRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DynamicPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DynamicPropertiesRule.java
@@ -47,7 +47,7 @@ import com.sun.codemodel.JVar;
  * @author Christian Trimble
  *
  */
-public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
+public class DynamicPropertiesRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
     public static final String NOT_FOUND_VALUE_FIELD = "NOT_FOUND_VALUE";
     public static final String SETTER_NAME = "set";
@@ -56,10 +56,8 @@ public class DynamicPropertiesRule implements Rule<JDefinedClass, JDefinedClass>
     public static final String DEFINED_SETTER_NAME = "declaredProperty";
     public static final String DEFINED_GETTER_NAME = "declaredPropertyOrNotFound";
 
-    private RuleFactory ruleFactory;
-
     public DynamicPropertiesRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+       super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -69,14 +69,12 @@ import static org.jsonschema2pojo.util.TypeUtil.resolveType;
  *      "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.19">http:
  *      //tools.ietf.org/html/draft-zyp-json-schema-03#section-5.19</a>
  */
-public class EnumRule implements Rule<JClassContainer, JType> {
+public class EnumRule extends AbstractRuleFactoryRule<JClassContainer, JType> {
 
     private static final String VALUE_FIELD_NAME = "value";
 
-    private final RuleFactory ruleFactory;
-
     protected EnumRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**
@@ -113,7 +111,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
         try {
             _enum = createEnum(node, nodeName, container);
         } catch (ClassAlreadyExistsException e) {
-            ruleFactory.getLogger().error("Could not create enum.", e);
+            ruleFactory.getLogger().error("Could not create enum " + nodeName, e);
             return e.getExistingClass();
         }
 
@@ -337,6 +335,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
 
                 try {
                     Class<?> existingClass = Thread.currentThread().getContextClassLoader().loadClass(fqn);
+                    ruleFactory.getLogger().error("Enum " + existingClass.getCanonicalName() + " already existed.");
                     throw new ClassAlreadyExistsException(container.owner().ref(existingClass));
                 } catch (ClassNotFoundException e) {
                     return container.owner()._class(fqn, ClassType.ENUM);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/FormatRule.java
@@ -43,17 +43,16 @@ import com.sun.codemodel.JType;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.23">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.23</a>
  */
-public class FormatRule implements Rule<JType, JType> {
+public class FormatRule extends AbstractRuleFactoryRule<JType, JType> {
 
     public static String ISO_8601_DATE_FORMAT = "yyyy-MM-dd";
     public static String ISO_8601_TIME_FORMAT = "HH:mm:ss.SSS";
     public static String ISO_8601_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
-    private final RuleFactory ruleFactory;
     private final Map<String, Class<?>> formatTypeMapping;
 
     protected FormatRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
         this.formatTypeMapping = getFormatTypeMapping(ruleFactory.getGenerationConfig());
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/JavaNameRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/JavaNameRule.java
@@ -22,7 +22,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JDocComment;
 import com.sun.codemodel.JDocCommentable;
 
-public class JavaNameRule implements Rule<JDocCommentable, JDocComment> {
+public class JavaNameRule extends AbstractRuleFactoryRule<JDocCommentable, JDocComment> {
+
+    /**
+     * @deprecated Please switch to {@link JavaNameRule(RuleFactory)}
+     */
+    public JavaNameRule() {
+        super(null);
+    }
+
+    public JavaNameRule(RuleFactory ruleFactory)
+    {
+        super(ruleFactory);
+    }
 
     @Override
     public JDocComment apply(String nodeName, JsonNode node, JsonNode parent, JDocCommentable generatableType, Schema currentSchema) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MediaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MediaRule.java
@@ -32,18 +32,30 @@ import com.sun.codemodel.JType;
  * @author Christian Trimble
  * @since 0.4.2
  */
-public class MediaRule implements Rule<JType, JType> {
+public class MediaRule extends AbstractRuleFactoryRule<JType, JType> {
 
     private static final String BINARY_ENCODING = "binaryEncoding";
 
     /**
-     * <p>
-     * Constructs a new media rule.
+     * Constructs a new media rule with a reference to rule factory.
      * </p>
      *
      * @since 0.4.2
+     * @deprecated Please switch to {@link MediaRule(RuleFactory)}
      */
-    protected MediaRule() {
+    public MediaRule() {
+        super(null);
+    }
+
+    /**
+     * <p>
+     * Constructs a new media rule with a reference to rule factory.
+     * </p>
+     *
+     * @since 1.0.3
+     */
+    protected MediaRule(RuleFactory ruleFactory) {
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRule.java
@@ -27,12 +27,10 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Map;
 
-public class MinItemsMaxItemsRule implements Rule<JFieldVar, JFieldVar> {
-
-    private final RuleFactory ruleFactory;
+public class MinItemsMaxItemsRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
 
     protected MinItemsMaxItemsRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRule.java
@@ -27,12 +27,10 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Map;
 
-public class MinLengthMaxLengthRule implements Rule<JFieldVar, JFieldVar> {
-    
-    private final RuleFactory ruleFactory;
-    
+public class MinLengthMaxLengthRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
+
     protected MinLengthMaxLengthRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
     
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinimumMaximumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinimumMaximumRule.java
@@ -24,12 +24,10 @@ import org.jsonschema2pojo.Schema;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JFieldVar;
 
-public class MinimumMaximumRule implements Rule<JFieldVar, JFieldVar> {
-
-    private final RuleFactory ruleFactory;
+public class MinimumMaximumRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
 
     protected MinimumMaximumRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NotRequiredRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/NotRequiredRule.java
@@ -32,17 +32,15 @@ import com.sun.codemodel.JFieldVar;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.7">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.7</a>
  */
-public class NotRequiredRule implements Rule<JDocCommentable, JDocCommentable> {
+public class NotRequiredRule extends AbstractRuleFactoryRule<JDocCommentable, JDocCommentable> {
 
     /**
      * Text added to JavaDoc to indicate that a field is not required
      */
     public static final String NOT_REQUIRED_COMMENT_TEXT = "\n(Can be null)";
 
-    private final RuleFactory ruleFactory;
-
     protected NotRequiredRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -62,14 +62,13 @@ import org.jsonschema2pojo.util.SerializableHelper;
  *      "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1">http:/
  *      /tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1</a>
  */
-public class ObjectRule implements Rule<JPackage, JType> {
+public class ObjectRule extends AbstractRuleFactoryRule<JPackage, JType> {
 
-    private final RuleFactory ruleFactory;
     private final ReflectionHelper reflectionHelper;
     private final ParcelableHelper parcelableHelper;
 
     protected ObjectRule(RuleFactory ruleFactory, ParcelableHelper parcelableHelper, ReflectionHelper reflectionHelper) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
         this.parcelableHelper = parcelableHelper;
         this.reflectionHelper = reflectionHelper;
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PatternRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PatternRule.java
@@ -23,12 +23,10 @@ import org.jsonschema2pojo.Schema;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JFieldVar;
 
-public class PatternRule implements Rule<JFieldVar, JFieldVar> {
-
-    private RuleFactory ruleFactory;
+public class PatternRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
 
     public PatternRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertiesRule.java
@@ -35,12 +35,10 @@ import com.sun.codemodel.JVar;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2</a>
  */
-public class PropertiesRule implements Rule<JDefinedClass, JDefinedClass> {
-
-    private final RuleFactory ruleFactory;
+public class PropertiesRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
     protected PropertiesRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -37,12 +37,10 @@ import org.jsonschema2pojo.Schema;
  * "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2">http:/
  * /tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2</a>
  */
-public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
-
-    private final RuleFactory ruleFactory;
+public class PropertyRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
     protected PropertyRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
@@ -39,14 +39,12 @@ import com.sun.codemodel.JType;
  * @see <a
  * href="http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3">http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3</a>
  */
-public class RequiredArrayRule implements Rule<JDefinedClass, JDefinedClass> {
-
-    private final RuleFactory ruleFactory;
+public class RequiredArrayRule extends AbstractRuleFactoryRule<JDefinedClass, JDefinedClass> {
 
     public static final String REQUIRED_COMMENT_TEXT = "\n(Required)";
 
     protected RequiredArrayRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredRule.java
@@ -32,12 +32,10 @@ import com.sun.codemodel.JFieldVar;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.7">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.7</a>
  */
-public class RequiredRule implements Rule<JDocCommentable, JDocCommentable> {
-
-    private final RuleFactory ruleFactory;
+public class RequiredRule extends AbstractRuleFactoryRule<JDocCommentable, JDocCommentable> {
 
     protected RequiredRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/Rule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/Rule.java
@@ -52,4 +52,5 @@ public interface Rule<T, R> {
      */
     R apply(String nodeName, JsonNode node, JsonNode parent, T generatableType, Schema currentSchema);
 
+    RuleFactory getRuleFactory();
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -95,7 +95,7 @@ public class RuleFactory {
      * @return a schema rule that can handle the "description" declaration.
      */
     public Rule<JDocCommentable, JDocComment> getDescriptionRule() {
-        return new DescriptionRule();
+        return new DescriptionRule(this);
     }
 
     /**
@@ -217,7 +217,7 @@ public class RuleFactory {
      * @return a schema rule that can handle the "title" declaration.
      */
     public Rule<JDocCommentable, JDocComment> getTitleRule() {
-        return new TitleRule();
+        return new TitleRule(this);
     }
 
     /**
@@ -414,7 +414,7 @@ public class RuleFactory {
      * @return a schema rule that can handle the "media" declaration.
      */
     public Rule<JType, JType> getMediaRule() {
-        return new MediaRule();
+        return new MediaRule(this);
     }
 
     /**
@@ -430,7 +430,7 @@ public class RuleFactory {
     }
 
     public Rule<JDocCommentable, JDocComment> getJavaNameRule() {
-        return new JavaNameRule();
+        return new JavaNameRule(this);
     }
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -35,12 +35,10 @@ import com.sun.codemodel.JType;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5</a>
  */
-public class SchemaRule implements Rule<JClassContainer, JType> {
-
-    private final RuleFactory ruleFactory;
+public class SchemaRule extends AbstractRuleFactoryRule<JClassContainer, JType> {
 
     protected SchemaRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TitleRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TitleRule.java
@@ -27,9 +27,17 @@ import com.sun.codemodel.JDocCommentable;
  * @see <a
  *      href="http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.21">http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.21</a>
  */
-public class TitleRule implements Rule<JDocCommentable, JDocComment> {
+public class TitleRule extends AbstractRuleFactoryRule<JDocCommentable, JDocComment> {
 
+    /**
+     * @deprecated Please switch to {@link TitleRule(RuleFactory)}
+     */
     protected TitleRule() {
+        super(null);
+    }
+
+    protected TitleRule(RuleFactory ruleFactory) {
+        super(ruleFactory);
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -35,14 +35,12 @@ import com.sun.codemodel.JType;
  *
  * @see <a href= "http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1">http:/ /tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1</a>
  */
-public class TypeRule implements Rule<JClassContainer, JType> {
+public class TypeRule extends AbstractRuleFactoryRule<JClassContainer, JType> {
 
   private static final String DEFAULT_TYPE_NAME = "any";
 
-  private final RuleFactory ruleFactory;
-
   protected TypeRule(RuleFactory ruleFactory) {
-    this.ruleFactory = ruleFactory;
+    super(ruleFactory);
   }
 
   /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
@@ -23,12 +23,10 @@ import org.jsonschema2pojo.Schema;
 import com.sun.codemodel.JFieldVar;
 import scala.annotation.meta.field;
 
-public class ValidRule implements Rule<JFieldVar, JFieldVar> {
-    
-    private final RuleFactory ruleFactory;
-    
+public class ValidRule extends AbstractRuleFactoryRule<JFieldVar, JFieldVar> {
+
     public ValidRule(RuleFactory ruleFactory) {
-        this.ruleFactory = ruleFactory;
+       super(ruleFactory);
     }
 
     @Override

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -44,6 +44,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   String[] fileExtensions
   Class<? extends Annotator> customAnnotator
   Class<? extends RuleFactory> customRuleFactory
+  Map<String, String> customRuleFactoryConfiguration
   boolean generateBuilders
   boolean includeJsonTypeInfoAnnotation
   boolean useInnerClassBuilders
@@ -123,6 +124,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     inclusionLevel = InclusionLevel.NON_NULL
     customAnnotator = NoopAnnotator.class
     customRuleFactory = RuleFactory.class
+    customRuleFactoryConfiguration = Collections.emptyMap()
     includeJsr303Annotations = false
     includeJsr305Annotations = false
     useOptionalForGetters = false
@@ -206,6 +208,10 @@ public class JsonSchemaExtension implements GenerationConfig {
     customRuleFactory = clazz
   }
 
+  public void setCustomRuleFactoryConfiguration(Map<String, String> map) {
+    customRuleFactoryConfiguration = map
+  }
+
   public void setSourceType(String s) {
     sourceType = SourceType.valueOf(s.toUpperCase())
   }
@@ -214,8 +220,8 @@ public class JsonSchemaExtension implements GenerationConfig {
     sourceSortOrder = SourceSortOrder.valueOf(sortOrder.toUpperCase())
   }
 
-  public void setTargetLangauge(String language) {
-    targetLangauge = Langauge.valueOf(language.toUpperCase())
+  public void setTargetLanguage(String language) {
+    targetLanguage = Language.valueOf(language.toUpperCase())
   }
 
   public void setIncludeConstructorPropertiesAnnotation(boolean enabled) {
@@ -248,6 +254,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |inclusionLevel = ${InclusionLevel.toString() }
        |customAnnotator = ${customAnnotator.getName()}
        |customRuleFactory = ${customRuleFactory.getName()}
+       |customRuleFactoryConfiguration = ${customRuleFactoryConfiguration}
        |includeJsr303Annotations = ${includeJsr303Annotations}
        |includeJsr305Annotations = ${includeJsr305Annotations}
        |useOptionalForGetters = ${useOptionalForGetters}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryConfigurationIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryConfigurationIT.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JType;
+import edu.emory.mathcs.backport.java.util.Collections;
+import org.joda.time.LocalDate;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.jsonschema2pojo.rules.FormatRule;
+import org.jsonschema2pojo.rules.Rule;
+import org.jsonschema2pojo.rules.RuleFactory;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertThat;
+
+public class CustomRuleFactoryConfigurationIT
+{
+
+    @org.junit.Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void customConfigurationToEnableLocalDate() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                config("customRuleFactory", TestRuleFactory.class.getName(),
+                       "customRuleFactoryConfiguration", Collections.singletonMap("useLocalDate", "true")));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
+
+        Method getter = generatedType.getMethod("getStringAsDate");
+
+        Class<?> returnType = getter.getReturnType();
+        assertThat(returnType.equals(LocalDate.class), is(true));
+    }
+
+    @Test
+    public void customConfigurationToDisableLocalDate() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                                                                       config("customRuleFactory", TestRuleFactory.class.getName(),
+                                                                              "customRuleFactoryConfiguration", Collections.singletonMap("useLocalDate", "false")));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
+
+        Method getter = generatedType.getMethod("getStringAsDate");
+
+        Class<?> returnType = getter.getReturnType();
+        assertThat(returnType.equals(String.class), is(true));
+    }
+
+    @Test
+    public void customConfigurationDefaultValue() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
+                                                                       config("customRuleFactory", TestRuleFactory.class.getName()));
+
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.FormattedProperties");
+
+        Method getter = generatedType.getMethod("getStringAsDate");
+
+        Class<?> returnType = getter.getReturnType();
+        assertThat(returnType.equals(LocalDate.class), is(false));
+    }
+
+    public static class TestRuleFactory extends RuleFactory {
+
+        @Override
+        public Rule<JType, JType> getFormatRule() {
+            return new FormatRule(this) {
+                @Override
+                public JType apply(String nodeName, JsonNode node, JsonNode parent, JType baseType, Schema schema) {
+
+                    Map<String, String> customRuleFactoryConfiguration = getRuleFactory().getGenerationConfig().getCustomRuleFactoryConfiguration();
+
+                    if (node.asText().equals("date") &&
+                            customRuleFactoryConfiguration.getOrDefault("useLocalDate", "false").equalsIgnoreCase("true") ) {
+                        return baseType.owner().ref(LocalDate.class);
+                    }
+
+                    return super.apply(nodeName, node, parent, baseType, schema);
+                }
+            };
+        }
+
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRuleTest.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRuleTest.java
@@ -69,7 +69,7 @@ public class Jsonschema2PojoRuleTest {
             public org.jsonschema2pojo.rules.Rule<JPackage, JType> getObjectRule() {
                 final org.jsonschema2pojo.rules.Rule<JPackage, JType> workingRule = super.getObjectRule();
 
-                return new org.jsonschema2pojo.rules.Rule<JPackage, JType>() {
+                return new org.jsonschema2pojo.rules.AbstractRuleFactoryRule<JPackage, JType>(this) {
                     @Override
                     public JType apply(String nodeName, JsonNode node, JsonNode parent, JPackage generatableType, Schema currentSchema) {
                         JType objectType = workingRule.apply(nodeName, node, null, generatableType, currentSchema);

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -320,6 +320,15 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private String customRuleFactory = RuleFactory.class.getName();
 
     /**
+     * A configuration map that can be used by custom rule factories.
+     /
+     * @parameter property="jsonschema2pojo.customRuleFactoryConfiguration"
+     *            default-value=""
+     * @since 1.0.3
+     */
+    private Map<String, String> customRuleFactoryConfiguration = new HashMap<>();
+
+    /**
      * Whether to include
      * <a href="http://jcp.org/en/jsr/detail?id=303">JSR-303/349</a> annotations
      * (for schema rules like minimum, maximum, etc) in generated Java types.
@@ -1023,6 +1032,12 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         } else {
             return RuleFactory.class;
         }
+    }
+
+    @Override
+    public Map<String, String> getCustomRuleFactoryConfiguration()
+    {
+        return customRuleFactoryConfiguration;
     }
 
     @Override


### PR DESCRIPTION
This will allow custom rule factories to have a simple string to string map of configuration properties.  For example in maven this allows a property such as this to be defined:

```
<plugin>
	<groupId>org.jsonschema2pojo</groupId>
	<artifactId>jsonschema2pojo-maven-plugin</artifactId>
	<version>1.0.3-SNAPSHOT</version>
	<executions>
		<execution>
			<goals>
				<goal>generate</goal>
			</goals>
		</execution>
	</executions>
	<dependencies>
		<dependency>
			<groupId>org.example.jsonschema2pojo-extensions</groupId>
			<artifactId>org.example.jsonschema2pojo-extensions.custom-rule-factory</artifactId>
			<version>${project.version}</version>
		</dependency>
	</dependencies>

	<configuration>
		<customRuleFactory>org.example.extensions.rules.CustomRuleFactory</customRuleFactory>

		<customRuleFactoryConfiguration>
			<quantitiesAsString>true</quantitiesAsString>
		</customRuleFactoryConfiguration>
	</configuration>
</plugin>
```

This allows the custom rule factory to have configuration in the configuration section of the plugin without fear of it being an invalid configuration.
