### PR TITLE
Let AnnotationHelper respect targetVersion

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -151,7 +151,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
         EnumDefinition enumDefinition = buildEnumDefinition(nodeName, node, backingType);
 
         if(ruleFactory.getGenerationConfig() != null && ruleFactory.getGenerationConfig().isIncludeGeneratedAnnotation()) {
-            AnnotationHelper.addGeneratedAnnotation(_enum);
+            AnnotationHelper.addGeneratedAnnotation(ruleFactory.getGenerationConfig(), _enum);
         }
 
         JFieldVar valueField = addConstructorAndFields(enumDefinition, _enum);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -133,7 +133,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         }
        
         if (ruleFactory.getGenerationConfig().isIncludeGeneratedAnnotation()) {
-        	AnnotationHelper.addGeneratedAnnotation(jclass);
+        	AnnotationHelper.addGeneratedAnnotation(ruleFactory.getGenerationConfig(), jclass);
         }
         if (ruleFactory.getGenerationConfig().isIncludeToString()) {
             addToString(jclass);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/AnnotationHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/AnnotationHelper.java
@@ -16,6 +16,9 @@
 
 package org.jsonschema2pojo.util;
 
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.util.LanguageFeatures;
+
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JDefinedClass;
@@ -36,13 +39,14 @@ public class AnnotationHelper {
         } catch (ClassNotFoundException e) {
             return false;
         }
-
     }
 
-    public static void addGeneratedAnnotation(JDefinedClass jclass) {
-        if (!tryToAnnotate(jclass, JAVA_9_GENERATED)) {
-            tryToAnnotate(jclass, JAVA_8_GENERATED);
+    public static void addGeneratedAnnotation(GenerationConfig config, JDefinedClass jclass) {
+        if (LanguageFeatures.canUseJava9(config)) {
+            if (tryToAnnotate(jclass, JAVA_9_GENERATED)) {
+                return;
+            }
         }
+        tryToAnnotate(jclass, JAVA_8_GENERATED);
     }
-
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/LanguageFeatures.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/LanguageFeatures.java
@@ -24,6 +24,7 @@ import org.jsonschema2pojo.GenerationConfig;
 
 public class LanguageFeatures {
 
+    private static final Collection<String> LESS_THAN_9 = asList("1.1", "1.2", "1.3", "1.4", "1.5", "5", "1.6", "6", "1.7", "7", "1.8", "8");
     private static final Collection<String> LESS_THAN_8 = asList("1.1", "1.2", "1.3", "1.4", "1.5", "5", "1.6", "6", "1.7", "7");
     private static final Collection<String> LESS_THAN_7 = asList("1.1", "1.2", "1.3", "1.4", "1.5", "5", "1.6", "6");
 
@@ -33,5 +34,9 @@ public class LanguageFeatures {
 
     public static boolean canUseJava8(GenerationConfig config) {
         return !LESS_THAN_8.contains(config.getTargetVersion());
+    }
+
+    public static boolean canUseJava9(GenerationConfig config) {
+        return !LESS_THAN_9.contains(config.getTargetVersion());
     }
 }


### PR DESCRIPTION
this should avoid the problem of using the wrong annotation when building on jdk 11 but targeting java 8