### PR TITLE
Fix generating of enum constant names with mixed case values

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -470,7 +470,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
         boolean found = false;
 
         for (String existingName : existingNames) {
-            if (name.equalsIgnoreCase(existingName)) {
+            if (name.equals(existingName)) {
                 found = true;
                 break;
             }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumsWithMixedCaseConstantNames.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/enum/enumsWithMixedCaseConstantNames.json
@@ -1,0 +1,26 @@
+{
+  "type" : "object",
+  "properties" : {
+    "enumProperty" : {
+      "type" : "string",
+      "enum" : ["WORD", "Word"]
+    },
+    "enumPropertyWithJavaEnumNames" : {
+      "type" : "string",
+      "enum" : ["WORD", "Word"],
+      "javaEnumNames" : ["WORD","Word"]
+    },
+    "enumPropertyWithJavaEnums" : {
+      "type" : "string",
+      "enum" : ["WORD", "Word"],
+      "javaEnums" : [
+        {
+          "name": "WORD"
+        },
+        {
+          "name": "Word"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Addressing issue #1310

Please note that this might be a potential breaking change for cases when enums are defined with `javaEnumNames` or `javaEnums` and had enum alike names defined.
As outlined in the issue, current behavior is to generate:
```
    Female("Female"),
    FeMale_("FeMale"),
```
whilst new behavior would be to generate:
```
    Female("Female"),
    FeMale("FeMale"),
```