### PR TITLE
Use LinkedHashMap for additional properties, so the original ordering in the JSON is preserved

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.rules;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Spliterator;
@@ -138,7 +138,7 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
         JClass propertiesMapType = jclass.owner().ref(Map.class);
         propertiesMapType = propertiesMapType.narrow(jclass.owner().ref(String.class), propertyType.boxify());
 
-        JClass propertiesMapImplType = jclass.owner().ref(HashMap.class);
+        JClass propertiesMapImplType = jclass.owner().ref(LinkedHashMap.class);
         propertiesMapImplType = propertiesMapImplType.narrow(jclass.owner().ref(String.class), propertyType.boxify());
 
         JFieldVar field = jclass.field(JMod.PRIVATE, propertiesMapType, "additionalProperties");


### PR DESCRIPTION
Original GitHub issue:
> It's quite annoying that additionalProperties values lose their initial array order when json is parsed.
> Since I use the same schema classes to generate json after tweaking, I can't sort them too.
> I guess it will be easy to add an option to generate LinkedHashMap instead of HashMap for additionalProperties field.