### PR TITLE
Added support for JSON-B

### DIFF
--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -41,6 +41,10 @@
         </li>
         <li><code>JACKSON</code> (alias for JACKSON2)
         </li>
+        <li><code>JSONB</code> (apply annotations from the JSON-B 1.x library)
+        </li>
+        <li><code>JSONB2</code> (apply annotations from the JSON-B 2.x library)
+        </li>
         <li><code>GSON</code> (apply annotations from the <a
             href="https://code.google.com/p/google-gson//">Gson</a> library)
         </li>

--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -14,6 +14,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AnnotationStyle.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AnnotationStyle.java
@@ -39,6 +39,10 @@ public enum AnnotationStyle {
      */
     JACKSON2,
 
+    JSONB1,
+
+    JSONB2,
+
     /**
      * Gson 2.x
      */

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AnnotatorFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AnnotatorFactory.java
@@ -46,6 +46,10 @@ public class AnnotatorFactory {
             case JACKSON:
             case JACKSON2:
                 return new Jackson2Annotator(generationConfig);
+            case JSONB1:
+                return new Jsonb1Annotator(generationConfig);
+            case JSONB2:
+                return new Jsonb2Annotator(generationConfig);
             case GSON:
                 return new GsonAnnotator(generationConfig);
             case MOSHI1:

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb1Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb1Annotator.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JAnnotationArrayMember;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JMethod;
+
+import org.jsonschema2pojo.rules.FormatRule;
+
+import javax.json.bind.annotation.JsonbDateFormat;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.json.bind.annotation.JsonbTransient;
+
+import java.util.Iterator;
+
+/**
+ * Annotates generated Java types using the Jackson 2.x mapping annotations.
+ *
+ * @see <a
+ *      href="https://github.com/FasterXML/jackson-annotations">https://github.com/FasterXML/jackson-annotations</a>
+ */
+public class Jsonb1Annotator extends AbstractAnnotator {
+
+    public Jsonb1Annotator(GenerationConfig generationConfig) {
+        super(generationConfig);
+    }
+
+    @Override
+    public void propertyOrder(JDefinedClass clazz, JsonNode propertiesNode) {
+        JAnnotationArrayMember annotationValue = clazz.annotate(JsonbPropertyOrder.class).paramArray("value");
+
+        for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
+            annotationValue.param(properties.next());
+        }
+    }
+
+    @Override
+    public void propertyField(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
+        field.annotate(JsonbProperty.class).param("value", propertyName);
+    }
+
+    @Override
+    public void propertyGetter(JMethod getter, JDefinedClass clazz, String propertyName) {
+        getter.annotate(JsonbProperty.class).param("value", propertyName);
+    }
+
+    @Override
+    public void propertySetter(JMethod setter, JDefinedClass clazz, String propertyName) {
+        setter.annotate(JsonbProperty.class).param("value", propertyName);
+    }
+
+    @Override
+    public boolean isAdditionalPropertiesSupported() {
+        return true;
+    }
+
+    @Override
+    public void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName) {
+        field.annotate(JsonbTransient.class);
+    }
+
+    @Override
+    public void dateField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
+        String pattern = null;
+        if (node.has("customDatePattern")) {
+            pattern = node.get("customDatePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomDatePattern())) {
+            pattern = getGenerationConfig().getCustomDatePattern();
+        } else if (getGenerationConfig().isFormatDates()) {
+            pattern = FormatRule.ISO_8601_DATE_FORMAT;
+        }
+
+        if (!field.type().fullName().equals("java.lang.String")) {
+            pattern = pattern != null? pattern : FormatRule.ISO_8601_DATE_FORMAT;
+            field.annotate(JsonbDateFormat.class).param("value", pattern);
+        }
+    }
+
+    @Override
+    public void timeField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
+        String pattern = null;
+        if (node.has("customTimePattern")) {
+            pattern = node.get("customTimePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomTimePattern())) {
+            pattern = getGenerationConfig().getCustomTimePattern();
+        } else if (getGenerationConfig().isFormatDates()) {
+            pattern = FormatRule.ISO_8601_TIME_FORMAT;
+        }
+
+        if (!field.type().fullName().equals("java.lang.String")) {
+            pattern = pattern != null? pattern : FormatRule.ISO_8601_TIME_FORMAT;
+            field.annotate(JsonbDateFormat.class).param("value", pattern);
+        }
+    }
+
+    @Override
+    public void dateTimeField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
+        String pattern = null;
+        if (node.has("customDateTimePattern")) {
+            pattern = node.get("customDateTimePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomDateTimePattern())) {
+            pattern = getGenerationConfig().getCustomDateTimePattern();
+        } else if (getGenerationConfig().isFormatDateTimes()) {
+            pattern = FormatRule.ISO_8601_DATETIME_FORMAT;
+        }
+
+        if (!field.type().fullName().equals("java.lang.String")) {
+            pattern = pattern != null? pattern : FormatRule.ISO_8601_DATETIME_FORMAT;
+            field.annotate(JsonbDateFormat.class).param("value", pattern);
+        }
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb1Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb1Annotator.java
@@ -1,6 +1,4 @@
 /**
- * Copyright © 2010-2020 Nokia
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -34,10 +32,8 @@ import javax.json.bind.annotation.JsonbTransient;
 import java.util.Iterator;
 
 /**
- * Annotates generated Java types using the Jackson 2.x mapping annotations.
- *
- * @see <a
- *      href="https://github.com/FasterXML/jackson-annotations">https://github.com/FasterXML/jackson-annotations</a>
+ * Annotates generated Java types using the JSON-B 1 mapping annotations. Implementation inspired by
+ * Jackson2Annotator.
  */
 public class Jsonb1Annotator extends AbstractAnnotator {
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb2Annotator.java
@@ -1,6 +1,4 @@
 /**
- * Copyright © 2010-2020 Nokia
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -34,10 +32,8 @@ import jakarta.json.bind.annotation.JsonbPropertyOrder;
 import jakarta.json.bind.annotation.JsonbTransient;
 
 /**
- * Annotates generated Java types using the Jackson 2.x mapping annotations.
- *
- * @see <a
- *      href="https://github.com/FasterXML/jackson-annotations">https://github.com/FasterXML/jackson-annotations</a>
+ * Annotates generated Java types using the JSON-B 2 mapping annotations. Implementation inspired by
+ * Jackson2Annotator.
  */
 public class Jsonb2Annotator extends AbstractAnnotator {
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb2Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonb2Annotator.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JAnnotationArrayMember;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JMethod;
+
+import org.jsonschema2pojo.rules.FormatRule;
+
+import java.util.Iterator;
+
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbPropertyOrder;
+import jakarta.json.bind.annotation.JsonbTransient;
+
+/**
+ * Annotates generated Java types using the Jackson 2.x mapping annotations.
+ *
+ * @see <a
+ *      href="https://github.com/FasterXML/jackson-annotations">https://github.com/FasterXML/jackson-annotations</a>
+ */
+public class Jsonb2Annotator extends AbstractAnnotator {
+
+    public Jsonb2Annotator(GenerationConfig generationConfig) {
+        super(generationConfig);
+    }
+
+    @Override
+    public void propertyOrder(JDefinedClass clazz, JsonNode propertiesNode) {
+        JAnnotationArrayMember annotationValue = clazz.annotate(JsonbPropertyOrder.class).paramArray("value");
+
+        for (Iterator<String> properties = propertiesNode.fieldNames(); properties.hasNext();) {
+            annotationValue.param(properties.next());
+        }
+    }
+
+    @Override
+    public void propertyField(JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
+        field.annotate(JsonbProperty.class).param("value", propertyName);
+    }
+
+    @Override
+    public void propertyGetter(JMethod getter, JDefinedClass clazz, String propertyName) {
+        getter.annotate(JsonbProperty.class).param("value", propertyName);
+    }
+
+    @Override
+    public void propertySetter(JMethod setter, JDefinedClass clazz, String propertyName) {
+        setter.annotate(JsonbProperty.class).param("value", propertyName);
+    }
+
+    @Override
+    public boolean isAdditionalPropertiesSupported() {
+        return true;
+    }
+
+    @Override
+    public void additionalPropertiesField(JFieldVar field, JDefinedClass clazz, String propertyName) {
+        field.annotate(JsonbTransient.class);
+    }
+
+    @Override
+    public void dateField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
+        String pattern = null;
+        if (node.has("customDatePattern")) {
+            pattern = node.get("customDatePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomDatePattern())) {
+            pattern = getGenerationConfig().getCustomDatePattern();
+        } else if (getGenerationConfig().isFormatDates()) {
+            pattern = FormatRule.ISO_8601_DATE_FORMAT;
+        }
+
+        if (!field.type().fullName().equals("java.lang.String")) {
+            pattern = pattern != null? pattern : FormatRule.ISO_8601_DATE_FORMAT;
+            field.annotate(JsonbDateFormat.class).param("value", pattern);
+        }
+    }
+
+    @Override
+    public void timeField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
+        String pattern = null;
+        if (node.has("customTimePattern")) {
+            pattern = node.get("customTimePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomTimePattern())) {
+            pattern = getGenerationConfig().getCustomTimePattern();
+        } else if (getGenerationConfig().isFormatDates()) {
+            pattern = FormatRule.ISO_8601_TIME_FORMAT;
+        }
+
+        if (!field.type().fullName().equals("java.lang.String")) {
+            pattern = pattern != null? pattern : FormatRule.ISO_8601_TIME_FORMAT;
+            field.annotate(JsonbDateFormat.class).param("value", pattern);
+        }
+    }
+
+    @Override
+    public void dateTimeField(JFieldVar field, JDefinedClass clazz, JsonNode node) {
+        String pattern = null;
+        if (node.has("customDateTimePattern")) {
+            pattern = node.get("customDateTimePattern").asText();
+        } else if (node.has("customPattern")) {
+            pattern = node.get("customPattern").asText();
+        } else if (isNotEmpty(getGenerationConfig().getCustomDateTimePattern())) {
+            pattern = getGenerationConfig().getCustomDateTimePattern();
+        } else if (getGenerationConfig().isFormatDateTimes()) {
+            pattern = FormatRule.ISO_8601_DATETIME_FORMAT;
+        }
+
+        if (!field.type().fullName().equals("java.lang.String")) {
+            pattern = pattern != null? pattern : FormatRule.ISO_8601_DATETIME_FORMAT;
+            field.annotate(JsonbDateFormat.class).param("value", pattern);
+        }
+    }
+}

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -109,6 +109,8 @@ jsonSchema2Pojo {
   // The style of annotations to use in the generated Java types. Supported values:
   //  - jackson (alias of jackson2)
   //  - jackson2 (apply annotations from the Jackson 2.x library)
+  //  - jsonb (apply annotations from the JSON-B 1 library)
+  //  - jsonb2 (apply annotations from the JSON-B 2 library)
   //  - gson (apply annotations from the Gson library)
   //  - moshi1 (apply annotations from the Moshi 1.x library)
   //  - none (apply no annotations at all)

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -179,6 +179,24 @@
           <groupId>org.skyscreamer</groupId>
           <artifactId>jsonassert</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-json_1.1_spec</artifactId>
+            <version>1.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-jsonb</artifactId>
+            <version>1.2.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>2.0.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
@@ -53,6 +53,8 @@ public class GsonIT {
 
         assertThat(schemaRule.getGenerateDir(), not(containsText("org.codehaus.jackson")));
         assertThat(schemaRule.getGenerateDir(), not(containsText("com.fasterxml.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("jakarta.json.bind.annotation")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("javax.json.bind.annotation")));
         assertThat(schemaRule.getGenerateDir(), containsText("com.google.gson"));
         assertThat(schemaRule.getGenerateDir(), containsText("@SerializedName"));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb2IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb2IT.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.jsonschema2pojo.integration.util.FileSearchMatcher.containsText;
+import static org.jsonschema2pojo.integration.util.JsonAssert.assertEqualsJson;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.io.IOUtils;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbPropertyOrder;
+
+public class Jsonb2IT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    private Jsonb jsonb;
+
+    @Before
+    public void setUp() {
+        jsonb = JsonbBuilder.create();
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void annotationStyleJsonb2ProducesJsonb2Annotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        Class generatedType = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+                config("annotationStyle", "jsonb2"))
+            .loadClass("com.example.PrimitiveProperties");
+
+        assertThat(schemaRule.getGenerateDir(), not(containsText("org.codehaus.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.fasterxml.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.google.gson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("javax.json.bind.annotation")));
+        assertThat(schemaRule.getGenerateDir(), containsText("jakarta.json.bind.annotation"));
+
+        Method getter = generatedType.getMethod("getA");
+
+        assertThat(generatedType.getAnnotation(JsonbPropertyOrder.class), is(notNullValue()));
+        assertThat(getter.getAnnotation(JsonbProperty.class), is(notNullValue()));
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes"})
+    public void annotationStyleJsonb2ProducesDateFormatAnnotation() throws ClassNotFoundException, SecurityException, NoSuchFieldException {
+
+        Class generatedType = schemaRule.generateAndCompile("/schema/format/customDateTimeFormat.json", "com.example",
+                config("annotationStyle", "jsonb2"))
+            .loadClass("com.example.CustomDateTimeFormat");
+
+        assertThat(generatedType.getDeclaredField("defaultFormat").getAnnotation(JsonbDateFormat.class), is(notNullValue()));
+    }
+
+    @Test
+    public void annotationStyleJsonb2MakesTypesThatWorkWithJsonb2() throws ClassNotFoundException, SecurityException, IOException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/json/examples/", "com.example",
+            config("annotationStyle", "jsonb2",
+                "propertyWordDelimiters", "_",
+                "sourceType", "json",
+                "useLongIntegers", true));
+
+        assertJsonRoundTrip(resultsClassLoader, "com.example.Torrent", "/json/examples/torrent.json");
+        assertJsonRoundTrip(resultsClassLoader, "com.example.GetUserData", "/json/examples/GetUserData.json");
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void assertJsonRoundTrip(ClassLoader resultsClassLoader, String className, String jsonResource) throws ClassNotFoundException, IOException, IOException {
+        Class generatedType = resultsClassLoader.loadClass(className);
+
+        String expectedJson = IOUtils.toString(getClass().getResource(jsonResource), Charset.forName("UTF-8"));
+        Object javaInstance = jsonb.fromJson(expectedJson, generatedType);
+        String actualJson = jsonb.toJson(javaInstance);
+
+        assertEqualsJson(expectedJson, actualJson);
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JsonbIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JsonbIT.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+import static org.jsonschema2pojo.integration.util.FileSearchMatcher.containsText;
+import static org.junit.Assert.assertThat;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.json.bind.annotation.JsonbDateFormat;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbPropertyOrder;
+
+import java.lang.reflect.Method;
+
+public class JsonbIT {
+
+    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void annotationStyleJsonb1ProducesJsonb1Annotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        Class generatedType = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+                config("annotationStyle", "jsonb1"))
+            .loadClass("com.example.PrimitiveProperties");
+
+        assertThat(schemaRule.getGenerateDir(), not(containsText("org.codehaus.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.fasterxml.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.google.gson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("jakarta.json.bind.annotation")));
+        assertThat(schemaRule.getGenerateDir(), containsText("javax.json.bind.annotation"));
+
+        Method getter = generatedType.getMethod("getA");
+
+        assertThat(generatedType.getAnnotation(JsonbPropertyOrder.class), is(notNullValue()));
+        assertThat(getter.getAnnotation(JsonbProperty.class), is(notNullValue()));
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes"})
+    public void annotationStyleJsonb1ProducesDateFormatAnnotation() throws ClassNotFoundException, SecurityException, NoSuchFieldException {
+
+        Class generatedType = schemaRule.generateAndCompile("/schema/format/customDateTimeFormat.json", "com.example",
+            config("annotationStyle", "jsonb1"))
+            .loadClass("com.example.CustomDateTimeFormat");
+
+        assertThat(generatedType.getDeclaredField("defaultFormat").getAnnotation(JsonbDateFormat.class), is(notNullValue()));
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void annotationStyleJsonb2ProducesJsonb2Annotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+        Class generatedType = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example",
+                config("annotationStyle", "jsonb2"))
+            .loadClass("com.example.PrimitiveProperties");
+
+        assertThat(schemaRule.getGenerateDir(), not(containsText("org.codehaus.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.fasterxml.jackson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("com.google.gson")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("javax.json.bind.annotation")));
+        assertThat(schemaRule.getGenerateDir(), containsText("jakarta.json.bind.annotation"));
+
+        Method getter = generatedType.getMethod("getA");
+
+        assertThat(generatedType.getAnnotation(jakarta.json.bind.annotation.JsonbPropertyOrder.class), is(notNullValue()));
+        assertThat(getter.getAnnotation(jakarta.json.bind.annotation.JsonbProperty.class), is(notNullValue()));
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes"})
+    public void annotationStyleJsonb2ProducesDateFormatAnnotation() throws ClassNotFoundException, SecurityException, NoSuchFieldException {
+
+        Class generatedType = schemaRule.generateAndCompile("/schema/format/customDateTimeFormat.json", "com.example",
+                config("annotationStyle", "jsonb2"))
+            .loadClass("com.example.CustomDateTimeFormat");
+
+        assertThat(generatedType.getDeclaredField("defaultFormat").getAnnotation(jakarta.json.bind.annotation.JsonbDateFormat.class), is(notNullValue()));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Moshi1IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Moshi1IT.java
@@ -62,6 +62,8 @@ public class Moshi1IT {
                         "sourceType", "json"))
                 .loadClass("com.example.Torrent");
 
+        assertThat(schemaRule.getGenerateDir(), not(containsText("jakarta.json.bind.annotation")));
+        assertThat(schemaRule.getGenerateDir(), not(containsText("javax.json.bind.annotation")));
         assertThat(schemaRule.getGenerateDir(), not(containsText("org.codehaus.jackson")));
         assertThat(schemaRule.getGenerateDir(), not(containsText("com.fasterxml.jackson")));
         assertThat(schemaRule.getGenerateDir(), not(containsText("com.google.gson")));

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -249,7 +249,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      * <li><code>jackson2</code> (apply annotations from the
      * <a href="https://github.com/FasterXML/jackson-annotations">Jackson
      * 2.x</a> library)</li>
-     * <li><code>jackson</code> (alias for jackson2)
+     * <li><code>jackson</code> (alias for jackson2)</li>
+     * <li><code>jsonb</code> (apply annotations from the
+     * JSON-B 1.x library)</li>
+     * <li><code>jsonb2</code> (apply annotations from the
+     * JSON-B 2.x library)</li>
      * <li><code>gson</code> (apply annotations from the
      * <a href="https://code.google.com/p/google-gson/">gson</a> library)</li>
      * <li><code>moshi1</code> (apply annotations from the


### PR DESCRIPTION
My suggestion for JSON-B-support. I have provided two annotators for JSON-B 1 and 2. They differ only in the package of the annotations though. Alternatively, one could provide a baseclass, too, and let the two extending classes only provide the annotation classes. Thiw, however, would lead to a close coupleing of both versions. Another alternative would be to have the subversion be specified by the configuration of the plugin and provide one class that handles both versions by respecting the configuration. Thought I leave that decision up to you.