### PR TITLE
Support customContentResolver

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -43,6 +43,7 @@ import org.apache.tools.ant.types.Reference;
 import org.jsonschema2pojo.AllFileFilter;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.ContentResolver;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.InclusionLevel;
 import org.jsonschema2pojo.Jsonschema2Pojo;
@@ -196,6 +197,9 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private boolean includeGeneratedAnnotation = true;
 
     private boolean useJakartaValidation = false;
+
+    private Class<? extends ContentResolver> customContentResolver = ContentResolver.class;
+
     /**
      * Execute this task (it's expected that all relevant setters will have been
      * called by Ant to provide task configuration <em>before</em> this method
@@ -983,6 +987,19 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
             .collect(Collectors.toMap(m -> m.split(":")[0], m -> m.split(":")[1]));
     }
 
+    @SuppressWarnings("unchecked")
+    public void setCustomContentResolver(String customContentResolver) {
+        if (isNotBlank(customContentResolver)) {
+            try {
+                this.customContentResolver = (Class<? extends ContentResolver>) Class.forName(customContentResolver);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
+        } else {
+            this.customContentResolver = ContentResolver.class;
+        }
+    }
+
     @Override
     public boolean isGenerateBuilders() {
         return generateBuilders;
@@ -1334,5 +1351,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseJakartaValidation() {
         return useJakartaValidation;
+    }
+
+    @Override
+    public Class<? extends ContentResolver> getCustomContentResolver() {
+        return customContentResolver;
     }
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -632,6 +632,15 @@
       </td>
       <td align="center" valign="top">No (default <code>false</code>)</td>
   </tr>
+  <tr>
+    <td valign="top">customContentResolver</td>
+    <td valign="top">
+      <p>A fully qualified class name, referring to a content resolver class that extends <code>org.jsonschema2pojo.ContentResolver</code>.
+      </p>
+      <p>By specifying a custom implementation you can customize most aspects of resolving schemas.</p>
+    </td>
+    <td align="center" valign="top">No</td>
+  </tr>
 </table>
 <h3>Examples</h3>
 <pre>

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.jsonschema2pojo.AllFileFilter;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.Annotator;
+import org.jsonschema2pojo.ContentResolver;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.InclusionLevel;
 import org.jsonschema2pojo.NoopAnnotator;
@@ -248,6 +249,9 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "--useJakartaValidation" }, description = "Whether to use annotations from jakarta.validation package instead of javax.validation package when adding JSR-303/349 annotations to generated Java types")
     private boolean useJakartaValidation = false;
+
+    @Parameter(names = { "-CR", "--custom-content-resolver" }, description = "The fully qualified class name referring to a custom content resolver class that extends org.jsonschema2pojo.ContentResolver to customize content resolution for code generation.", converter = ClassConverter.class)
+    private Class<? extends ContentResolver> customContentResolver = ContentResolver.class;
 
     private static final int EXIT_OKAY = 0;
     private static final int EXIT_ERROR = 1;
@@ -613,5 +617,10 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isUseJakartaValidation() {
         return useJakartaValidation;
+    }
+
+    @Override
+    public Class<? extends ContentResolver> getCustomContentResolver() {
+        return customContentResolver;
     }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/ContentResolver.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/ContentResolver.java
@@ -37,15 +37,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class ContentResolver {
 
-    private static final Set<String> CLASSPATH_SCHEMES = new HashSet<>(asList("classpath", "resource", "java"));
+    protected static final Set<String> CLASSPATH_SCHEMES = new HashSet<>(asList("classpath", "resource", "java"));
     
-    private final ObjectMapper objectMapper;
+    protected final ObjectMapper objectMapper;
 
-    public ContentResolver() {
-        this(null);
+    protected GenerationConfig config;
+
+    public ContentResolver(GenerationConfig config) {
+        this(null, config);
     }
 
-    public ContentResolver(JsonFactory jsonFactory) {
+    public ContentResolver(JsonFactory jsonFactory, GenerationConfig config) {
+        this.config = config;
         this.objectMapper = new ObjectMapper(jsonFactory)
                 .enable(JsonParser.Feature.ALLOW_COMMENTS)
                 .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
@@ -82,7 +85,7 @@ public class ContentResolver {
 
     }
 
-    private JsonNode resolveFromClasspath(URI uri) {
+    protected JsonNode resolveFromClasspath(URI uri) {
 
         String path = removeStart(removeStart(uri.toString(), uri.getScheme() + ":"), "/");
         InputStream contentAsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -494,4 +494,9 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isUseJakartaValidation() {
         return false;
     }
+
+    @Override
+    public Class<? extends ContentResolver> getCustomContentResolver() {
+        return ContentResolver.class;
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -626,4 +626,11 @@ public interface GenerationConfig {
    */
   boolean isUseJakartaValidation();
 
