### PR TITLE
correct gradle default values for includeGetters/includeSetters

### DIFF
--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -218,10 +218,10 @@ jsonSchema2Pojo {
   serializable = false
 
   // Whether to include getters or to omit these accessor methods and create public fields instead.
-  includeGetters = false
+  includeGetters = true
 
   // Whether to include setters or to omit these accessor methods and create public fields instead.
-  includeSetters = false
+  includeSetters = true
 
   // Whether to include dynamic getters, setters, and builders or to omit these methods.
   includeDynamicAccessors = false


### PR DESCRIPTION
The default for both values is `true`, according to
 https://github.com/joelittlejohn/jsonschema2pojo/blob/2d55620ac925ff7406f2982a2c37d49a6697cd20/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy#L146-L147