### PR TITLE
Fix: fixed underscore management to JSON schema

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -61,6 +61,9 @@ public class NameHelper {
     public String capitalizeTrailingWords(String name) {
         char[] wordDelimiters = generationConfig.getPropertyWordDelimiters();
 
+        if(name.equals("_")){
+            name = "underscore";
+        }
         if (containsAny(name, wordDelimiters)) {
             String capitalizedNodeName;
             if (areAllWordsUpperCaseBesideDelimiters(name, wordDelimiters)) {


### PR DESCRIPTION
Hi everybody,

We are working with the UBL Invoices JSON schema (http://docs.oasis-open.org/ubl/UBL-2.1-JSON/). 

During class generation using the _jsonschema2pojo-maven-plugin_, we get the following exception: _"Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 0" (https://github.com/joelittlejohn/jsonschema2pojo/issues/632)

After code investigation, we found out the character "_" was identified as illegal, then it has removed from the name.

We cannot modify the UBL schema, because we need to build a maintainable application. For this reason, we propose substituting "_" with "underscore" in this fix to avoid a library broke down.

Thanks to everybody.
Simone