### PR TITLE
fix(sec): upgrade jcommander to 1.75

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.30</version>
+                <version>1.75</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgrade jcommander from 1.30 to 1.75 for vulnerability fix:
- [MPS-2022-12225](https://www.oscs1024.com/hd/MPS-2022-12225)