### PR TITLE
Generate Method Names in "$ref" Properties Using a "javaName"

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -16,6 +16,8 @@
 
 package org.jsonschema2pojo.rules;
 
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.JsonPointerUtils;
 import org.jsonschema2pojo.Schema;
@@ -214,6 +216,10 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         if (node.has("$ref")) {
             Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             JsonNode refNode = refSchema.getContent();
+            if (node.has("javaName") && (refNode.getNodeType().equals(JsonNodeType.OBJECT))) {
+                // A shallow copy would also work but this object does not implement `clone``.
+                refNode = ((ObjectNode) refNode).deepCopy().set("javaName", node.get("javaName"));
+            }
             return resolveRefs(refNode, refSchema);
         } else {
             return node;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -52,8 +52,9 @@ public class JavaNameIT {
 
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
-    public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
+    public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchMethodException {
 
         ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/javaName.json", "com.example.javaname");
         Class<?> classWithJavaNames = javaNameClassLoader.loadClass("com.example.javaname.JavaName");
@@ -65,6 +66,9 @@ public class JavaNameIT {
         assertThat(instance, hasProperty("enumWithoutJavaName"));
         assertThat(instance, hasProperty("javaObject"));
         assertThat(instance, hasProperty("objectWithoutJavaName"));
+        assertThat(instance, hasProperty("javaReference"));
+        instance.getClass().getMethod("getJavaReference");
+        assertThat(instance, hasProperty("referenceWithoutJavaName"));
 
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/javaName.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/javaName/javaName.json
@@ -21,6 +21,13 @@
     },
     "objectWithoutJavaName" : {
       "type" : "object"
+    },
+    "referenceWithJavaName": {
+      "$ref": "../properties/primitiveProperties.json",
+      "javaName": "javaReference"
+    },
+    "referenceWithoutJavaName": {
+      "$ref": "../properties/primitiveProperties.json"
     }
   }
 }


### PR DESCRIPTION
This is my first PR here, please help me out with anything else that might be required.

This is my attempt at addressing #678. It works by injecting the `javaName` value from a parent node that uses `$ref` into a copy of the referenced node.

As a weirdness, without the changes to `PropertyRule.java` the updated test fails on line 69 `hasProperty("javaReference")`, which is confusing to me. A property with the name `javaReference` does exist on the actual object if you enter a debugger, but for some reason `hamcrest.beans.PropertyUtil` sees a different set of property names. I'm not sure why that is.