### PR TITLE
Adds builder method when using innerBuilder

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/BuilderRule.java
@@ -110,6 +110,10 @@ public class BuilderRule implements Rule<JDefinedClass, JDefinedClass> {
       generateNoArgsBuilderConstructors(instanceClass, builderClass, concreteBuilderClass);
     }
 
+    JMethod builderMethod = instanceClass.method(JMod.PUBLIC + JMod.STATIC, builderClass, "builder");
+    JBlock builderBody = builderMethod.body();
+    builderBody._return(JExpr._new(concreteBuilderClass));
+
     return builderClass;
   }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
@@ -224,4 +224,42 @@ public class UseInnerClassBuildersIT {
     assertEquals(parentProperty, getParentProperty.invoke(childObject));
     assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
   }
+
+  /**
+   * This method confirms that if innerBuilders are used, a "builder" method is created on the class that returns an instance of the builder
+   */
+  @Test
+  public void innerBuilderCreatesBuilderMethod()
+          throws ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException {
+    ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
+            config("generateBuilders", true, "useInnerClassBuilders", true));
+
+    Class<?> childClass = resultsClassLoader.loadClass("com.example.Child");
+    Method builderMethod = childClass.getMethod("builder");
+
+    Class<?> builderClass = builderMethod.getReturnType();
+
+    Method buildMethod = builderClass.getMethod("build");
+    Method withChildProperty = builderClass.getMethod("withChildProperty", Integer.class);
+    Method withParentProperty = builderClass.getMethod("withParentProperty", String.class);
+    Method withSharedProperty = builderClass.getMethod("withSharedProperty", String.class);
+
+    int childProperty = 1;
+    String parentProperty = "parentProperty";
+    String sharedProperty = "sharedProperty";
+
+    Object builder = builderMethod.invoke(childClass);
+    withChildProperty.invoke(builder, childProperty);
+    withParentProperty.invoke(builder, parentProperty);
+    withSharedProperty.invoke(builder, sharedProperty);
+    Object childObject = buildMethod.invoke(builder);
+
+    Method getChildProperty = childClass.getMethod("getChildProperty");
+    Method getParentProperty = childClass.getMethod("getParentProperty");
+    Method getSharedProperty = childClass.getMethod("getSharedProperty");
+
+    assertEquals(childProperty, getChildProperty.invoke(childObject));
+    assertEquals(parentProperty, getParentProperty.invoke(childObject));
+    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+  }
 }


### PR DESCRIPTION
This PR updates the code to add a `public static` method called `builder` to all the classes that are created with the `generateBuilders` and `useInnerClassBuilders`.

This is a sample of how the builder method looks like:

```
public static Child.ChildBuilderBase builder() {
    return new Child.ChildBuilder();
}
```

Fixes #1396