### PR TITLE
Add $Id Management in the generator. With it, it is possible to

### DIFF
--- a/jsonschema2pojo-ant/pom.xml
+++ b/jsonschema2pojo-ant/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema2pojo</artifactId>
         <groupId>org.jsonschema2pojo</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+	    <version>1.2.2-Id-Management</version>
     </parent>
 
     <artifactId>jsonschema2pojo-ant</artifactId>

--- a/jsonschema2pojo-cli/pom.xml
+++ b/jsonschema2pojo-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema2pojo</artifactId>
         <groupId>org.jsonschema2pojo</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+	    <version>1.2.2-Id-Management</version>
     </parent>
 
     <artifactId>jsonschema2pojo-cli</artifactId>

--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema2pojo</artifactId>
         <groupId>org.jsonschema2pojo</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.2.2-Id-Management</version>
     </parent>
 
     <artifactId>jsonschema2pojo-core</artifactId>

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
@@ -76,6 +76,7 @@ public class Jsonschema2Pojo {
             URL source = sources.next();
 
             if (URLUtil.parseProtocol(source.toString()) == URLProtocol.FILE && URLUtil.getFileFromURL(source).isDirectory()) {
+            	parseRecursive(config, mapper, codeModel, defaultString(config.getTargetPackage()), Arrays.asList(URLUtil.getFileFromURL(source).listFiles(config.getFileFilter())));
                 generateRecursive(config, mapper, codeModel, defaultString(config.getTargetPackage()), Arrays.asList(URLUtil.getFileFromURL(source).listFiles(config.getFileFilter())));
             } else {
                 mapper.generate(codeModel, getNodeName(source, config), defaultString(config.getTargetPackage()), source);
@@ -136,6 +137,22 @@ public class Jsonschema2Pojo {
                 mapper.generate(codeModel, getNodeName(child.toURI().toURL(), config), defaultString(packageName), child.toURI().toURL());
             } else {
                 generateRecursive(config, mapper, codeModel, childQualifiedName(packageName, child.getName()), Arrays.asList(child.listFiles(config.getFileFilter())));
+            }
+        }
+    }
+    private static void parseRecursive(GenerationConfig config, SchemaMapper mapper, JCodeModel codeModel, String packageName, List<File> schemaFiles) throws IOException {
+
+        Collections.sort(schemaFiles, config.getSourceSortOrder().getComparator());
+
+        for (File child : schemaFiles) {
+            if (child.isFile()) {
+                if (config.getSourceType() == SourceType.JSON || config.getSourceType() == SourceType.YAML) {
+                    // any cached schemas will have ids that are fragments, relative to the previous document (and shouldn't be reused)
+                    mapper.getRuleFactory().getSchemaStore().clearCache();
+                }
+                mapper.parse(codeModel, getNodeName(child.toURI().toURL(), config), defaultString(packageName), child.toURI().toURL());
+            } else {
+            	parseRecursive(config, mapper, codeModel, childQualifiedName(packageName, child.getName()), Arrays.asList(child.listFiles(config.getFileFilter())));
             }
         }
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaMapper.java
@@ -18,6 +18,7 @@ package org.jsonschema2pojo;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.jsonschema2pojo.rules.RuleFactory;
@@ -37,6 +38,7 @@ import com.sun.codemodel.JType;
  * used to create type generation rules for this mapper.
  */
 public class SchemaMapper {
+	
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
 
     private final RuleFactory ruleFactory;
@@ -88,6 +90,35 @@ public class SchemaMapper {
         ObjectNode schemaNode = readSchema(schemaUrl);
 
         return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage, new Schema(null, schemaNode, null));
+
+    }
+    /**
+     * Reads a schema and register schema which may be used after during the generation.
+     *
+     * @param codeModel
+     *            the java code-generation context that should be used to
+     *            generated new types
+     * @param className
+     *            the name of the parent class the represented by this schema
+     * @param packageName
+     *            the target package that should be used for generated types
+     * @param schemaUrl
+     *            location of the schema to be used as input
+     */
+    public void parse(JCodeModel codeModel, String className, String packageName, URL schemaUrl) {
+
+			try {
+		        ObjectNode schemaNode = readSchema(schemaUrl);
+		        SchemaStore schemaStore = getRuleFactory().getSchemaStore();
+		        Schema schema = new Schema(schemaUrl.toURI(), schemaNode, null);
+		        schemaStore.registerId(schema, schemaUrl.toURI(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+				
+			} catch (URISyntaxException e) {
+				e.printStackTrace();
+			}
+
+
+//        return ruleFactory.getSchemaRule().apply(className, schemaNode, null, jpackage, new Schema(null, schemaNode, null));
 
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -27,130 +27,178 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class SchemaStore {
 
-    protected final Map<URI, Schema> schemas = new HashMap<>();
+	protected final Map<URI, Schema> schemas = new HashMap<>();
 
-    protected final FragmentResolver fragmentResolver = new FragmentResolver();
-    protected final ContentResolver contentResolver;
-    protected final RuleLogger logger;
+	protected final FragmentResolver fragmentResolver = new FragmentResolver();
+	protected final ContentResolver contentResolver;
+	protected final RuleLogger logger;
 
-    public SchemaStore() {
-        this.contentResolver = new ContentResolver();
-        this.logger = new NoopRuleLogger();
-    }
+	public SchemaStore() {
+		this.contentResolver = new ContentResolver();
+		this.logger = new NoopRuleLogger();
+	}
 
-    public SchemaStore(ContentResolver contentResolver, RuleLogger logger) {
-        this.contentResolver = contentResolver;
-        this.logger = logger;
-    }
+	public SchemaStore(ContentResolver contentResolver, RuleLogger logger) {
+		this.contentResolver = contentResolver;
+		this.logger = logger;
+	}
 
-    /**
-     * Create or look up a new schema which has the given ID and read the
-     * contents of the given ID as a URL. If a schema with the given ID is
-     * already known, then a reference to the original schema will be returned.
-     *
-     * @param id
-     *            the id of the schema being created
-     * @param refFragmentPathDelimiters A string containing any characters
-     *                                  that should act as path delimiters when resolving $ref fragments.
-     * @return a schema object containing the contents of the given path
-     */
-    public synchronized Schema create(URI id, String refFragmentPathDelimiters) {
+	public synchronized void registerId(Schema parent, URI fileId, String refFragmentPathDelimiters) {
 
-        URI normalizedId = id.normalize();
+		final JsonNode baseContent = contentResolver.resolve(fileId);
+		JsonNode jsonNode = baseContent.get("$id");
+		if (jsonNode != null) {
+			try {
+				URI id = new URI(jsonNode.asText());
+				URI normalizedId = id.normalize();
+				URI fileNormalizedId = fileId.normalize();
+				URI baseId2 = removeFragment(id).normalize();
+				URI fileNormalizedId2 = removeFragment(fileNormalizedId).normalize();
+				
+				boolean containsKey1 = schemas.containsKey(normalizedId);
+				boolean containsKey2 = schemas.containsKey(fileNormalizedId);
+				boolean containsKey3 = schemas.containsKey(baseId2);
+				boolean containsKey4 = schemas.containsKey(fileNormalizedId2);
+				if (!containsKey1 || !containsKey2 || containsKey3 || containsKey4) {
+					Schema schema = new Schema(fileNormalizedId2, baseContent, null);
+					if (!containsKey1) {
+						logger.debug("Reading schema: " + baseId2);
+						schemas.put(normalizedId, schema);
+					}
+					if (!containsKey2) {
+						logger.debug("Reading schema: " + baseId2);
+						schemas.put(fileNormalizedId, schema);
+					}
+					if (!containsKey3) {
+						logger.debug("Reading schema: " + baseId2);
+						schemas.put(baseId2, schema);
+					}
+					if (!containsKey4) {
+						logger.debug("Reading schema: " + baseId2);
+						schemas.put(fileNormalizedId2, schema);
+					}
+				}
 
-        if (!schemas.containsKey(normalizedId)) {
+			} catch (URISyntaxException e) {
+				e.printStackTrace();
+			}
 
-            URI baseId = removeFragment(id).normalize();
-            if (!schemas.containsKey(baseId)) {
-                logger.debug("Reading schema: " + baseId);
-                final JsonNode baseContent = contentResolver.resolve(baseId);
-                schemas.put(baseId, new Schema(baseId, baseContent, null));
-            }
+		}
 
-            final Schema baseSchema = schemas.get(baseId);
-            if (normalizedId.toString().contains("#")) {
-                JsonNode childContent = fragmentResolver.resolve(baseSchema.getContent(), '#' + id.getFragment(), refFragmentPathDelimiters);
-                schemas.put(normalizedId, new Schema(normalizedId, childContent, baseSchema));
-            }
-        }
+	}
 
-        return schemas.get(normalizedId);
-    }
+	/**
+	 * Create or look up a new schema which has the given ID and read the contents
+	 * of the given ID as a URL. If a schema with the given ID is already known,
+	 * then a reference to the original schema will be returned.
+	 *
+	 * @param id                        the id of the schema being created
+	 * @param refFragmentPathDelimiters A string containing any characters that
+	 *                                  should act as path delimiters when resolving
+	 *                                  $ref fragments.
+	 * @return a schema object containing the contents of the given path
+	 */
+	public synchronized Schema create(URI id, String refFragmentPathDelimiters) {
 
-    protected URI removeFragment(URI id) {
-        return URI.create(substringBefore(id.toString(), "#"));
-    }
+		URI normalizedId = id.normalize();
 
-    /**
-     * Create or look up a new schema using the given schema as a parent and the
-     * path as a relative reference. If a schema with the given parent and
-     * relative path is already known, then a reference to the original schema
-     * will be returned.
-     *
-     * @param parent
-     *            the schema which is the parent of the schema to be created.
-     * @param path
-     *            the relative path of this schema (will be used to create a
-     *            complete URI by resolving this path against the parent
-     *            schema's id)
-     * @param refFragmentPathDelimiters A string containing any characters
-     *                                  that should act as path delimiters when resolving $ref fragments.
-     * @return a schema object containing the contents of the given path
-     */
-    @SuppressWarnings("PMD.UselessParentheses")
-    public Schema create(Schema parent, String path, String refFragmentPathDelimiters) {
+		if (!schemas.containsKey(normalizedId)) {
 
-        if (!path.equals("#")) {
-            // if path is an empty string then resolving it below results in jumping up a level. e.g. "/path/to/file.json" becomes "/path/to"
-            path = stripEnd(path, "#?&/");
-        }
+			URI baseId = removeFragment(id).normalize();
+			if (!schemas.containsKey(baseId)) {
+				logger.debug("Reading schema: " + baseId);
+				final JsonNode baseContent = contentResolver.resolve(baseId);
+				schemas.put(baseId, new Schema(baseId, baseContent, null));
+			}
 
-        // encode the fragment for any funny characters
-        if (path.contains("#")) {
-            String pathExcludingFragment = substringBefore(path, "#");
-            String fragment = substringAfter(path, "#");
-            URI fragmentURI;
-            try {
-                fragmentURI = new URI(null, null, fragment);
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException("Invalid fragment: " + fragment + " in path: " + path);
-            }
-            path = pathExcludingFragment + "#" + fragmentURI.getRawFragment();
-        }
+			final Schema baseSchema = schemas.get(baseId);
+			if (normalizedId.toString().contains("#")) {
+				JsonNode childContent = fragmentResolver.resolve(baseSchema.getContent(), '#' + id.getFragment(),
+						refFragmentPathDelimiters);
+				schemas.put(normalizedId, new Schema(normalizedId, childContent, baseSchema));
+			}
+		}
 
-        URI id = (parent == null || parent.getId() == null) ? URI.create(path) : parent.getId().resolve(path);
+		return schemas.get(normalizedId);
+	}
 
-        String stringId = id.toString();
-        if (stringId.endsWith("#")) {
-            try {
-                id = new URI(stripEnd(stringId, "#"));
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException("Bad path: " + stringId);
-            }
-        }
+	protected URI removeFragment(URI id) {
+		return URI.create(substringBefore(id.toString(), "#"));
+	}
 
-        if (selfReferenceWithoutParentFile(parent, path) || substringBefore(stringId, "#").isEmpty()) {
-            JsonNode parentContent = parent.getGrandParent().getContent();
+	/**
+	 * Create or look up a new schema using the given schema as a parent and the
+	 * path as a relative reference. If a schema with the given parent and relative
+	 * path is already known, then a reference to the original schema will be
+	 * returned.
+	 *
+	 * @param parent                    the schema which is the parent of the schema
+	 *                                  to be created.
+	 * @param path                      the relative path of this schema (will be
+	 *                                  used to create a complete URI by resolving
+	 *                                  this path against the parent schema's id)
+	 * @param refFragmentPathDelimiters A string containing any characters that
+	 *                                  should act as path delimiters when resolving
+	 *                                  $ref fragments.
+	 * @return a schema object containing the contents of the given path
+	 */
+	@SuppressWarnings("PMD.UselessParentheses")
+	public Schema create(Schema parent, String path, String refFragmentPathDelimiters) {
 
-            if (schemas.containsKey(id)) {
-                return schemas.get(id);
-            } else {
-                Schema schema = new Schema(id, fragmentResolver.resolve(parentContent, path, refFragmentPathDelimiters), parent.getGrandParent());
-                schemas.put(id, schema);
-                return schema;
-            }
-        }
+		if (!path.equals("#")) {
+			// if path is an empty string then resolving it below results in jumping up a
+			// level. e.g. "/path/to/file.json" becomes "/path/to"
+			path = stripEnd(path, "#?&/");
+		}
 
-        return create(id, refFragmentPathDelimiters);
+		// encode the fragment for any funny characters
+		if (path.contains("#")) {
+			String pathExcludingFragment = substringBefore(path, "#");
+			String fragment = substringAfter(path, "#");
+			URI fragmentURI;
+			try {
+				fragmentURI = new URI(null, null, fragment);
+			} catch (URISyntaxException e) {
+				throw new IllegalArgumentException("Invalid fragment: " + fragment + " in path: " + path);
+			}
+			path = pathExcludingFragment + "#" + fragmentURI.getRawFragment();
+		}
 
-    }
+		URI id = (parent == null || parent.getId() == null) ? URI.create(path) : parent.getId().resolve(path);
 
-    protected boolean selfReferenceWithoutParentFile(Schema parent, String path) {
-        return parent != null && (parent.getId() == null || parent.getId().toString().startsWith("#/")) && path.startsWith("#");
-    }
+		String stringId = id.toString();
+		if (stringId.endsWith("#")) {
+			try {
+				id = new URI(stripEnd(stringId, "#"));
+			} catch (URISyntaxException e) {
+				throw new IllegalArgumentException("Bad path: " + stringId);
+			}
+		}
 
-    public synchronized void clearCache() {
-        schemas.clear();
-    }
+		if (selfReferenceWithoutParentFile(parent, path) || substringBefore(stringId, "#").isEmpty()) {
+			JsonNode parentContent = parent.getGrandParent().getContent();
+
+			if (schemas.containsKey(id)) {
+				return schemas.get(id);
+			} else {
+				Schema schema = new Schema(id, fragmentResolver.resolve(parentContent, path, refFragmentPathDelimiters),
+						parent.getGrandParent());
+				schemas.put(id, schema);
+				return schema;
+			}
+		}
+
+		return create(id, refFragmentPathDelimiters);
+
+	}
+
+	protected boolean selfReferenceWithoutParentFile(Schema parent, String path) {
+		return parent != null && (parent.getId() == null || parent.getId().toString().startsWith("#/"))
+				&& path.startsWith("#");
+	}
+
+	public synchronized void clearCache() {
+		schemas.clear();
+	}
 
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -64,9 +64,10 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
     public JType apply(String nodeName, JsonNode schemaNode, JsonNode parent, JClassContainer generatableType, Schema schema) {
 
         if (schemaNode.has("$ref")) {
-            final String nameFromRef = nameFromRef(schemaNode.get("$ref").asText());
+            String asText = schemaNode.get("$ref").asText();
+			final String nameFromRef = nameFromRef(asText);
 
-            schema = ruleFactory.getSchemaStore().create(schema, schemaNode.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            schema = ruleFactory.getSchemaStore().create(schema, asText, ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             schemaNode = schema.getContent();
 
             if (schema.isGenerated()) {

--- a/jsonschema2pojo-gradle-plugin/pom.xml
+++ b/jsonschema2pojo-gradle-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema2pojo</artifactId>
         <groupId>org.jsonschema2pojo</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+	    <version>1.2.2-Id-Management</version>
     </parent>
 
     <artifactId>jsonschema2pojo-gradle-plugin</artifactId>

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema2pojo</artifactId>
         <groupId>org.jsonschema2pojo</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+	    <version>1.2.2-Id-Management</version>
     </parent>
 
     <artifactId>jsonschema2pojo-integration-tests</artifactId>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/id/Jsonschema2PojoForIdRef.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/id/Jsonschema2PojoForIdRef.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.id;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.jsonschema2pojo.integration.util.CodeGenerationHelper;
+import org.jsonschema2pojo.integration.util.TestableJsonschema2PojoMojo;
+import org.jsonschema2pojo.maven.Jsonschema2PojoMojo;
+import org.junit.Test;
+
+public class Jsonschema2PojoForIdRef {
+
+	static File rootDirectory() {
+		return new File("target" + File.separator + "jsonschema2pojo");
+	}
+
+	@Test
+	public void sourcesAndCompile() throws ClassNotFoundException, NoSuchFieldException, SecurityException {
+
+		Map<String, Map<String, String>> classNameWithExpectedFieldAndType = new HashMap<>();
+		{
+			Map<String, String> expectedFieldAndType = new HashMap<>();
+
+			expectedFieldAndType.put("dataFirst1", "Set<DataFirst>");
+			expectedFieldAndType.put("dataFirst2", "DataFirst");
+			expectedFieldAndType.put("dataSecond1", "DataSecond");
+			expectedFieldAndType.put("prop", "Prop");
+
+			classNameWithExpectedFieldAndType.put("MainData", expectedFieldAndType);
+		}
+		{
+			Map<String, String> expectedFieldAndType = new HashMap<>();
+
+			expectedFieldAndType.put("dataSecond", "DataSecond");
+
+			classNameWithExpectedFieldAndType.put("DataFirst", expectedFieldAndType);
+		}
+		{
+			Map<String, String> expectedFieldAndType = new HashMap<>();
+
+			expectedFieldAndType.put("dataFirst", "Set<DataFirst>");
+			expectedFieldAndType.put("dataMain", "MainData");
+			expectedFieldAndType.put("dataSecond", "DataSecond");
+
+			classNameWithExpectedFieldAndType.put("DataSecond", expectedFieldAndType);
+		}
+		{
+			Map<String, String> expectedFieldAndType = new HashMap<>();
+
+			expectedFieldAndType.put("id", "Integer");
+			expectedFieldAndType.put("otherMainData", "MainData");
+
+			classNameWithExpectedFieldAndType.put("Prop", expectedFieldAndType);
+		}
+
+		try {
+			@SuppressWarnings("serial")
+			File rootDirectory = new File(rootDirectory(), "/test_$id");
+			File generateDirectory = new File(rootDirectory, "generate");
+			File compileDirectory = new File(rootDirectory, "compile");
+			generateDirectory.mkdirs();
+			compileDirectory.mkdirs();
+			String packageName = "org.testId";
+
+			Jsonschema2PojoMojo pluginMojo = new TestableJsonschema2PojoMojo().configure(new HashMap<String, Object>() {
+				{
+					put("sourceDirectory", new File("src/test/resources/json/examples_$id").toString());
+					put("outputDirectory", generateDirectory);
+					put("project", getMockProject());
+					put("targetPackage", packageName);
+				}
+			});
+
+			pluginMojo.execute();
+			assertTrue("Generation Ok",true);
+
+			CodeGenerationHelper.compile(generateDirectory, compileDirectory, Collections.EMPTY_LIST,
+					Collections.EMPTY_MAP);
+
+			assertTrue("Compile Ok",true);
+
+			URLClassLoader classLoader = new URLClassLoader(new URL[] { compileDirectory.toURL() },
+					this.getClass().getClassLoader());
+			
+			for (Entry<String, Map<String, String>> classes : classNameWithExpectedFieldAndType.entrySet()) {
+				String classInpect = classes.getKey();
+				Class<?> clazz = classLoader.loadClass(packageName+"."+classInpect);
+				for (Entry<String, String> field : classes.getValue().entrySet()) {
+					String filedName = field.getKey();
+					Field declaredField = clazz.getDeclaredField(filedName);
+					Class<?> type = declaredField.getType();
+					if (Collection.class.isAssignableFrom(type)) {
+						//Look for Generic
+						ParameterizedType genericType = (ParameterizedType)declaredField.getGenericType();
+						assertNotNull("Generic type of the collection can't be null", genericType);
+						assertEquals("In "+classInpect+" the filedName "+filedName+" doesn't match", type.getSimpleName()+"<"+((Class)genericType.getActualTypeArguments()[0]).getSimpleName()+">", field.getValue());
+					}else {
+						assertEquals(type.getSimpleName(), field.getValue());
+					}
+				}
+			}
+			assertTrue("All field has been found",true);
+
+		} catch (MojoExecutionException | DependencyResolutionRequiredException | MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+	private static MavenProject getMockProject() throws DependencyResolutionRequiredException {
+
+		MavenProject project = mock(MavenProject.class);
+		when(project.getCompileClasspathElements()).thenReturn(new ArrayList<String>());
+
+		return project;
+	}
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/json/examples_$id/data-first.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/json/examples_$id/data-first.json
@@ -1,0 +1,10 @@
+{
+    "$id": "http://test.jsonschema2pojo.org/schema-json-test/data-first",
+    "title": "data-first",
+    "description": "Describe An Object.",
+    "type": "object",
+    "properties": {
+        "dataSecond": {"$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-second"}
+    },
+    "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/json/examples_$id/data-second.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/json/examples_$id/data-second.json
@@ -1,0 +1,25 @@
+{
+    "$id": "http://test.jsonschema2pojo.org/schema-json-test/data-second",
+    "title": "data-second",
+    "description": "Describe An Object.",
+    "type": "object",
+    "properties": {
+        "DataFirst": {
+            "description": "Reference to http://test.jsonschema2pojo.org/schema-json-test/data-first",
+            "type": "array",
+            "items": { "$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-first" },
+            "uniqueItems": true
+        },
+        "DataSecond": {
+            "description": "SecondReference to http://test.jsonschema2pojo.org/schema-json-test/data-second",
+            "type": "object",
+            "$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-second"
+        },
+        "DataMain": {
+            "description": "http://test.jsonschema2pojo.org/schema-json-test/main-data",
+            "type": "object",
+            "$ref": "http://test.jsonschema2pojo.org/schema-json-test/main-data"
+        }
+    },
+    "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/json/examples_$id/main-data.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/json/examples_$id/main-data.json
@@ -1,0 +1,43 @@
+{
+    "$id": "http://test.jsonschema2pojo.org/schema-json-test/main-data",
+
+    "title": "main-data",
+    "description": "Describe An Object.",
+    "type": "object",
+    "properties": {
+        "DataFirst1": {
+            "description": "Reference to http://test.jsonschema2pojo.org/schema-json-test/data-first",
+            "type": "array",
+            "items": { "$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-first" },
+            "uniqueItems": true
+        },
+        "DataFirst2": {
+            "description": "SecondReference to http://test.jsonschema2pojo.org/schema-json-test/data-first",
+            "type": "object",
+            "$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-first"
+        },
+        "DataSecond1": {
+            "description": "Reference to http://test.jsonschema2pojo.org/schema-json-test/data-second",
+            "type": "object",
+            "$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-second"
+        },
+        "Prop": {
+            "description": "Tell how to initialize the component",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Just an Id",
+                    "type": "integer"
+                },
+                "other-main-data": {
+                    "description": "A ref to the same class",
+		            "$ref": "http://test.jsonschema2pojo.org/schema-json-test/main-data"
+                }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        }
+    },
+    "required": ["DataFirst1"],
+    "additionalProperties": false
+}

--- a/jsonschema2pojo-maven-plugin/pom.xml
+++ b/jsonschema2pojo-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema2pojo</artifactId>
         <groupId>org.jsonschema2pojo</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+	    <version>1.2.2-Id-Management</version>
     </parent>
 
     <artifactId>jsonschema2pojo-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.jsonschema2pojo</groupId>
     <artifactId>jsonschema2pojo</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2-Id-Management</version>
 
     <packaging>pom</packaging>
     <name>jsonschema2pojo</name>


### PR DESCRIPTION
reference ($ref) other Schemas by it's $id like Dialect 2020-12 declares it.
Samples is provided in jsonschema2pojo-integration-tests project in src/test/resources/json/examples_$id

Other example bellow : 
{
    "$id": "http://test.jsonschema2pojo.org/schema-json-test/main-data",
    "title": "main-data",
    "description": "Describe An Object.",
    "type": "object",
    "properties": {
        "DataFirst1": {
            "description": "Reference to http://test.jsonschema2pojo.org/schema-json-test/data-first",
            "type": "array",
            "items": { "$ref": "http://test.jsonschema2pojo.org/schema-json-test/data-first" },
            "uniqueItems": true
        }
    }
}