### PR TITLE
Issue 1152: existingJavaType takes precedence over $ref

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -199,7 +199,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
     }
 
     private JsonNode resolveRefs(JsonNode node, Schema parent) {
-        if (node.has("$ref")) {
+        if (node.has("$ref") && !node.has("existingJavaType")) {
             Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             JsonNode refNode = refSchema.getContent();
             return resolveRefs(refNode, refSchema);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -63,7 +63,7 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
     @Override
     public JType apply(String nodeName, JsonNode schemaNode, JsonNode parent, JClassContainer generatableType, Schema schema) {
 
-        if (schemaNode.has("$ref")) {
+        if (schemaNode.has("$ref") && !schemaNode.has("existingJavaType")) {
             final String nameFromRef = nameFromRef(schemaNode.get("$ref").asText());
 
             schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
@@ -358,6 +358,13 @@ public class TypeIT {
                 }));
     }
 
+    @Test
+    public void existingTypeAndRefIgnoresRef() throws NoSuchMethodException {
+        Method getterMethod = classWithManyTypes.getMethod("getExistingTypeWithRef");
+
+        assertThat(getterMethod.getReturnType().getName(), is("com.example.MyJsonViewClass"));
+    }
+
     public static class InheritedClassWithGenerics<X, Y, Z> {
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/type/types.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/type/types.json
@@ -103,6 +103,10 @@
         },
         "nullableStringProperty" : {
           "type" : ["null", "string"]
+        },
+        "existingTypeWithRef": {
+            "existingJavaType": "com.example.MyJsonViewClass",
+            "$ref": "genericJavaType.json"
         }
     }
 }


### PR DESCRIPTION
In the scenario where both existingJavaType and $ref are set on the same schema node, the creator of the schema intends to rely on an existing Java type for the code generation, but still wants to refer a schema for documentation and interoperability purposes.
Therefore, from code generation standpoint, existingJavaType takes precedence, and $ref is ignored.
Resolution of ref at property level is not needed in that scenario.