### PR TITLE
Updated gradle configuration names in examples

### DIFF
--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -34,11 +34,11 @@ repositories {
 
 dependencies {
   // Required if generating JSR-303 annotations
-  compile 'javax.validation:validation-api:1.1.0.CR2'
+  implementation 'javax.validation:validation-api:1.1.0.CR2'
   // Required if generating Jackson 2 annotations
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
   // Required if generating JodaTime data types
-  compile 'joda-time:joda-time:2.2'
+  implementation 'joda-time:joda-time:2.2'
 }
 
 // Each configuration is set to the default value


### PR DESCRIPTION
"compile" is deprecated in favor of "implementation"