### PR TITLE
Add @Generated annotation to classes and includeGeneratedAnnotation config option

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -192,6 +192,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private SourceSortOrder sourceSortOrder = SourceSortOrder.OS;
 
     private Map<String, String> formatTypeMapping = new HashMap<>();
+    
+    private boolean includeGeneratedAnnotation = true;
 
     /**
      * Execute this task (it's expected that all relevant setters will have been
@@ -1312,4 +1314,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public boolean isIncludeConstructorPropertiesAnnotation() {
         return includeConstructorPropertiesAnnotation;
     }
+    
+    @Override
+    public boolean isIncludeGeneratedAnnotation() { return includeGeneratedAnnotation; }
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -614,9 +614,12 @@
     </td>
     <td align="center" valign="top">None (default <code>''</code> (none))</td>
   </tr>
-
+  <tr>
+    <td valign="top">includeGeneratedAnnotation</td>
+    <td valign="top">Include <code>@javax.annotation.Generated</code> annotation to generated types</td>
+    <td align="center" valign="top">No (default <code>true</code>)</td>
+  </tr>
 </table>
-
 <h3>Examples</h3>
 <pre>
 &lt;taskdef name="jsonschema2pojo" classname="org.jsonschema2pojo.ant.Jsonschema2PojoTask">

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -243,6 +243,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = {"--print-log-levels"}, description = "Prints available log levels and exit.")
     private boolean printLogLevels = false;
 
+    @Parameter(names = {"--omit-generated-annotation"}, description = "Omit @Generated annotation on generated types")
+    private boolean omitGeneratedAnnotation = false;
+
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
 
@@ -598,4 +601,7 @@ public class Arguments implements GenerationConfig {
                 .stream()
                 .collect(Collectors.toMap(m -> m.split(":")[0], m -> m.split(":")[1]));
     }
+    
+    @Override
+    public boolean isIncludeGeneratedAnnotation() { return !omitGeneratedAnnotation; }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -478,4 +478,12 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isIncludeConstructorPropertiesAnnotation() {
         return false;
     }
+
+    /**
+     * @return <code>false</code>
+     */
+    @Override
+    public boolean isIncludeGeneratedAnnotation() {
+    	return true;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -610,5 +610,11 @@ public interface GenerationConfig {
   default boolean isUseInnerClassBuilders() {
     return false;
   }
-
+  
+  /**
+   * Whether to mark generated classes with the annotation <code>javax.annotation.@Generated</code>
+   *
+   */
+  boolean isIncludeGeneratedAnnotation();
+  
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -36,10 +36,12 @@ import org.jsonschema2pojo.exception.GenerationException;
 import org.jsonschema2pojo.model.EnumDefinition;
 import org.jsonschema2pojo.model.EnumDefinitionExtensionType;
 import org.jsonschema2pojo.model.EnumValueDefinition;
+import org.jsonschema2pojo.util.AnnotationHelper;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.codemodel.ClassType;
+import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassAlreadyExistsException;
@@ -144,6 +146,10 @@ public class EnumRule implements Rule<JClassContainer, JType> {
                     container.owner().ref(String.class);
 
         EnumDefinition enumDefinition = buildEnumDefinition(nodeName, node, backingType);
+
+        if(ruleFactory.getGenerationConfig() != null && ruleFactory.getGenerationConfig().isIncludeGeneratedAnnotation()) {
+            AnnotationHelper.addGeneratedAnnotation(_enum);
+        }
 
         JFieldVar valueField = addConstructorAndFields(enumDefinition, _enum);
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -35,9 +35,11 @@ import org.jsonschema2pojo.exception.GenerationException;
 import org.jsonschema2pojo.util.ParcelableHelper;
 import org.jsonschema2pojo.util.ReflectionHelper;
 import org.jsonschema2pojo.util.SerializableHelper;
+import org.jsonschema2pojo.util.AnnotationHelper;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.ClassType;
+import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JClassAlreadyExistsException;
@@ -125,7 +127,10 @@ public class ObjectRule implements Rule<JPackage, JType> {
         if (node.has("required")) {
             ruleFactory.getRequiredArrayRule().apply(nodeName, node.get("required"), node, jclass, schema);
         }
-
+       
+        if (ruleFactory.getGenerationConfig().isIncludeGeneratedAnnotation()) {
+        	AnnotationHelper.addGeneratedAnnotation(jclass);
+        }
         if (ruleFactory.getGenerationConfig().isIncludeToString()) {
             addToString(jclass);
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/AnnotationHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/AnnotationHelper.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JDefinedClass;
+
+public class AnnotationHelper {
+
+    static final String GENERATOR_NAME = "jsonschema2pojo";
+
+    public static void addGeneratedAnnotation(JDefinedClass jclass) {
+        JAnnotationUse generated = jclass.annotate(javax.annotation.Generated.class);
+        generated.param("value", GENERATOR_NAME);
+    }
+
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -95,6 +95,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   String refFragmentPathDelimiters
   SourceSortOrder sourceSortOrder
   Map<String, String> formatTypeMapping
+  boolean includeGeneratedAnnotation
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -154,6 +155,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     refFragmentPathDelimiters = "#/."
     sourceSortOrder = SourceSortOrder.OS
     formatTypeMapping = Collections.emptyMap()
+    includeGeneratedAnnotation = true
   }
 
   @Override
@@ -282,11 +284,17 @@ public class JsonSchemaExtension implements GenerationConfig {
        |formatTypeMapping = ${formatTypeMapping}
        |useInnerClassBuilders = ${useInnerClassBuilders}
        |includeConstructorPropertiesAnnotation = ${includeConstructorPropertiesAnnotation}
+       |includeGeneratedAnnotation = ${includeGeneratedAnnotation}
      """.stripMargin()
   }
   
   public boolean isFormatDateTimes() {
     return formatDateTimes
+  }
+
+  @Override
+  boolean isIncludeGeneratedAnnotation() {
+    return includeGeneratedAnnotation
   }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeGeneratedAnnotationIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeGeneratedAnnotationIT.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.hamcrest.Matchers;
+import org.jsonschema2pojo.integration.util.FileSearchMatcher;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.Generated;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+public class IncludeGeneratedAnnotationIT
+{
+	private static final String PROP_KEY = "includeGeneratedAnnotation";
+	private static final String SCHEMA_PATH = "/schema/" + PROP_KEY + "/" + PROP_KEY + ".json";
+	private static final String TEST_PACKAGE = "com.example";
+
+	@Rule
+	public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+	@Test
+	public void defaultConfig() throws ClassNotFoundException
+	{
+		File source = schemaRule.generate(SCHEMA_PATH, TEST_PACKAGE);
+
+		assertThat(source, FileSearchMatcher.containsText("javax.annotation.Generated"));
+	}
+
+	@Test
+	public void disabled() throws ClassNotFoundException
+	{
+		File source = schemaRule.generate(SCHEMA_PATH, TEST_PACKAGE, config(PROP_KEY, false));
+
+		assertThat(source, Matchers.not(FileSearchMatcher.containsText("javax.annotation.Generated")));
+	}
+
+	@Test
+	public void enabled() throws ClassNotFoundException
+	{
+		File source = schemaRule.generate(SCHEMA_PATH, TEST_PACKAGE, config(PROP_KEY, true));
+
+		assertThat(source, FileSearchMatcher.containsText("javax.annotation.Generated"));
+	}
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/includeGeneratedAnnotation/includeGeneratedAnnotation.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/includeGeneratedAnnotation/includeGeneratedAnnotation.json
@@ -1,0 +1,9 @@
+{
+  "type" : "object",
+  "properties" : {
+    "enum_Property" : {
+      "type" : "string",
+      "enum" : ["1", "2", "3", "4"]
+    }
+  }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -796,6 +796,12 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean includeConstructorPropertiesAnnotation = false;
 
     /**
+     * @parameter property="jsonschema2pojo.markGenerated"
+     *            default-value="false"
+     */
+    private boolean includeGeneratedAnnotation = true;
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -1237,5 +1243,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isUseInnerClassBuilders() {
         return useInnerClassBuilders;
+    }
+    
+    @Override
+    public boolean isIncludeGeneratedAnnotation() {
+    	return includeGeneratedAnnotation;
     }
 }


### PR DESCRIPTION
Restores the feature which added @javax.annotation.Generated annotation to generated code. In addition, the feature becomes conditional on a boolean configuration property "markGenerated" (as in JAXB. openapi ecc...), defaulted to false.
Addresses #1162 and related, without falling back to #577.

