### PR TITLE
Support symlinks when reading files

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/URLUtil.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/URLUtil.java
@@ -17,10 +17,12 @@
 package org.jsonschema2pojo.util;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.apache.commons.lang.StringUtils;
 import org.jsonschema2pojo.URLProtocol;
@@ -45,10 +47,27 @@ public class URLUtil {
     }
 
     public static File getFileFromURL(URL url) {
+
+        File file;
         try {
-            return new File(url.toURI());
+            file = new File(url.toURI());
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(String.format("URL contains an invalid URI syntax: %s", url), e);
+            throw new IllegalArgumentException(
+                String.format("URL contains an invalid URI syntax: %s", url), e
+            );
         }
+
+        // If symlink, then return the resolved File instead.
+        if (Files.isSymbolicLink(file.toPath())) {
+            try {
+                file = file.toPath().toRealPath().toFile();
+            } catch (IOException e) {
+                throw new IllegalArgumentException(
+                    String.format("Failed getting file from symlink URL: %s", url), e
+                );
+            }
+        }
+
+        return file;
     }
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/URLUtilTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/URLUtilTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.util;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.junit.Test;
+
+public class URLUtilTest {
+    @Test
+    public void testParseURLNoProto() throws MalformedURLException {
+        String input = "/path/to/file";
+        URL expected =  new File(input).toURI().toURL();
+        URL result = URLUtil.parseURL(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testParseURLFileProto() throws MalformedURLException {
+        String input = "file:///path/to/file";
+        URL expected =  URI.create(input).toURL();
+        URL result = URLUtil.parseURL(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testGetFileFromUrl() throws URISyntaxException {
+        URL url = getClass().getResource("/schema/address.json");
+
+        assert url != null;
+        File expected = new File(url.toURI());
+
+        File result = URLUtil.getFileFromURL(url);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testSymlinkGetFileFromUrl() throws URISyntaxException, IOException {
+        URL symlinkUrl = getClass().getResource("/schema/address-symlink.json");
+        URL targetUrl = getClass().getResource("/schema/address.json");
+
+        assert symlinkUrl != null;
+        assert targetUrl != null;
+
+        File expected = new File(targetUrl.getFile());
+
+        File result = URLUtil.getFileFromURL(symlinkUrl);
+        assertEquals(expected, result);
+    }
+
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/address-symlink.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/address-symlink.json
@@ -1,0 +1,1 @@
+address.json


### PR DESCRIPTION
Add symlink support to `URLUtils.getFileFromURL`. 

Also add unit tests for URLUtils. 

Fixes: #1256