### PR TITLE
Split and modify "([ti])a$" Inflector rule

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/Inflector.java
@@ -71,8 +71,9 @@ public class Inflector {
             .plural("specimen", "specimens");
 
         builder.singular("s$", "")
-            .singular("(n)ews$", "$1ews")
-            .singular("([ti])a$", "$1um")
+             .singular("(n)ews$", "$1ews")
+            .singular("ia$", "ium")
+            .singular("ata$", "atum")
             .singular("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "$1$2sis")
             .singular("(^analy)ses$", "$1sis")
             .singular("([^f])ves$", "$1fe")

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
@@ -65,6 +65,8 @@ public class InflectorTest {
         assertThat(Inflector.getInstance().singularize("WidgetList"), is("Widget"));
 
         assertThat(Inflector.getInstance().singularize("slaves"), is("slave"));
+        assertThat(Inflector.getInstance().singularize("data"), is("datum"));
+        assertThat(Inflector.getInstance().singularize("media"), is("medium"));
     }
 
     @Test


### PR DESCRIPTION
Split and modify `"([ti])a$"` Inflector rule as outlined in https://github.com/joelittlejohn/jsonschema2pojo/issues/1275#issuecomment-866767985