### PR TITLE
Add `includeNoArgsConstructor` option

### DIFF
--- a/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
+++ b/jsonschema2pojo-ant/src/main/java/org/jsonschema2pojo/ant/Jsonschema2PojoTask.java
@@ -153,6 +153,8 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
 
     boolean includeCopyConstructor = false;
 
+    boolean includeNoArgsConstructor = true;
+
     private boolean includeAdditionalProperties = true;
 
     private boolean includeGetters = true;
@@ -192,7 +194,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     private SourceSortOrder sourceSortOrder = SourceSortOrder.OS;
 
     private Map<String, String> formatTypeMapping = new HashMap<>();
-    
+
     private boolean includeGeneratedAnnotation = true;
 
     private boolean useJakartaValidation = false;
@@ -340,6 +342,20 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
      */
     public void setIncludeCopyConstructor(boolean includeCopyConstructor) {
         this.includeCopyConstructor = includeCopyConstructor;
+    }
+
+    /**
+     * Sets the 'includeNoArgsConstructor' configuration option. This property works in collaboration with the {@link
+     * #isIncludeConstructors()} configuration option, and will have no effect if {@link #isIncludeConstructors()}
+     * is not set to true. If {@link #isIncludeConstructors()} is set to true then this configuration determines
+     * whether the resulting object should include the no-args constructor. This option is compatible with any
+     * of the other constructor related options, but will be ignored if no other constructor is to be generated -
+     * this is because java will always infer the no-args constructor if no other constructors are present.
+     *
+     * @param includeNoArgsConstructor controls whether the resulting class will include the no-args constructor
+     */
+    public void setIncludeNoArgsConstructor(boolean includeNoArgsConstructor) {
+        this.includeNoArgsConstructor = includeNoArgsConstructor;
     }
 
     /**
@@ -1210,6 +1226,11 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     }
 
     @Override
+    public boolean isIncludeNoArgsConstructor() {
+        return includeNoArgsConstructor;
+    }
+
+    @Override
     public boolean isIncludeAdditionalProperties() {
         return includeAdditionalProperties;
     }
@@ -1313,7 +1334,7 @@ public class Jsonschema2PojoTask extends Task implements GenerationConfig {
     public SourceSortOrder getSourceSortOrder() {
         return sourceSortOrder;
     }
-    
+
     @Override
     public Map<String, String> getFormatTypeMapping() {
         return formatTypeMapping;

--- a/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
+++ b/jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html
@@ -286,6 +286,19 @@
     <td align="center" valign="top">No (default <code>false</code>)</td>
   </tr>
   <tr>
+    <td valign="top">includeNoArgsConstructor</td>
+    <td valign="top">The 'includeNoArgsConstructor' configuration option
+      works in collaboration with the {@link #isIncludeConstructors()} configuration option and is
+      incompatible with {@link #isConstructorsRequiredPropertiesOnly()}, and will have no effect if
+      {@link #isIncludeConstructors()} is not set to true. If {@link #isIncludeConstructors()} is
+      set to true then this configuration determines whether the resulting object should include the
+      no-args constructor. This option is compatible with any of the other constructor related options,
+      but will be ignored if no other constructor is to be generated - this is because java will
+      always infer the no-args constructor if no other constructors are present.
+    </td>
+    <td align="center" valign="top">No (default <code>true</code>)</td>
+  </tr>
+  <tr>
     <td valign="top">includeHashcodeAndEquals</td>
     <td valign="top">Whether to use include <code>hashCode</code> and <code>equals</code> methods in
       generated Java

--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -89,6 +89,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "--constructors-include-copy-constructor" }, description = "Generate constructors with a copy oriented parameter")
     private boolean includeCopyConstructor = false;
 
+    @Parameter(names = { "--constructors-include-no-args-constructor" }, description = "Generate constructor with no arguments")
+    private boolean includeNoArgsConstructor = false;
+
     @Parameter(names = { "-P", "--use-primitives" }, description = "Use primitives instead of wrapper types for bean properties")
     private boolean usePrimitives = false;
 
@@ -502,6 +505,9 @@ public class Arguments implements GenerationConfig {
 
     @Override
     public boolean isIncludeCopyConstructor() { return includeCopyConstructor; }
+
+    @Override
+    public boolean isIncludeNoArgsConstructor() { return includeNoArgsConstructor; }
 
     @Override
     public boolean isIncludeAdditionalProperties() {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -328,6 +328,12 @@ public class DefaultGenerationConfig implements GenerationConfig {
      * @return <code>true</code>
      */
     @Override
