### PR TITLE
Add Email bean validation annotation for "format":"email"

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -16,7 +16,6 @@
 
 package org.jsonschema2pojo.rules;
 
-import org.apache.commons.lang.StringUtils;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.JsonPointerUtils;
 import org.jsonschema2pojo.Schema;
@@ -31,6 +30,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Applies the schema rules that represent a property definition.
@@ -201,6 +201,12 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
             ruleFactory.getAnnotator().dateField(field, clazz, node);
         } else if ("time".equalsIgnoreCase(format)) {
             ruleFactory.getAnnotator().timeField(field, clazz, node);
+        } else if ("email".equalsIgnoreCase(format) && ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
+            if (ruleFactory.getGenerationConfig().isUseJakartaValidation()) {
+                field.annotate(jakarta.validation.constraints.Email.class);
+            } else {
+                field.annotate(javax.validation.constraints.Email.class);
+            }
         }
     }
 

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -154,9 +154,7 @@
         <!-- javax.validation implementation dependencies: start -->
         <dependency>
             <groupId>org.apache.bval</groupId>
-            <artifactId>bval-jsr303</artifactId>
-            <version>0.5</version>
-            <scope>test</scope>
+            <artifactId>bval-jsr</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/email.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/email.json
@@ -1,0 +1,9 @@
+{
+  "type" : "object",
+  "properties" : {
+    "email" : {
+      "type" : "string",
+      "format": "email"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
             <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
-                <version>1.1.0.Final</version>
+                <version>2.0.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>
@@ -357,6 +357,12 @@
                 <version>1.10.13</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.bval</groupId>
+                <artifactId>bval-jsr</artifactId>
+                <version>2.0.6</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>2.2.1</version>
@@ -386,7 +392,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>7.0.1.Final</version>
+                <version>7.0.5.Final</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Things to consider if are using the includeJsr303Annotations feature:

* If you have useJakartaValidation turned on, you'll now see `jakarta.validation.constraints.Email` added to a property when using `"format":"email"`.
* If don't have useJakartaValidation turned on, you'll now see [`javax.validation.constraints.Email`](https://javaee.github.io/javaee-spec/javadocs/javax/validation/constraints/Email.html) added to a property when using `"format":"email"`.
  * The Email annotation is introduced in the bean validation spec 2.0, so you will need to upgrade to javax.validation:validation-api 2.x (2.0.1.Final is a good choice). Note, all old annoations are maintained (with the same fully-qualified name) so upgrading this should not break anything.
  * If email validation is still not happening, your validator might only be doing bean validation 1.0 or 1.1 validations. You would then need to upgrade your validator (e.g. with bval, [upgrade to 2.0.5 or later](https://bval.apache.org/downloads.html)).