### PR TITLE
Feature to exclude property from generated toString

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -135,7 +135,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
             AnnotationHelper.addGeneratedAnnotation(ruleFactory.getGenerationConfig(), jclass);
         }
         if (ruleFactory.getGenerationConfig().isIncludeToString()) {
-            addToString(jclass);
+            addToString(jclass, node);
         }
 
         if (ruleFactory.getGenerationConfig().isIncludeHashcodeAndEquals()) {
@@ -262,8 +262,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
     }
 
-    private void addToString(JDefinedClass jclass) {
-        Map<String, JFieldVar> fields = jclass.fields();
+    private void addToString(JDefinedClass jclass, JsonNode node) {
+        Map<String, JFieldVar> fields = removeFieldsExcludedFromToString(jclass.fields(), node);
         JMethod toString = jclass.method(JMod.PUBLIC, String.class, "toString");
         Set<String> excludes = new HashSet<>(Arrays.asList(ruleFactory.getGenerationConfig().getToStringExcludes()));
 
@@ -371,6 +371,10 @@ public class ObjectRule implements Rule<JPackage, JType> {
         toString.annotate(Override.class);
     }
 
+    private Map<String, JFieldVar> removeFieldsExcludedFromToString(Map<String, JFieldVar> fields, JsonNode node) {
+        return removeFieldsExcludedByNodeConfig(fields, node, "excludedFromToString");
+    }
+
     private void addHashCode(JDefinedClass jclass, JsonNode node) {
         Map<String, JFieldVar> fields = removeFieldsExcludedFromEqualsAndHashCode(jclass.fields(), node);
 
@@ -427,13 +431,17 @@ public class ObjectRule implements Rule<JPackage, JType> {
     }
 
     private Map<String, JFieldVar> removeFieldsExcludedFromEqualsAndHashCode(Map<String, JFieldVar> fields, JsonNode node) {
+        return removeFieldsExcludedByNodeConfig(fields, node, "excludedFromEqualsAndHashCode");
+    }
+
+    private Map<String, JFieldVar> removeFieldsExcludedByNodeConfig(Map<String, JFieldVar> fields, JsonNode node, String nodeConfigProperty) {
         Map<String, JFieldVar> filteredFields = new HashMap<>(fields);
 
         JsonNode properties = node.get("properties");
 
         if (properties != null) {
-            if (node.has("excludedFromEqualsAndHashCode")) {
-                JsonNode excludedArray = node.get("excludedFromEqualsAndHashCode");
+            if (node.has(nodeConfigProperty)) {
+                JsonNode excludedArray = node.get(nodeConfigProperty);
 
                 for (Iterator<JsonNode> iterator = excludedArray.elements(); iterator.hasNext(); ) {
                     String excludedPropertyName = iterator.next().asText();
@@ -447,8 +455,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
                 String propertyName = entry.getKey();
                 JsonNode propertyNode = entry.getValue();
 
-                if (propertyNode.has("excludedFromEqualsAndHashCode") &&
-                        propertyNode.get("excludedFromEqualsAndHashCode").asBoolean()) {
+                if (propertyNode.has(nodeConfigProperty) &&
+                        propertyNode.get(nodeConfigProperty).asBoolean()) {
                     filteredFields.remove(ruleFactory.getNameHelper().getPropertyName(propertyName, propertyNode));
                 }
             }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromToStringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromToStringIT.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ExcludedFromToStringIT {
+    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static Class<?> clazz;
+
+    @BeforeClass
+    public static void generateAndCompileEnum() throws ClassNotFoundException {
+
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/excludedFromToString/excludedFromToString.json", "com.example");
+
+        clazz = resultsClassLoader.loadClass("com.example.ExcludedFromToString");
+    }
+
+    @Test
+    public void toStringTest() throws IllegalAccessException, InstantiationException, IntrospectionException, InvocationTargetException {
+
+        Object instance = clazz.newInstance();
+
+        setProperty(instance, "excludedByProperty", "one");
+        setProperty(instance, "excludedByArray", "two");
+        setProperty(instance, "notExcluded", "three");
+        setProperty(instance, "notExcludedByProperty", "four");
+
+        String toString = instance.toString();
+        assertThat(toString, not(containsString("excludedByProperty")));
+        assertThat(toString, not(containsString("one")));
+        assertThat(toString, not(containsString("excludedByArray")));
+        assertThat(toString, not(containsString("two")));
+        assertThat(toString, containsString("notExcluded"));
+        assertThat(toString, containsString("three"));
+        assertThat(toString, containsString("notExcludedByProperty"));
+        assertThat(toString, containsString("four"));
+    }
+
+    private static void setProperty(Object instance, String property, String value) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+        new PropertyDescriptor(property, clazz).getWriteMethod().invoke(instance, value);
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/excludedFromToString/excludedFromToString.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/excludedFromToString/excludedFromToString.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "excludedFromToString" : [ "excludedByArray" ],
+  "properties": {
+    "notExcluded" : {
+      "type" : "string"
+    },
+    "excludedByProperty" : {
+      "type" : "string",
+      "excludedFromToString" : true
+    },
+    "notExcludedByProperty" : {
+      "type" : "string",
+      "excludedFromToString" : false
+    },
+    "excludedByArray" : {
+      "type" : "string"
+    }
+  }
+}


### PR DESCRIPTION
Allow `excludedFromToString` feature to be used inside JSON schema.
Useful for marking sensitive information to be generated into `toString()` method.