### PR TITLE
Make equals and hashCode generation deterministic (order of expressions)

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -16,14 +16,17 @@
 
 package org.jsonschema2pojo.rules;
 
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.*;
 import static org.jsonschema2pojo.rules.PrimitiveTypes.*;
 import static org.jsonschema2pojo.util.TypeUtil.*;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -427,7 +430,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
     }
 
     private Map<String, JFieldVar> removeFieldsExcludedFromEqualsAndHashCode(Map<String, JFieldVar> fields, JsonNode node) {
-        Map<String, JFieldVar> filteredFields = new HashMap<>(fields);
+        Map<String, JFieldVar> filteredFields = new LinkedHashMap<>(fields);
 
         JsonNode properties = node.get("properties");
 


### PR DESCRIPTION
# Description

Order of lines of code in the generated `equals` and `hashCode` methods was non-deterministic. This means that the generated files with code have changed between generations (even if nothing has changed in the schema itself).

After the change, the order of these lines will be the same as the order of fields in the schema.

# Example for `hashCode`

For a simple schema that includes two fields: `field1` and `field2`, the generator randomly produced either 

```java
@Override
    public int hashCode() {
        int result = 1;
        result = ((result* 31)+((this.field1 == null)? 0 :this.field1.hashCode()));
        result = ((result* 31)+((this.field2 == null)? 0 :this.field2.hashCode()));
        return result;
    }
```

or 

```java
@Override
    public int hashCode() {
        int result = 1;
        result = ((result* 31)+((this.field2== null)? 0 :this.field2.hashCode()));
        result = ((result* 31)+((this.field1 == null)? 0 :this.field1.hashCode()));
        return result;
    }
```