### PR TITLE
Add Javadoc to constructors parameters for properties that have title/description/$comment

### DIFF
--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -180,7 +180,7 @@
             <artifactId>robolectric</artifactId>
         </dependency>
         <dependency>
-            <groupId>qdox</groupId>
+            <groupId>com.thoughtworks.qdox</groupId>
             <artifactId>qdox</artifactId>
         </dependency>
         <dependency>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -74,8 +73,7 @@ public class ConstructorsIT {
   }
 
 
-  @Ignore
-  public static class ConstructorTestClasses {
+  private static class ConstructorTestClasses {
 
     protected Class<?> typeWithoutProperties;
     protected Class<?> typeWithoutRequiredProperties;
@@ -104,7 +102,7 @@ public class ConstructorsIT {
   /**
    * Tests what happens when includeConstructors is set to true
    */
-  public static class DefaultInlcudeConstructorsIT {
+  public static class DefaultIncludeConstructorsIT {
 
     @ClassRule
     public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
@@ -126,7 +124,7 @@ public class ConstructorsIT {
     }
 
     @Test
-    public void testGeneratesCosntructorWithAllPropertiesArrayStyle() throws Exception {
+    public void testGeneratesConstructorWithAllPropertiesArrayStyle() throws Exception {
       assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequiredArray).getModifiers(), "public");
     }
 
@@ -225,7 +223,7 @@ public class ConstructorsIT {
     }
 
     @Test
-    public void testGeneratesCosntructorWithAllPropertiesArrayStyle() throws Exception {
+    public void testGeneratesConstructorWithAllPropertiesArrayStyle() throws Exception {
       assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequiredArray).getModifiers(), "public");
     }
 
@@ -297,7 +295,7 @@ public class ConstructorsIT {
     }
 
     @Test
-    public void testGeneratesCosntructorWithAllPropertiesArrayStyle() throws Exception {
+    public void testGeneratesConstructorWithAllPropertiesArrayStyle() throws Exception {
       assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequiredArray).getModifiers(), "public");
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsJavadocIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsJavadocIT.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Matcher;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.thoughtworks.qdox.JavaProjectBuilder;
+import com.thoughtworks.qdox.model.DocletTag;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaConstructor;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
+
+@RunWith(Enclosed.class)
+public class ConstructorsJavadocIT {
+
+    private static final DefaultJavaClass cString = new DefaultJavaClass(String.class.getName());
+    private static final DefaultJavaClass cDouble = new DefaultJavaClass(Double.class.getName());
+
+    @RunWith(Parameterized.class)
+    public static class ConstructorWithRequiredPropertiesOnlyIT {
+
+        @Parameters(name = "{0}")
+        public static Collection<String> data() {
+            return asList("constructorsRequiredPropertiesOnly", "includeRequiredPropertiesConstructor");
+        }
+
+        @Rule
+        public final Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+        private final String configuration;
+
+        public ConstructorWithRequiredPropertiesOnlyIT(String configuration) {
+            this.configuration = configuration;
+        }
+
+        @Test
+        public void requiredPropertiesConstructor_hasJavadocForDocumentedProperties() throws IOException {
+            JavaClass javaClass = buildJavadocClass(
+                    schemaRule,
+                    config("includeConstructors", true, "includeAllPropertiesConstructor", false, configuration, true));
+
+            assertThat(javaClass.getConstructors().size(), is(2));
+            assertNoArgConstructor(javaClass.getConstructor(Collections.emptyList()));
+            final List<String> paramTagValues = getParamTagValues(javaClass.getConstructor(asList(cString, cString, cString, cString, cDouble, cDouble)));
+            // 3 documented properties in sub class and 2 documented from super class
+            assertThat(paramTagValues.size(), is(5));
+            assertSuperClassDocumentedProperties(paramTagValues);
+            assertThat(paramTagValues, hasItemContaining("descriptionOnly", "A description_only description."));
+            assertThat(paramTagValues, hasItemContaining("titleAndDescription", "A title_and_description title. A title_and_description description."));
+            assertThat(paramTagValues, hasItemContaining("tileOnly", "A title_only title."));
+        }
+    }
+
+    public static class ConstructorWithAllPropertiesIT {
+
+        @Rule
+        public final Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+        @Test
+        public void allPropertiesConstructor_hasJavadocForDocumentedProperties() throws IOException {
+            // 'constructorsRequiredPropertiesOnly' is false and 'includeAllPropertiesConstructor' is true by default
+            JavaClass javaClass = buildJavadocClass(schemaRule, config("includeConstructors", true));
+
+            assertThat(javaClass.getConstructors().size(), is(2));
+            assertNoArgConstructor(javaClass.getConstructor(Collections.emptyList()));
+            final List<String> paramTagValues = getParamTagValues(javaClass.getConstructor(
+                            asList(cString, cString, cString, cString, cString, cString, cString, cString, cDouble, cDouble, cDouble)));
+            // 6 documented properties in sub class and 2 documented from super class
+            assertThat(paramTagValues.size(), is(8));
+            assertThat(paramTagValues, hasItemContaining("descriptionOnly", "A description_only description."));
+            assertThat(paramTagValues, hasItemContaining("nonRequiredTileOnly", "A non_required_tile_only title."));
+            assertThat(paramTagValues, hasItemContaining("titleAndDescription", "A title_and_description title. A title_and_description description."));
+            assertThat(paramTagValues, hasItemContaining("nonRequiredDescriptionOnly", "A non_required_description_only description."));
+            assertThat(paramTagValues, hasItemContaining("tileOnly", "A title_only title."));
+            assertThat(paramTagValues, hasItemContaining("nonRequiredTitleAndDescription", "A non_required_title_and_description title. A non_required_title_and_description description."));
+            assertSuperClassDocumentedProperties(paramTagValues);
+        }
+
+    }
+
+    public static class IncludeCopyConstructorIT {
+
+        @Rule
+        public final Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+        @Test
+        public void copyConstructor_hasJavadocForDocumentedProperties() throws IOException {
+            JavaClass javaClass = buildJavadocClass(schemaRule, config("includeConstructors", true, "includeCopyConstructor", true));
+
+            assertNoArgConstructor(javaClass.getConstructor(Collections.emptyList()));
+
+            final List<String> paramTagValues = getParamTagValues(javaClass.getConstructor(Collections.singletonList(javaClass)));
+            assertThat(paramTagValues, hasSize(1));
+            assertThat(paramTagValues, hasItemContaining("source", "the object being copied"));
+        }
+
+    }
+
+    private static JavaClass buildJavadocClass(Jsonschema2PojoRule schemaRule, Map<String, Object> config) throws IOException {
+        schemaRule.generateAndCompile("/schema/constructors/javadoc/javadocConstructor.json", "com.example", config);
+
+        final JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
+        javaDocBuilder.addSource(schemaRule.generated("com/example/JavadocConstructor.java"));
+        return javaDocBuilder.getClassByName("com.example.JavadocConstructor");
+    }
+
+    private static List<String> getParamTagValues(JavaConstructor javaConstructor) {
+        return javaConstructor.getTagsByName("param").stream().map(DocletTag::getValue).collect(Collectors.toList());
+    }
+
+    private static void assertNoArgConstructor(JavaConstructor noArgConstructor) {
+        assertThat(noArgConstructor.getComment(), equalTo("No args constructor for use in serialization"));
+    }
+
+    private static void assertSuperClassDocumentedProperties(List<String> paramTagValues) {
+        assertThat(paramTagValues, hasItemContaining("scPropertyWTitle", "A sc_property_w_title title."));
+        assertThat(paramTagValues, hasItemContaining("scPropertyWDescription", "A sc_property_w_description description."));
+    }
+
+    private static Matcher<Iterable<? super String>> hasItemContaining(String first, String second) {
+        return hasItem(both(containsString(first)).and(containsString(second)));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
@@ -27,7 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 
 /*
@@ -46,7 +46,7 @@ public class DescriptionEnumIT {
         schemaRule.generateAndCompile("/schema/description/descriptionEnum.json", "com.example");
         File generatedJavaFile = schemaRule.generated("com/example/DescriptionEnum.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithDescription = javaDocBuilder.getClassByName("com.example.DescriptionEnum");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
@@ -21,17 +21,20 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
-import com.thoughtworks.qdox.model.Type;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class DescriptionIT {
 
@@ -45,7 +48,7 @@ public class DescriptionIT {
         schemaRule.generateAndCompile("/schema/description/description.json", "com.example");
         File generatedJavaFile = schemaRule.generated("com/example/Description.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithDescription = javaDocBuilder.getClassByName("com.example.Description");
@@ -73,7 +76,7 @@ public class DescriptionIT {
     @Test
     public void descriptionAppearsInGetterJavadoc() {
 
-        JavaMethod javaMethod = classWithDescription.getMethodBySignature("getDescription", new Type[] {});
+        JavaMethod javaMethod = classWithDescription.getMethodBySignature("getDescription", Collections.emptyList());
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("A description for this property"));
@@ -83,7 +86,8 @@ public class DescriptionIT {
     @Test
     public void descriptionAppearsInSetterJavadoc() {
 
-        JavaMethod javaMethod = classWithDescription.getMethodBySignature("setDescription", new Type[] { new Type("java.lang.String") });
+        final List<JavaType> parameterTypes = Collections.singletonList(new DefaultJavaClass("java.lang.String"));
+        JavaMethod javaMethod = classWithDescription.getMethodBySignature("setDescription", parameterTypes);
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("A description for this property"));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DollarCommentIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DollarCommentIT.java
@@ -16,11 +16,13 @@
 
 package org.jsonschema2pojo.integration;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
-import com.thoughtworks.qdox.model.Type;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
+
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -28,6 +30,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -44,7 +48,7 @@ public class DollarCommentIT {
         schemaRule.generateAndCompile("/schema/dollar_comment/dollar_comment.json", "com.example");
         File generatedJavaFile = schemaRule.generated("com/example/DollarComment.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithDescription = javaDocBuilder.getClassByName("com.example.DollarComment");
@@ -72,7 +76,7 @@ public class DollarCommentIT {
     @Test
     public void dollarCommentAppearsInGetterJavadoc() {
 
-        JavaMethod javaMethod = classWithDescription.getMethodBySignature("getWithComment", new Type[] {});
+        JavaMethod javaMethod = classWithDescription.getMethodBySignature("getWithComment", Collections.emptyList());
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("JavaDoc linking to {@link #descriptionAndComment}"));
@@ -82,7 +86,8 @@ public class DollarCommentIT {
     @Test
     public void dollarCommentAppearsInSetterJavadoc() {
 
-        JavaMethod javaMethod = classWithDescription.getMethodBySignature("setWithComment", new Type[] { new Type("java.lang.String") });
+        final List<JavaType> parameterTypes = Collections.singletonList(new DefaultJavaClass("java.lang.String"));
+        JavaMethod javaMethod = classWithDescription.getMethodBySignature("setWithComment", parameterTypes);
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("JavaDoc linking to {@link #descriptionAndComment}"));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 
@@ -138,7 +138,7 @@ public class JavaNameIT {
         schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
         File generatedJavaFile = schemaRule.generated("com/example/javaname/JavaName.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         JavaClass classWithDescription = javaDocBuilder.getClassByName("com.example.javaname.JavaName");
@@ -174,7 +174,7 @@ public class JavaNameIT {
         schemaRule.generateAndCompile("/schema/javaName/javaNameWithRequiredProperties.json", "com.example.required");
         File generatedJavaFileWithRequiredProperties = schemaRule.generated("com/example/required/JavaNameWithRequiredProperties.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFileWithRequiredProperties);
 
         JavaClass classWithRequiredProperties = javaDocBuilder.getClassByName("com.example.required.JavaNameWithRequiredProperties");
@@ -192,7 +192,7 @@ public class JavaNameIT {
         schemaRule.generateAndCompile("/schema/javaName/javaNameWithRequiredProperties.json", "com.example.required");
         File generatedJavaFileWithRequiredProperties = schemaRule.generated("com/example/required/JavaNameWithRequiredProperties.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFileWithRequiredProperties);
 
         JavaClass classWithRequiredProperties = javaDocBuilder.getClassByName("com.example.required.JavaNameWithRequiredProperties");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
@@ -21,17 +21,20 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
-import com.thoughtworks.qdox.model.Type;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class RequiredArrayIT extends RequiredIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
@@ -44,7 +47,7 @@ public class RequiredArrayIT extends RequiredIT {
         classSchemaRule.generateAndCompile("/schema/required/requiredArray.json", "com.example");
         File generatedJavaFile = classSchemaRule.generated("com/example/RequiredArray.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithRequired = javaDocBuilder.getClassByName("com.example.RequiredArray");
@@ -63,7 +66,7 @@ public class RequiredArrayIT extends RequiredIT {
     @Test
     public void requiredAppearsInGetterJavadoc() {
 
-        JavaMethod javaMethod = classWithRequired.getMethodBySignature("getRequiredProperty", new Type[] {});
+        JavaMethod javaMethod = classWithRequired.getMethodBySignature("getRequiredProperty", Collections.emptyList());
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("(Required)"));
@@ -73,7 +76,8 @@ public class RequiredArrayIT extends RequiredIT {
     @Test
     public void requiredAppearsInSetterJavadoc() {
 
-        JavaMethod javaMethod = classWithRequired.getMethodBySignature("setRequiredProperty", new Type[] { new Type("java.lang.String") });
+        final List<JavaType> parameterTypes = Collections.singletonList(new DefaultJavaClass("java.lang.String"));
+        JavaMethod javaMethod = classWithRequired.getMethodBySignature("setRequiredProperty", parameterTypes);
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("(Required)"));
@@ -81,7 +85,7 @@ public class RequiredArrayIT extends RequiredIT {
     }
 
     @Test
-    public void nonRequiredFiedHasNoRequiredText() {
+    public void nonRequiredFieldHasNoRequiredText() {
 
         JavaField javaField = classWithRequired.getFieldByName("nonRequiredProperty");
         String javaDocComment = javaField.getComment();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
@@ -21,17 +21,20 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
-import com.thoughtworks.qdox.model.Type;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class RequiredIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
@@ -44,7 +47,7 @@ public class RequiredIT {
         classSchemaRule.generateAndCompile("/schema/required/required.json", "com.example");
         File generatedJavaFile = classSchemaRule.generated("com/example/Required.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithRequired = javaDocBuilder.getClassByName("com.example.Required");
@@ -63,7 +66,7 @@ public class RequiredIT {
     @Test
     public void requiredAppearsInGetterJavadoc() {
 
-        JavaMethod javaMethod = classWithRequired.getMethodBySignature("getRequiredProperty", new Type[] {});
+        JavaMethod javaMethod = classWithRequired.getMethodBySignature("getRequiredProperty", Collections.emptyList());
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("(Required)"));
@@ -73,7 +76,8 @@ public class RequiredIT {
     @Test
     public void requiredAppearsInSetterJavadoc() {
 
-        JavaMethod javaMethod = classWithRequired.getMethodBySignature("setRequiredProperty", new Type[] { new Type("java.lang.String") });
+        final List<JavaType> parameterTypes = Collections.singletonList(new DefaultJavaClass("java.lang.String"));
+        JavaMethod javaMethod = classWithRequired.getMethodBySignature("setRequiredProperty", parameterTypes);
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("(Required)"));
@@ -81,7 +85,7 @@ public class RequiredIT {
     }
 
     @Test
-    public void nonRequiredFiedHasNoRequiredText() {
+    public void nonRequiredFieldHasNoRequiredText() {
 
         JavaField javaField = classWithRequired.getFieldByName("nonRequiredProperty");
         String javaDocComment = javaField.getComment();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
@@ -27,7 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 
 /*
@@ -45,7 +45,7 @@ public class TitleEnumIT {
         classSchemaRule.generateAndCompile("/schema/title/titleEnum.json", "com.example");
         File generatedJavaFile = classSchemaRule.generated("com/example/TitleEnum.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithTitle = javaDocBuilder.getClassByName("com.example.TitleEnum");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
@@ -21,17 +21,20 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
-import com.thoughtworks.qdox.model.Type;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class TitleIT {
     @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
@@ -44,7 +47,7 @@ public class TitleIT {
         classSchemaRule.generateAndCompile("/schema/title/title.json", "com.example");
         File generatedJavaFile = classSchemaRule.generated("com/example/Title.java");
 
-        JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
         javaDocBuilder.addSource(generatedJavaFile);
 
         classWithTitle = javaDocBuilder.getClassByName("com.example.Title");
@@ -72,7 +75,7 @@ public class TitleIT {
     @Test
     public void descriptionAppearsInGetterJavadoc() {
 
-        JavaMethod javaMethod = classWithTitle.getMethodBySignature("getTitle", new Type[] {});
+        JavaMethod javaMethod = classWithTitle.getMethodBySignature("getTitle", Collections.emptyList());
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("A title for this property"));
@@ -82,7 +85,8 @@ public class TitleIT {
     @Test
     public void descriptionAppearsInSetterJavadoc() {
 
-        JavaMethod javaMethod = classWithTitle.getMethodBySignature("setTitle", new Type[] { new Type("java.lang.String") });
+        final List<JavaType> parameterTypes = Collections.singletonList(new DefaultJavaClass("java.lang.String"));
+        JavaMethod javaMethod = classWithTitle.getMethodBySignature("setTitle", parameterTypes);
         String javaDocComment = javaMethod.getComment();
 
         assertThat(javaDocComment, containsString("A title for this property"));

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/javadoc/javadocConstructor.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/constructors/javadoc/javadocConstructor.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "extends": {
+    "$ref": "#/$defs/super_type"
+  },
+  "properties": {
+    "non_documented": {
+      "type": "string",
+      "description": null,
+      "title": null,
+      "required": true
+    },
+    "tile_only": {
+      "type": "string",
+      "title": "A title_only title",
+      "required": true
+    },
+    "description_only": {
+      "type": "string",
+      "description": "A description_only description.",
+      "required": true
+    },
+    "title_and_description": {
+      "type": "string",
+      "title": "A title_and_description title.",
+      "description": "A title_and_description description",
+      "required": true
+    },
+    "non_required_non_documented": {
+      "type": "string"
+    },
+    "non_required_tile_only": {
+      "type": "string",
+      "title": "A non_required_tile_only title."
+    },
+    "non_required_description_only": {
+      "type": "string",
+      "description": "A non_required_description_only description"
+    },
+    "non_required_title_and_description": {
+      "type": "string",
+      "title": "A non_required_title_and_description title",
+      "description": "A non_required_title_and_description description."
+    }
+  },
+  "$defs": {
+    "super_type": {
+      "type": "object",
+      "properties": {
+        "undocumented_sc_property": {
+          "type": "number"
+        },
+        "sc_property_w_title": {
+          "type": "number",
+          "title": "A sc_property_w_title title",
+          "required": true
+        },
+        "sc_property_w_description": {
+          "type": "number",
+          "description": "A sc_property_w_description description",
+          "required": true
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -410,9 +410,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>qdox</groupId>
+                <groupId>com.thoughtworks.qdox</groupId>
                 <artifactId>qdox</artifactId>
-                <version>1.6.1</version>
+                <version>2.0.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Add Javadoc to constructors parameters which have corresponding documented properties.
Properties that are not documented (do not have `title` or `description`) won't be added to constructors Javadoc.

Following format will be used:
```java
/**
 * {@param {title. }?{description.}?}?
 */
```

Closes #1463