+    public boolean isIncludeNoArgsConstructor() { return true; }
+
+    /**
+     * @return <code>true</code>
+     */
+    @Override
     public boolean isIncludeAdditionalProperties() {
         return true;
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -417,6 +417,18 @@ public interface GenerationConfig {
   boolean isIncludeCopyConstructor();
 
   /**
+   * Gets the 'includeNoArgsConstructor' configuration option. This property works in collaboration with the {@link
+   * #isIncludeConstructors()} configuration option, and will have no effect if {@link #isIncludeConstructors()}
+   * is not set to true. If {@link #isIncludeConstructors()} is set to true then this configuration determines
+   * whether the resulting object should include the default constructor. This option is compatible with any
+   * of the other constructor related options, but will be ignored if no other constructor is to be generated -
+   * this is because java will always infer the default constructor if no other constructors are present.
+   *
+   * @return whether the resulting object should not include the default a constructor.
+   */
+  boolean isIncludeNoArgsConstructor();
+
+  /**
    * Gets the 'includeAdditionalProperties' configuration option.
    *
    * @return Whether to allow 'additional properties' support in objects.

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ConstructorRule.java
@@ -81,10 +81,14 @@ public class ConstructorRule implements Rule<JDefinedClass, JDefinedClass> {
 
     // Only generate the constructors if there are actually properties to put in them
     if (!requiredClassProperties.isEmpty() || !requiredCombinedSuperProperties.isEmpty()) {
+      final GenerationConfig generationConfig = ruleFactory.getGenerationConfig();
 
-      // Generate the no arguments constructor - we'll need this even if there is a property
-      // constructor available, because it is used by the serialization and deserialization
-      generateNoArgsConstructor(instanceClass);
+      // If there are no properties to put on the constructor than we don't need
+      // the no-args constructor as java infers it, so we can make this computation
+      // only if the required properties constructor is being generated
+      if (generationConfig.isIncludeNoArgsConstructor()) {
+        generateNoArgsConstructor(instanceClass);
+      }
 
       // Generate the actual constructor taking in only the required properties
       addFieldsConstructor(instanceClass, requiredClassProperties, requiredCombinedSuperProperties);
@@ -125,9 +129,12 @@ public class ConstructorRule implements Rule<JDefinedClass, JDefinedClass> {
 
     // Only generate the constructors if there are actually properties to put in them
     if (requiresConstructors) {
-      // Generate the no arguments constructor - we'll need this even if there is a property
-      // constructor available, because it is used by the serialization and deserialization
-      generateNoArgsConstructor(instanceClass);
+      // If there are no other constructors to generate then the no-args constructor is
+      // not needed as java infers it, so we can make this computation only if the required
+      // properties constructor is being generated
+      if (generationConfig.isIncludeNoArgsConstructor()) {
+        generateNoArgsConstructor(instanceClass);
+      }
 
       if (includeCopyConstructor) {
         addCopyConstructor(instanceClass, classProperties, combinedSuperProperties);

--- a/jsonschema2pojo-gradle-plugin/README.md
+++ b/jsonschema2pojo-gradle-plugin/README.md
@@ -229,6 +229,9 @@ jsonSchema2Pojo {
   // This property is irrelevant if constructorsRequiredPropertiesOnly = true
   includeCopyConstructor = false
 
+  // Whether to *add* the no-args constructor, alongside other constructors.
+  includeNoArgsConstructor = false
+
   // Whether to make the generated types Parcelable for Android
   parcelable = false
 

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -60,6 +60,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean includeRequiredPropertiesConstructor;
   boolean includeAllPropertiesConstructor;
   boolean includeCopyConstructor;
+  boolean includeNoArgsConstructor;
   boolean includeHashcodeAndEquals
   boolean includeJsr303Annotations
   boolean includeJsr305Annotations
@@ -117,6 +118,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     constructorsRequiredPropertiesOnly = false
     includeRequiredPropertiesConstructor = false
     includeAllPropertiesConstructor = true
+    includeNoArgsConstructor = true
     includeToString = true
     toStringExcludes = [] as String[]
     annotationStyle = AnnotationStyle.JACKSON
@@ -247,6 +249,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeRequiredPropertiesConstructor = ${includeRequiredPropertiesConstructor}
        |includeAllPropertiesConstructor = ${includeAllPropertiesConstructor}
        |includeCopyConstructor = ${includeCopyConstructor}
+       |includeNoArgsConstructor = ${includeNoArgsConstructor}
        |includeToString = ${includeToString}
        |toStringExcludes = ${Arrays.toString(toStringExcludes)}
        |annotationStyle = ${annotationStyle.toString().toLowerCase()}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsIT.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
@@ -37,6 +38,13 @@ public class ConstructorsIT {
 
   public static void assertHasModifier(int modifier, int modifiers, String modifierName) {
     assertEquals("Expected the bit " + modifierName + " (" + modifier + ")" + " to be set but got: " + modifiers, modifier, modifier & modifiers);
+  }
+
+  public static void assertHasNoNoArgsConstructor(Class<?> cls) {
+    Constructor<?>[] constructors = cls.getDeclaredConstructors();
+    assertFalse("Expected " + cls + " to have no default constructor", Arrays
+            .stream(constructors)
+            .anyMatch(params -> params.getParameterCount() == 0));
   }
 
   public static void assertHasOnlyDefaultConstructor(Class<?> cls) {
@@ -355,4 +363,205 @@ public class ConstructorsIT {
     }
   }
 
+  /**
+   * Tests what happens when includeConstructors is set to true but includeNoArgsConstructor is set to false
+   */
+  public static class ExcludeNoArgsConstructorConstructorWithIncludeConstructorsIT {
+    @ClassRule
+    public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static ConstructorTestClasses testClasses = null;
+
+    @BeforeClass
+    public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+      // @formatter:off
+      testClasses = new ConstructorTestClasses(classSchemaRule, config(
+              "propertyWordDelimiters", "_",
+              "includeConstructors", true,
+              "includeNoArgsConstructor", false));
+      // @formatter:on
+    }
+
+    @Test
+    public void testGeneratesConstructorWithAllProperties() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequired).getModifiers(), "public");
+    }
+
+    @Test
+    public void testGeneratesConstructorWithAllPropertiesArrayStyle() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequiredArray);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequiredArray).getModifiers(), "public");
+    }
+
+    @Test
+    public void testNoConstructorWithoutProperties() {
+
+      // Has default constructor anyway since no other constructor is available
+      assertHasOnlyDefaultConstructor(testClasses.typeWithoutProperties);
+    }
+  }
+
+  /**
+   * Tests with constructorsRequiredPropertiesOnly set to true but includeNoArgsConstructor to false
+   */
+  public static class ExcludeNoArgsConstructorConstructorWithRequiredOnlyIT {
+
+    @ClassRule
+    public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static ConstructorTestClasses testClasses = null;
+
+    @BeforeClass
+    public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+      // @formatter:off
+      testClasses = new ConstructorTestClasses(classSchemaRule,
+              config(
+                      "propertyWordDelimiters", "_",
+                      "includeConstructors", true,
+                      "constructorsRequiredPropertiesOnly", true,
+                      "includeNoArgsConstructor", false));
+      // @formatter:on
+    }
+
+    @Test
+    public void testCreatesConstructorWithRequiredParamsButNotNoArgsConstructor() throws Exception {
+      Constructor<?> constructor = getRequiredPropertiesConstructor(testClasses.typeWithRequired);
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+
+    @Test
+    public void testCreatesConstructorWithRequiredParamsArrayStyleButNotNoArgsConstructor() throws Exception {
+      Constructor<?> constructor = getRequiredPropertiesConstructor(testClasses.typeWithRequiredArray);
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+
+    @Test
+    public void testNoConstructorWithoutRequiredParams() {
+      // Despite includeNoArgsConstructor being set to true, it will be present
+      // since we have no required properties but required properties only is enabled
+      assertHasOnlyDefaultConstructor(testClasses.typeWithoutRequiredProperties);
+    }
+
+    @Test
+    public void testDoesntGenerateConstructorsWithoutConfig() throws Exception {
+      // Despite includeNoArgsConstructor being set to true, it will be present because we have no properties
+      assertHasOnlyDefaultConstructor(testClasses.typeWithoutProperties);
+    }
+  }
+
+  /**
+   * Tests what happens when includeConstructors and includeRequiredPropertiesConstructor is set to true,
+   * but includeNoArgsConstructor is set to false
+   */
+  public static class ExcludeNoArgsConstructorWithIncludeRequiredConstructorsIT {
+
+    @ClassRule
+    public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static ConstructorTestClasses testClasses = null;
+
+    @BeforeClass
+    public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+      // @formatter:off
+      testClasses = new ConstructorTestClasses(classSchemaRule,
+              config(
+                      "propertyWordDelimiters", "_",
+                      "includeConstructors", true,
+                      "includeRequiredPropertiesConstructor", true,
+                      "includeNoArgsConstructor", false));
+      // @formatter:on
+    }
+
+    @Test
+    public void testGeneratesConstructorWithAllProperties() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequired).getModifiers(), "public");
+    }
+
+    @Test
+    public void testGeneratesConstructorWithAllPropertiesArrayStyle() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequiredArray);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequiredArray).getModifiers(), "public");
+    }
+
+    @Test
+    public void testCreatesConstructorWithRequiredParams() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      Constructor<?> constructor = getAllPropertiesConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+
+    @Test
+    public void testCreatesConstructorWithRequiredParamsArrayStyle() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequiredArray);
+      Constructor<?> constructor = getAllPropertiesConstructor(testClasses.typeWithRequiredArray);
+      assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+
+    /**
+     * Test that duplicate constructors are not generated (compile time error is not thrown) when:
+     * <ul>
+     *     <li>all properties are required</li>
+     *     <li>{@code includeAllPropertiesConstructor} configuration property is {@code true}</li>
+     *     <li>{@code includeRequiredPropertiesConstructor} configuration property is {@code true}</li>
+     */
+    @Test
+    public void testGeneratesConstructorWithAllPropertiesRequired() throws Exception {
+      classSchemaRule.generate(
+              "/schema/constructors/allPropertiesRequiredConstructor.json",
+              "com.example",
+              config("includeConstructors", true,
+                      "includeAllPropertiesConstructor", true,
+                      "includeRequiredPropertiesConstructor", true,
+                      "includeNoArgsConstructor", false));
+      Class<?> type = classSchemaRule.compile().loadClass("com.example.AllPropertiesRequiredConstructor");
+      assertHasNoNoArgsConstructor(type);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(type).getModifiers(), "public");
+    }
+  }
+
+  /**
+   * Tests what happens when includeConstructors and includeCopyConstructor is set to true,
+   * but includeNoArgsConstructor is set to false
+   */
+  public static class ExcludeNoArgsConstructorWithIncludeCopyConstructorsIT {
+
+    @ClassRule
+    public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    private static ConstructorTestClasses testClasses = null;
+
+    @BeforeClass
+    public static void generateAndCompileConstructorClasses() throws ClassNotFoundException {
+      // @formatter:off
+      testClasses = new ConstructorTestClasses(classSchemaRule,
+              config("propertyWordDelimiters", "_",
+                      "includeConstructors", true,
+                      "includeCopyConstructor", true,
+                      "includeNoArgsConstructor", false));
+      // @formatter:on
+    }
+
+    @Test
+    public void testGeneratesConstructorWithAllProperties() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequired).getModifiers(), "public");
+    }
+
+    @Test
+    public void testGeneratesConstructorWithAllPropertiesArrayStyle() throws Exception {
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequiredArray);
+      assertHasModifier(JMod.PUBLIC, getAllPropertiesConstructor(testClasses.typeWithRequiredArray).getModifiers(), "public");
+    }
+
+    @Test
+    public void testCreatesConstructorWithCopyParams() throws Exception {
+      Constructor<?> constructor = testClasses.typeWithRequired.getConstructor(testClasses.typeWithRequired);
+      assertHasNoNoArgsConstructor(testClasses.typeWithRequired);
+      assertHasModifier(JMod.PUBLIC, constructor.getModifiers(), "public");
+    }
+  }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Compiler.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Compiler.java
@@ -49,7 +49,7 @@ public class Compiler {
     }
 
     public void compile(JavaCompiler javaCompiler, Writer out, File sourceDirectory, File outputDirectory, List<File> classpath, DiagnosticListener<? super JavaFileObject> diagnosticListener, String targetVersion ) {
-        targetVersion = targetVersion == null ? "1.6" : targetVersion;
+        targetVersion = targetVersion == null ? "1.8" : targetVersion;
 
         StandardJavaFileManager fileManager = javaCompiler.getStandardFileManager(null, null, null);
 

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -580,6 +580,19 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     private boolean includeCopyConstructor = false;
 
     /**
+     * The 'includeNoArgsConstructor' configuration option. This property works in collaboration with the {@link
+     * #isIncludeConstructors()} configuration option, and will have no effect if {@link #isIncludeConstructors()}
+     * is not set to true. If {@link #isIncludeConstructors()} is set to true then this configuration determines
+     * whether the resulting object should include the no-args constructor. This option is compatible with any
+     * of the other constructor related options, but will be ignored if no other constructor is to be generated -
+     * this is because java will always infer the no-args constructor if no other constructors are present.
+     *
+     * @since 1.0.3
+     */
+    @Parameter(property = "jsonschema2pojo.includeNoArgsConstructor", defaultValue = "true")
+    private boolean includeNoArgsConstructor = true;
+
+    /**
      * Whether to allow 'additional properties' support in objects. Setting this
      * to false will disable additional properties support, regardless of the
      * input schema(s).
@@ -1113,6 +1126,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isIncludeCopyConstructor() {
         return includeCopyConstructor;
+    }
+
+    @Override
+    public boolean isIncludeNoArgsConstructor() {
+        return includeNoArgsConstructor;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

The no-args constructor is not necessary for all serializarers and deserializers. For example. when using _Micronaut_ with _serde_, it's perfectibily acceptable to not have the no-args constructor for serialization and deserialization to be successful. Not only that, but it actually interferes with the deserialization process when the `includeSetters` option is set to false (all properties constructor would require being annotated with `@JsonCreator` for all properties to be set accordingly).

### Purposal

As such, I'm creating this PR which implements the `includeNoArgsConstructor` option, set to true by default for backwards compatibility reasons and allows the user to disable the generation of the no-args constructor.