### PR TITLE
Feature/added required nonnull check

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -66,8 +66,8 @@ import org.jsonschema2pojo.util.URLUtil;
  *      Task</a>
  */
 public class Jsonschema2PojoTask extends Task implements GenerationConfig {
-
-    private boolean generateBuilders;
+	
+	private boolean generateBuilders;
 
     private boolean includeTypeInfo = false;
 
@@ -115,6 +115,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     private boolean includeJsr303Annotations = false;
 
+    private boolean includeRequireNonNullOnRequiredFields = false;
+    
     private boolean includeJsr305Annotations = false;
 
     private boolean useOptionalForGetters;
@@ -947,6 +949,10 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public void setRefFragmentPathDelimiters(String refFragmentPathDelimiters) {
         this.refFragmentPathDelimiters = refFragmentPathDelimiters;
     }
+    
+    public void setIncludeRequireNonNullOnRequiredFields(boolean includeRequireNonNullOnRequiredFields) {
+		this.includeRequireNonNullOnRequiredFields = includeRequireNonNullOnRequiredFields;
+	}
 
     /**
      * Sets the 'sourceSortOrder' property of this class
@@ -1337,5 +1343,9 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     @Override
     public boolean isUseJakartaValidation() {
         return useJakartaValidation;
+    }
+    @Override
+    public boolean isIncludeRequireNonNullOnRequiredFields() {
+    	return includeRequireNonNullOnRequiredFields;
     }
 }

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -294,6 +294,12 @@
     <td align="center" valign="top">No (default <code>true</code>)</td>
   </tr>
   <tr>
+    <td valign="top"><a id="includeRequireNonNullOnRequiredFields"></a>includeRequireNonNullOnRequiredFields</td>
+    <td valign="top">Whether to include <code>java.util.Objects.requireNonNull(property)</code> in each setter for required field
+    </td>
+    <td align="center" valign="top">No (default <code>false</code>)</td>
+  </tr>
+  <tr>
     <td valign="top"><a id="includeJsr303Annotations"></a>includeJsr303Annotations</td>
     <td valign="top">Whether to include <a
         href="http://jcp.org/en/jsr/detail?id=303">JSR-303/349</a> annotations

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -133,6 +133,8 @@ public class Arguments implements GenerationConfig {
 
     @Parameter(names = { "-303", "--jsr303-annotations" }, description = "Add JSR-303/349 annotations to generated Java types.")
     private boolean includeJsr303Annotations = false;
+    @Parameter(names = { "-RN", "--require-nonnull-check" }, description = "Add JSR-303/349 annotations to generated Java types.")
+    private boolean includeRequireNonNullOnRequiredFields = false;
 
     @Parameter(names = { "-305", "--jsr305-annotations" }, description = "Add JSR-305 annotations to generated Java types.")
     private boolean includeJsr305Annotations = false;
@@ -394,6 +396,11 @@ public class Arguments implements GenerationConfig {
         return customRuleFactory;
     }
 
+    @Override
+    public boolean isIncludeRequireNonNullOnRequiredFields() {
+    	return includeRequireNonNullOnRequiredFields;
+    }
+    
     @Override
     public boolean isIncludeJsr303Annotations() {
         return includeJsr303Annotations;

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -495,4 +495,9 @@ public class DefaultGenerationConfig implements GenerationConfig {
     public boolean isUseJakartaValidation() {
         return false;
     }
+
+	@Override
+	public boolean isIncludeRequireNonNullOnRequiredFields() {
+		return false;
+	}
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -250,6 +250,12 @@ public interface GenerationConfig {
    *         generated Java types.
    */
   boolean isIncludeJsr305Annotations();
+  /**
+   * Gets the 'includeRequireNonNullOnRequiredFields' configuration option.
+   *
+   * @return Whether to add non-null check in setter method on given field.
+   */
+  boolean isIncludeRequireNonNullOnRequiredFields();
 
   /**
    * Gets the 'useOptionalForGetters' configuration option.

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DefaultRule.java
@@ -96,6 +96,13 @@ public class DefaultRule implements Rule<JFieldVar, JFieldVar> {
         } else if (fieldType.startsWith(String.class.getName()) && node != null ) {
             field.init(getDefaultValue(field.type(), node));
         } else if (defaultPresent) {
+        	boolean requireNonNullCheck = (ruleFactory.getGenerationConfig().isIncludeRequireNonNullOnRequiredFields() && isRequired(nodeName, node, currentSchema));
+        	if (requireNonNullCheck) {
+
+        		if (field.type() instanceof JDefinedClass && ((JDefinedClass) field.type()).getClassType().equals(ClassType.ENUM)) {
+            		field.annotate(SuppressWarnings.class).param("value", "null");
+        		}
+        	}
             field.init(getDefaultValue(field.type(), node));
 
         }
@@ -107,6 +114,9 @@ public class DefaultRule implements Rule<JFieldVar, JFieldVar> {
         return getDefaultValue(fieldType, node.asText());
     }
 
+    private boolean isRequired(String nodeName, JsonNode node, Schema schema) {
+        return PropertyRule.isRequired(nodeName, node, schema);
+    }
     static JExpression getDefaultValue(JType fieldType, String value) {
 
         fieldType = fieldType.unboxify();

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -153,7 +153,8 @@ jsonSchema2Pojo {
 
   // Whether to include JSR-305 annotations, for schema rules like Nullable, NonNull, etc
   includeJsr305Annotations = false
-
+  // Whether to add Objects.requireNonNull in setter
+  includeRequireNonNullOnRequiredFields = false
   // The Level of inclusion to set in the generated Java types (for Jackson serializers)
   inclusionLevel = InclusionLevel.NON_NULL
 

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -98,6 +98,8 @@ public class JsonSchemaExtension implements GenerationConfig {
   Map<String, String> formatTypeMapping
   boolean includeGeneratedAnnotation
   boolean useJakartaValidation
+  boolean includeRequireNonNullOnRequiredFields
+    
 
   public JsonSchemaExtension() {
     // See DefaultGenerationConfig
@@ -150,6 +152,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeDynamicGetters = false
     includeDynamicSetters = false
     includeDynamicBuilders = false
+	includeRequireNonNullOnRequiredFields = false
     formatDates = false
     formatTimes = false
     formatDateTimes = false
@@ -255,6 +258,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |customAnnotator = ${customAnnotator.getName()}
        |customRuleFactory = ${customRuleFactory.getName()}
        |includeJsr303Annotations = ${includeJsr303Annotations}
+	   |includeRequireNonNullOnRequiredFields = ${includeRequireNonNullOnRequiredFields}
        |includeJsr305Annotations = ${includeJsr305Annotations}
        |useOptionalForGetters = ${useOptionalForGetters}
        |sourceType = ${sourceType.toString().toLowerCase()}

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -331,7 +331,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
      */
     @Parameter(property = "jsonschema2pojo.includeJsr303Annotations", defaultValue = "false")
     private boolean includeJsr303Annotations = false;
-
+    
+    
+    @Parameter(property = "jsonschema2pojo.includeRequireNonNullOnRequiredFields", defaultValue = "false")
+    private boolean includeRequireNonNullOnRequiredFields = false;
     /**
      * Whether to include
      * <a href="http://jcp.org/en/jsr/detail?id=305">JSR-305</a> annotations
@@ -992,6 +995,10 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         }
     }
 
+    @Override
+    public boolean isIncludeRequireNonNullOnRequiredFields() {
+    	return includeRequireNonNullOnRequiredFields;
+    }
     @Override
     public boolean isIncludeJsr303Annotations() {
         return includeJsr303Annotations;


### PR DESCRIPTION
When a field in json schema is required and includeJsr303Annotations then compiler complains about missing checks of nullability of the fields.

I have introduced new config option includeRequireNonNullOnRequiredFields which added required checks so no nullability compiler warnings