### PR TITLE
Switched from javax.validation to jakarta.validation

### DIFF
--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DigitsRule.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.rules;
 
-import javax.validation.constraints.Digits;
+import jakarta.validation.constraints.Digits;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRule.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Map;
 
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Size;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRule.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Map;
 
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Size;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinimumMaximumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinimumMaximumRule.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.rules;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PatternRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PatternRule.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.rules;
 
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.Pattern;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredArrayRule.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.annotation.Nonnull;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RequiredRule.java
@@ -18,7 +18,7 @@ package org.jsonschema2pojo.rules;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.rules;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.jsonschema2pojo.Schema;
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DigitsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DigitsRuleTest.java
@@ -26,9 +26,9 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Random;
 
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Size;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Random;
 
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Size;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Random;
 
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Size;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinimumMaximumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinimumMaximumRuleTest.java
@@ -26,9 +26,9 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Random;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PatternRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PatternRuleTest.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.Pattern;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Collection;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
   // Required if generating JSR-303 annotations
-  implementation 'javax.validation:validation-api:1.1.0.CR2'
+  implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
   // Required if generating Jackson 2 annotations
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
   // Required if generating JodaTime data types

--- a/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     // Required if generating Moshi 1.x annotations
     implementation 'com.squareup.moshi:moshi:1.12.0'
     // Required if generating JSR-303 annotations
-    implementation 'javax.validation:validation-api:2.0.1.Final'
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
     // Required if generating Jackson 2 annotations
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
 }

--- a/jsonschema2pojo-gradle-plugin/example/android/lib/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/lib/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     // Required if generating Moshi 1.x annotations
     implementation 'com.squareup.moshi:moshi:1.12.0'
     // Required if generating JSR-303 annotations
-    implementation 'javax.validation:validation-api:2.0.1.Final'
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
     // Required if generating Jackson 2 annotations
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
 }

--- a/jsonschema2pojo-gradle-plugin/example/java/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/java/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'javax.validation:validation-api:1.1.0.CR2'
+  implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
 
   // see src/main/resources/json/external_dependencies.json

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -146,6 +151,10 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -32,9 +32,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.FileSearchMatcher;
@@ -53,7 +53,7 @@ public class IncludeJsr303AnnotationsIT {
     public void jsrAnnotationsAreNotIncludedByDefault() {
         File outputDirectory = schemaRule.generate("/schema/jsr303/all.json", "com.example");
 
-        assertThat(outputDirectory, not(containsText("javax.validation")));
+        assertThat(outputDirectory, not(containsText("jakarta.validation")));
     }
 
     @Test
@@ -61,7 +61,7 @@ public class IncludeJsr303AnnotationsIT {
         File outputDirectory = schemaRule.generate("/schema/jsr303/all.json", "com.example",
                 config("includeJsr303Annotations", false));
 
-        assertThat(outputDirectory, not(containsText("javax.validation")));
+        assertThat(outputDirectory, not(containsText("jakarta.validation")));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
@@ -41,7 +41,7 @@ public class IncludeJsr305AnnotationsIT {
     public void jsrAnnotationsAreNotIncludedByDefault() {
         File outputDirectory = schemaRule.generate("/schema/jsr303/all.json", "com.example");
 
-        assertThat(outputDirectory, not(containsText("javax.validation")));
+        assertThat(outputDirectory, not(containsText("jakarta.validation")));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class IncludeJsr305AnnotationsIT {
         File outputDirectory = schemaRule.generate("/schema/jsr303/all.json", "com.example",
                 config("includeJsr305Annotations", false));
 
-        assertThat(outputDirectory, not(containsText("javax.validation")));
+        assertThat(outputDirectory, not(containsText("jakarta.validation")));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -371,9 +371,9 @@
                 <version>3.11</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>1.0.0.GA</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
@@ -447,7 +447,19 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>4.3.0.Final</version>
+                <version>7.0.1.Final</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>4.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>4.0.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
We needed this fix for a project where we had to move from the javax to jakarta namespace. Maybe it's useful for others as well.