### PR TITLE
Support - as reading from input stream

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/ContentResolver.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/ContentResolver.java
@@ -51,6 +51,8 @@ public class ContentResolver {
                 .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     }
 
+    static JsonNode cachedStdIn;
+
     /**
      * Resolve a given URI to read its contents and parse the result as JSON.
      * <p>
@@ -73,7 +75,14 @@ public class ContentResolver {
         }
 
         try {
-            return objectMapper.readTree(uri.toURL());
+            if(uri.getPath().endsWith("/-")) {
+                if(cachedStdIn==null) {
+                    cachedStdIn = objectMapper.readTree(System.in);
+                }
+                return cachedStdIn;
+            } else {
+                return objectMapper.readTree(uri.toURL());
+            }
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Error parsing document: " + uri, e);
         } catch (IOException e) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
@@ -168,6 +168,10 @@ public class Jsonschema2Pojo {
 
     public static String getNodeName(String filePath, GenerationConfig config) {
         try {
+            if(filePath.endsWith("/-")) {
+                // if standard input '-' use base directory as name.
+                filePath=filePath.substring(0,filePath.length()-2);
+            }
             String fileName = FilenameUtils.getName(URLDecoder.decode(filePath, StandardCharsets.UTF_8.toString()));
             String[] extensions = config.getFileExtensions() == null ? new String[] {} : config.getFileExtensions();
             

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaGenerator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaGenerator.java
@@ -53,8 +53,14 @@ public class SchemaGenerator {
     public ObjectNode schemaFromExample(URL example) {
 
         try {
-            JsonNode content = this.objectMapper.readTree(example);
+            JsonNode content = null;
+            if (example.getPath().endsWith("/-")) {
+                content = this.objectMapper.readTree(System.in);
+            } else {
+                content = this.objectMapper.readTree(example);
+            }
             return schemaFromExample(content);
+
         } catch (IOException e) {
             throw new GenerationException("Could not process JSON in source file", e);
         }


### PR DESCRIPTION
idea I had was to enable using - as reading from standard input so you can do something like:

```
curl https://api.github.com/users/maxandersen | jbang --debug org.jsonschema2pojo:jsonschema2pojo-cli:1.1.3-SNAPSHOT --source - --target out -T json
```

would that be interesting ? (if yes I'll investigate adding tests for it)

things I noticed doing this that i'm not sure is expected or bugs:

when treating input as schema the same url is requested multiple times in ContentResolver requiring me to add a cache for standard input...maybe should instead do it generically instead of reading url multiple times?

when treating input as json then content resolvers are NOT used but instead read directly so had to add - handling of urls redundantly.

wdyt ?