### PR TITLE
Fixing problems with remote URL when using Maven Plugin

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/URLUtil.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/URLUtil.java
@@ -21,11 +21,27 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.jsonschema2pojo.URLProtocol;
 
 public class URLUtil {
+
+    private static final Set<URLProtocol> LOCAL_PROTOCOL = Arrays.stream(new URLProtocol[]{URLProtocol.NO_PROTOCOL, URLProtocol.FILE}).collect(Collectors.toSet());
+
+    private URLUtil() {
+    }
+
+    public static boolean isLocalUrl(String input) {
+        return LOCAL_PROTOCOL.contains(parseProtocol(input));
+    }
+
+    public static boolean isRemoteUrl(String input) {
+        return !isLocalUrl(input);
+    }
 
     public static URLProtocol parseProtocol(String input) {
         return URLProtocol.fromString(StringUtils.substringBefore(input, ":"));

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -819,7 +819,8 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
         } else if (!isEmpty(sourcePaths)) {
             // verify individual source paths
             for (int i = 0; i < sourcePaths.length; i++) {
-                sourcePaths[i] = FilenameUtils.normalize(sourcePaths[i]);
+                sourcePaths[i] = URLUtil.isLocalUrl(sourcePaths[i]) ?
+                        FilenameUtils.normalize(sourcePaths[i]) : sourcePaths[i];
                 try {
                     URLUtil.parseURL(sourcePaths[i]);
                 } catch (IllegalArgumentException e) {


### PR DESCRIPTION
When using remote URL's like an HTTP-Url as sourcePaths input. The URL's have been normalized to a file like notation. Afterwards the type generator was unable to resolve the remote file.