### PR TITLE
Replaced deprecated mockito method calls, minor other improvements

### DIFF
--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaMapperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaMapperTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -41,7 +40,7 @@ import com.sun.codemodel.JPackage;
 public class SchemaMapperTest {
 
     @Test
-    public void generateReadsSchemaAsObject() throws IOException {
+    public void generateReadsSchemaAsObject() {
 
         final SchemaRule mockSchemaRule = mock(SchemaRule.class);
 
@@ -64,7 +63,7 @@ public class SchemaMapperTest {
     }
 
     @Test
-    public void generateCreatesSchemaFromExampleJsonWhenInJsonMode() throws IOException {
+    public void generateCreatesSchemaFromExampleJsonWhenInJsonMode() {
 
         URL schemaContent = this.getClass().getResource("/schema/address.json");
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SourceSortOrderTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SourceSortOrderTest.java
@@ -22,29 +22,28 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Comparator;
 
 import org.junit.Test;
 
 public class SourceSortOrderTest {
     @Test
-    public void testTwoFilesAreCompared_FILES_FIRST() throws IOException {
+    public void testTwoFilesAreCompared_FILES_FIRST() {
         testTwoFilesAreCompared(SourceSortOrder.FILES_FIRST.getComparator());
     }
 
     @Test
-    public void twoDirectoriesAreCompared_FILES_FIRST() throws IOException {
+    public void twoDirectoriesAreCompared_FILES_FIRST() {
         testTwoDirectoriesAreCompared(SourceSortOrder.FILES_FIRST.getComparator());
     }
 
     @Test
-    public void testTwoFilesAreCompared_SUBDIRS_FIRST() throws IOException {
+    public void testTwoFilesAreCompared_SUBDIRS_FIRST() {
         testTwoFilesAreCompared(SourceSortOrder.SUBDIRS_FIRST.getComparator());
     }
 
     @Test
-    public void twoDirectoriesAreCompared_SUBDIRS_FIRST() throws IOException {
+    public void twoDirectoriesAreCompared_SUBDIRS_FIRST() {
         testTwoDirectoriesAreCompared(SourceSortOrder.SUBDIRS_FIRST.getComparator());
     }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DigitsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DigitsRuleTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -56,7 +55,7 @@ public class DigitsRuleTest {
 
     private final boolean isApplicable;
     private DigitsRule rule;
-    private Class<?> fieldClass;
+    private final Class<?> fieldClass;
     private final boolean useJakartaValidation;
     private final Class<? extends Annotation> digitsClass;
     private final Class<? extends Annotation> sizeClass;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.jsonschema2pojo.Annotator;
@@ -27,7 +26,7 @@ import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -41,14 +40,14 @@ import com.sun.codemodel.JType;
 
 public class EnumRuleTest {
 
-    private Schema schema = mock(Schema.class);
-    private NameHelper nameHelper = mock(NameHelper.class);
-    private Annotator annotator = mock(Annotator.class);
-    private RuleFactory ruleFactory = mock(RuleFactory.class);
-    private TypeRule typeRule = mock(TypeRule.class);
-    private RuleLogger logger = mock(RuleLogger.class);
+    private final Schema schema = mock(Schema.class);
+    private final NameHelper nameHelper = mock(NameHelper.class);
+    private final Annotator annotator = mock(Annotator.class);
+    private final RuleFactory ruleFactory = mock(RuleFactory.class);
+    private final TypeRule typeRule = mock(TypeRule.class);
+    private final RuleLogger logger = mock(RuleLogger.class);
 
-    private EnumRule rule = new EnumRule(ruleFactory);
+    private final EnumRule rule = new EnumRule(ruleFactory);
 
     @Before
     public void wireUpConfig() {
@@ -62,7 +61,7 @@ public class EnumRuleTest {
     public void applyGeneratesUniqueEnumNamesForMultipleEnumNodesWithSameName() {
 
         Answer<String> firstArgAnswer = new FirstArgAnswer<>();
-        when(nameHelper.getClassName(anyString(), Matchers.any(JsonNode.class))).thenAnswer(firstArgAnswer);
+        when(nameHelper.getClassName(anyString(), ArgumentMatchers.any(JsonNode.class))).thenAnswer(firstArgAnswer);
         when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
         when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -55,7 +54,7 @@ public class MinItemsMaxItemsRuleTest {
 
     private final boolean isApplicable;
     private MinItemsMaxItemsRule rule;
-    private Class<?> fieldClass;
+    private final Class<?> fieldClass;
     private final boolean useJakartaValidation;
     private final Class<? extends Annotation> sizeClass;
     @Mock

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -55,7 +54,7 @@ public class MinLengthMaxLengthRuleTest {
 
     private final boolean isApplicable;
     private MinLengthMaxLengthRule rule;
-    private Class<?> fieldClass;
+    private final Class<?> fieldClass;
     private final boolean useJakartaValidation;
     private final Class<? extends Annotation> sizeClass;
     @Mock

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinimumMaximumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinimumMaximumRuleTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -57,7 +56,7 @@ public class MinimumMaximumRuleTest {
 
     private final boolean isApplicable;
     private MinimumMaximumRule rule;
-    private Class<?> fieldClass;
+    private final Class<?> fieldClass;
     private final boolean useJakartaValidation;
     private final Class<? extends Annotation> decimalMaxClass;
     private final Class<? extends Annotation> decimalMinClass;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PatternRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PatternRuleTest.java
@@ -18,7 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -54,7 +53,7 @@ public class PatternRuleTest {
 
     private final boolean isApplicable;
     private PatternRule rule;
-    private Class<?> fieldClass;
+    private final Class<?> fieldClass;
     private final boolean useJakartaValidation;
     private final Class<? extends Annotation> patternClass;
     @Mock

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -18,8 +18,6 @@ package org.jsonschema2pojo.rules;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
@@ -44,8 +42,8 @@ public class SchemaRuleTest {
     private static final String NODE_NAME = "nodeName";
     private static final String TARGET_CLASS_NAME = SchemaRuleTest.class.getName() + ".DummyClass";
 
-    private RuleFactory mockRuleFactory = mock(RuleFactory.class);
-    private SchemaRule rule = new SchemaRule(mockRuleFactory);
+    private final RuleFactory mockRuleFactory = mock(RuleFactory.class);
+    private final SchemaRule rule = new SchemaRule(mockRuleFactory);
 
     @Test
     public void refsToOtherSchemasAreLoaded() throws URISyntaxException, JClassAlreadyExistsException {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -18,15 +18,12 @@ package org.jsonschema2pojo.rules;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.jsonschema2pojo.GenerationConfig;
-import org.jsonschema2pojo.Schema;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -42,10 +39,10 @@ import com.sun.codemodel.JType;
 
 public class TypeRuleTest {
 
-    private GenerationConfig config = mock(GenerationConfig.class);
-    private RuleFactory ruleFactory = mock(RuleFactory.class);
+    private final GenerationConfig config = mock(GenerationConfig.class);
+    private final RuleFactory ruleFactory = mock(RuleFactory.class);
 
-    private TypeRule rule = new TypeRule(ruleFactory);
+    private final TypeRule rule = new TypeRule(ruleFactory);
 
     @Before
     public void wireUpConfig() {
@@ -78,7 +75,7 @@ public class TypeRuleTest {
 
         JType mockDateType = mock(JType.class);
         FormatRule mockFormatRule = mock(FormatRule.class);
-        when(mockFormatRule.apply(eq("fooBar"), eq(formatNode), any(), Mockito.isA(JType.class), isNull(Schema.class))).thenReturn(mockDateType);
+        when(mockFormatRule.apply(eq("fooBar"), eq(formatNode), any(), Mockito.isA(JType.class), isNull())).thenReturn(mockDateType);
         when(ruleFactory.getFormatRule()).thenReturn(mockFormatRule);
 
         JType result = rule.apply("fooBar", objectNode, null, jpackage, null);
@@ -563,7 +560,7 @@ public class TypeRuleTest {
 
         JType result = rule.apply("fooBar", objectNode, null, jpackage, null);
 
-        assertThat(result, is((JType) mockArrayType));
+        assertThat(result, is(mockArrayType));
     }
 
     @Test
@@ -581,7 +578,7 @@ public class TypeRuleTest {
 
         JType result = rule.apply("fooBar", objectNode, null, jpackage, null);
 
-        assertThat(result, is((JType) mockObjectType));
+        assertThat(result, is(mockObjectType));
     }
 
     @Test


### PR DESCRIPTION
Replaced deprecated mockito methods that were removed in `4.0.0` (https://github.com/joelittlejohn/jsonschema2pojo/pull/1345)
Additionally:

- removed unused import statements
- removed redundant casts
- removed redundant `throws IOException`
- added `final` modifier to fields