### PR TITLE
Fix detection of targetVersion for Android gradle builds

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,9 +13,6 @@ jobs:
   buildTest:
     name: Build JDK ${{ matrix.java_version }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: jsonschema2pojo-gradle-plugin/example/android
     strategy:
       matrix:
         java_version: [8]
@@ -31,5 +28,7 @@ jobs:
           distribution: temurin
       - name: Install Android SDK
         uses: malinskiy/action-android/install-sdk@release/0.1.1
-      - name: Build project
-        run: ./gradlew assembleDebug
+      - name: Install latest jsonschema2pojo SNAPSHOT
+        run: mvn -B install -DskipTests -Dmaven.javadoc.skip -Dmaven.site.skip
+      - name: Build projects
+        run: cd jsonschema2pojo-gradle-plugin/example/android && ./gradlew --info assembleDebug

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaAndroidTask.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/GenerateJsonSchemaAndroidTask.groovy
@@ -62,9 +62,13 @@ class GenerateJsonSchemaAndroidTask extends SourceTask {
 
   void setTargetVersion(JsonSchemaExtension configuration) {
     if (!configuration.targetVersion) {
-      def compileJavaTask = project.getTasksByName("compileJava", false).first()
-      configuration.targetVersion = compileJavaTask.getProperties().get("sourceCompatibility")
-      logger.info 'Using Gradle sourceCompatibility as targetVersion for jsonschema2pojo: ' + configuration.targetVersion
+      if (project.plugins.hasPlugin("com.android.application")) {
+        configuration.targetVersion = project.plugins.getPlugin("com.android.application").extension.compileOptions.sourceCompatibility
+        logger.info 'Using android.compileOptions.sourceCompatibility as targetVersion for jsonschema2pojo: ' + configuration.targetVersion
+      } else if (project.plugins.hasPlugin("com.android.library")) {
+        configuration.targetVersion = project.plugins.getPlugin("com.android.library").extension.compileOptions.sourceCompatibility
+        logger.info 'Using android.compileOptions.sourceCompatibility as targetVersion for jsonschema2pojo: ' + configuration.targetVersion
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes the broken targetVersion detection for Gradle Android builds, and also updates the Android Sample GitHub action so that it actually runs against the HEAD code (rather than the latest release). 