+  /**
+   * Gets the 'customContentResolver' configuration option.
+   *
+   * @return A content resolver that will be used in addition to the default one
+   */
+  Class<? extends ContentResolver> getCustomContentResolver();
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -33,7 +33,7 @@ public class SchemaStore {
     protected final ContentResolver contentResolver;
 
     public SchemaStore() {
-        this.contentResolver = new ContentResolver();
+        this.contentResolver = new ContentResolver(null);
     }
 
     public SchemaStore(ContentResolver contentResolver) {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverNetworkTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverNetworkTest.java
@@ -52,7 +52,7 @@ public class ContentResolverNetworkTest {
         server.stop();
     }
 
-    private ContentResolver resolver = new ContentResolver();
+    private ContentResolver resolver = new ContentResolver(null);
     
     @Test(expected=IllegalArgumentException.class)
     public void brokenLinkCausesIllegalArgumentException() {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class ContentResolverTest {
 
-    private ContentResolver resolver = new ContentResolver();
+    private ContentResolver resolver = new ContentResolver(null);
     
     @Test(expected=IllegalArgumentException.class)
     public void wrongProtocolCausesIllegalArgumentException() {

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -295,6 +295,10 @@ jsonSchema2Pojo {
   // Whether to use annotations from jakarta.validation package instead of javax.validation package
   // when adding JSR-303 annotations to generated Java types
   useJakartaValidation = false
+
+  // A class that extends org.jsonschema2pojo.ContentResolver and will be used to
+  // resolve schemas for code generation.
+  customContentResolver = com.MyCustomContentResolver
 }
 ```
 

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -18,6 +18,7 @@ package org.jsonschema2pojo.gradle
 import org.jsonschema2pojo.AnnotationStyle
 import org.jsonschema2pojo.Annotator
 import org.jsonschema2pojo.AllFileFilter
+import org.jsonschema2pojo.ContentResolver
 import org.jsonschema2pojo.GenerationConfig
 import org.jsonschema2pojo.InclusionLevel
 import org.jsonschema2pojo.NoopAnnotator
@@ -97,6 +98,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   Map<String, String> formatTypeMapping
   boolean includeGeneratedAnnotation
   boolean useJakartaValidation
+  Class<? extends ContentResolver> customContentResolver
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -158,6 +160,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     formatTypeMapping = Collections.emptyMap()
     includeGeneratedAnnotation = true
     useJakartaValidation = false
+    customContentResolver = ContentResolver.class
   }
 
   @Override
@@ -224,6 +227,10 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeConstructorPropertiesAnnotation = enabled
   }
 
+  public void setCustomContentResolver(String clazz) {
+    customContentResolver = Class.forName(clazz, true, this.class.classLoader)
+  }
+
   @Override
   public String toString() {
     """|generateBuilders = ${generateBuilders}
@@ -288,6 +295,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeConstructorPropertiesAnnotation = ${includeConstructorPropertiesAnnotation}
        |includeGeneratedAnnotation = ${includeGeneratedAnnotation}
        |useJakartaValidation = ${useJakartaValidation}
+       |customContentResolver = ${customContentResolver.getName()}
      """.stripMargin()
   }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomContentResolverIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomContentResolverIT.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.jsonschema2pojo.ContentResolver;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.jsonschema2pojo.rules.FormatRule;
+import org.jsonschema2pojo.rules.Rule;
+import org.jsonschema2pojo.rules.RuleFactory;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JType;
+
+public class CustomContentResolverIT {
+
+    @org.junit.Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void customContentResolverIsAbelToResolveUrn() throws ClassNotFoundException, SecurityException, NoSuchMethodException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/subtypeOfUrn.json", "com.example",
+                config("customContentResolver", TestContentResolver.class.getName()));
+
+        Class subtype = resultsClassLoader.loadClass("com.example.SubtypeOfUrn");
+        Class supertype = resultsClassLoader.loadClass("com.example.A");
+
+        assertThat(subtype.getSuperclass(), is(equalTo(supertype)));
+    }
+
+    public static class TestContentResolver extends ContentResolver {
+        public TestContentResolver(JsonFactory factory, GenerationConfig config) {
+            super(factory, config);
+        }
+
+        public TestContentResolver(GenerationConfig config) {
+            super(config);
+        }
+
+        Map<URI, URI> map = Map.of(URI.create("urn:jsonschema2pojo:it:a"), URI.create("/schema/extends/a.json"));
+
+        @Override
+        public JsonNode resolve(URI uri) {
+            if (map.get(uri) != null) {
+                return super.resolve(map.get(uri));
+            }
+
+            return super.resolve(uri);
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfUrn.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/extends/subtypeOfUrn.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "extends": {
+        "$ref": "urn:jsonschema2pojo:it:a"
+    },
+    "properties": {
+        "parent": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -39,6 +39,7 @@ import org.jsonschema2pojo.AllFileFilter;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.AnnotatorFactory;
+import org.jsonschema2pojo.ContentResolver;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.InclusionLevel;
 import org.jsonschema2pojo.Jsonschema2Pojo;
@@ -820,6 +821,17 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean useJakartaValidation = false;
 
     /**
+     * A fully qualified class name, referring to a class that extends
+     * <code>org.jsonschema2pojo.ContentResolver</code> and will be used to
+     * resolve schemas for code generation.
+     *
+     * @parameter property="jsonschema2pojo.customContentResolver"
+     *            default-value="org.jsonschema2pojo.ContentResolver"
+     * @since 1.1.3
+     */
+    private String customContentResolver = ContentResolver.class.getName();
+
+    /**
      * Executes the plugin, to read the given source and behavioural properties
      * and generate POJOs. The current implementation acts as a wrapper around
      * the command line interface.
@@ -1274,5 +1286,19 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isUseJakartaValidation() {
         return useJakartaValidation;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends ContentResolver> getCustomContentResolver() {
+        if (isNotBlank(customContentResolver)) {
+            try {
+                return (Class<? extends ContentResolver>) Class.forName(customContentResolver);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
+        } else {
+            return ContentResolver.class;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for prodiving a custom `ContentResolver` implementation. This e.g. allows implementing a custom resolution for URNs (originally requested here https://github.com/joelittlejohn/jsonschema2pojo/issues/412).

This PR also passes the `GenerationConfig` to the custom `ContentResolver` so one could potentially build up a map of URN IDs to JSON schemas on the classpath by parsing the schema files referenced in `GenerationConfig.getSource()`.