### PR TITLE
Fix #1669: JSR 303 annotations on array types

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRule.java
@@ -63,6 +63,14 @@ public class MinItemsMaxItemsRule implements Rule<JFieldVar, JFieldVar> {
     }
 
     private boolean isApplicableType(JFieldVar field) {
+        // Per https://github.com/joelittlejohn/jsonschema2pojo/issues/1669
+        // Class.forName() loads array classes for names like "[B" (for primitives) and
+        // "[Ljava.lang.String;" (for objects). However, JType.fullName() returns the name as
+        // "byte[]" and "java.lang.String[]" respectively. So, we need to check if the type is an
+        // array type before inspecting names, and if so, return true.
+        if (field.type().isArray())
+            return true;
+
         try {
             String typeName = field.type().boxify().fullName();
             // For collections, the full name will be something like 'java.util.List<String>' and we
@@ -76,8 +84,7 @@ public class MinItemsMaxItemsRule implements Rule<JFieldVar, JFieldVar> {
             return String.class.isAssignableFrom(fieldClass)
                     || Collection.class.isAssignableFrom(fieldClass)
                     || Map.class.isAssignableFrom(fieldClass)
-                    || Array.class.isAssignableFrom(fieldClass)
-                    || field.type().isArray();
+                    || Array.class.isAssignableFrom(fieldClass);
         } catch (ClassNotFoundException ignore) {
             return false;
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRule.java
@@ -63,6 +63,14 @@ public class MinLengthMaxLengthRule implements Rule<JFieldVar, JFieldVar> {
     }
 
     private boolean isApplicableType(JFieldVar field) {
+        // Per https://github.com/joelittlejohn/jsonschema2pojo/issues/1669
+        // Class.forName() loads array classes for names like "[B" (for primitives) and
+        // "[Ljava.lang.String;" (for objects). However, JType.fullName() returns the name as
+        // "byte[]" and "java.lang.String[]" respectively. So, we need to check if the type is an
+        // array type before inspecting names, and if so, return true.
+        if (field.type().isArray())
+            return true;
+     
         try {
             String typeName = field.type().boxify().fullName();
             // For collections, the full name will be something like 'java.util.List<String>' and we
@@ -76,8 +84,7 @@ public class MinLengthMaxLengthRule implements Rule<JFieldVar, JFieldVar> {
             return String.class.isAssignableFrom(fieldClass)
                     || Collection.class.isAssignableFrom(fieldClass)
                     || Map.class.isAssignableFrom(fieldClass)
-                    || Array.class.isAssignableFrom(fieldClass)
-                    || field.type().isArray();
+                    || Array.class.isAssignableFrom(fieldClass);
         } catch (ClassNotFoundException ignore) {
             return false;
         }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
@@ -81,6 +81,8 @@ public class MinItemsMaxItemsRuleTest {
                 { false, Long.class },
                 { false, Float.class },
                 { false, Double.class },
+                // For example, type string with media.binaryEncoding="base64"
+                { true, byte[].class }
         }).stream()
                 .flatMap(o -> Stream.of(true, false).map(b -> Stream.concat(stream(o), Stream.of(b)).toArray()))
                 .collect(Collectors.toList());
@@ -108,6 +110,7 @@ public class MinItemsMaxItemsRuleTest {
         when(node.get("minItems")).thenReturn(subNode);
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("minItems")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName());
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);
@@ -126,6 +129,7 @@ public class MinItemsMaxItemsRuleTest {
         when(node.get("maxItems")).thenReturn(subNode);
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("maxItems")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName());
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);
@@ -149,6 +153,7 @@ public class MinItemsMaxItemsRuleTest {
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("minItems")).thenReturn(true);
         when(node.has("maxItems")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName());
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);
@@ -172,6 +177,7 @@ public class MinItemsMaxItemsRuleTest {
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("minItems")).thenReturn(true);
         when(node.has("maxItems")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName() + "<String>");
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
@@ -81,6 +81,8 @@ public class MinLengthMaxLengthRuleTest {
                 { false, Long.class },
                 { false, Float.class },
                 { false, Double.class },
+                // For example, type string with media.binaryEncoding="base64"
+                { true, byte[].class }                
         }).stream()
                 .flatMap(o -> Stream.of(true, false).map(b -> Stream.concat(stream(o), Stream.of(b)).toArray()))
                 .collect(Collectors.toList());
@@ -108,6 +110,7 @@ public class MinLengthMaxLengthRuleTest {
         when(node.get("minLength")).thenReturn(subNode);
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("minLength")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName());
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);
@@ -126,6 +129,7 @@ public class MinLengthMaxLengthRuleTest {
         when(node.get("maxLength")).thenReturn(subNode);
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("maxLength")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName());
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);
@@ -149,6 +153,7 @@ public class MinLengthMaxLengthRuleTest {
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("minLength")).thenReturn(true);
         when(node.has("maxLength")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName());
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);
@@ -172,6 +177,7 @@ public class MinLengthMaxLengthRuleTest {
         when(fieldVar.annotate(sizeClass)).thenReturn(annotation);
         when(node.has("minLength")).thenReturn(true);
         when(node.has("maxLength")).thenReturn(true);
+        when(fieldVar.type().isArray()).thenReturn(fieldClass.isArray());
         when(fieldVar.type().boxify().fullName()).thenReturn(fieldClass.getTypeName() + "<String>");
 
         JFieldVar result = rule.apply("node", node, null, fieldVar, null);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
@@ -21,6 +21,8 @@ import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.junit.Assert.*;
 
+import jakarta.validation.constraints.Size;
+
 import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -61,7 +63,10 @@ public class MediaIT {
     @BeforeClass
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
-        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/media/mediaProperties.json", "com.example", config("customAnnotator", QuotedPrintableAnnotator.class.getName()));
+        ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/media/mediaProperties.json", "com.example",
+            config("customAnnotator", QuotedPrintableAnnotator.class.getName(),
+                "includeJsr303Annotations", true,
+                "useJakartaValidation", true));
 
         classWithMediaProperties = resultsClassLoader.loadClass("com.example.MediaProperties");
     }
@@ -169,6 +174,20 @@ public class MediaIT {
                         equalTo(new byte[] { (byte)0xFF, (byte)0xF0, (byte)0x0F, (byte)0x00})));
     }
 
+    @Test
+    public void shouldCreateCorrectValidationAnnotations() throws SecurityException, NoSuchFieldException {
+      Field minimalField = classWithMediaProperties.getDeclaredField("minimalBinary");
+      Field annotatedField = classWithMediaProperties.getDeclaredField("base64WithMinAndMaxLength");
+
+      assertThat("any minimal binary field has return type byte[]", minimalField.getType(), equalToType(BYTE_ARRAY));
+      assertThat("any minimal binary field has no @Size annotation", minimalField.getAnnotation(Size.class), nullValue());
+      
+      assertThat("the annotated binary field has type byte[]", annotatedField.getType(), equalToType(BYTE_ARRAY));
+      assertThat("the annotated binary field has annotation @Size", annotatedField.getAnnotation(Size.class), notNullValue());
+      assertThat("the annotated binary field has annotation @Size with min=1", annotatedField.getAnnotation(Size.class).min(), equalTo(1));
+      assertThat("the annotated binary field has annotation @Size with max=100", annotatedField.getAnnotation(Size.class).max(), equalTo(100));
+    }
+    
     @Test
     public void shouldRoundTripBase64Field() throws Exception {
         roundTripAssertions(

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/media/mediaProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/media/mediaProperties.json
@@ -39,6 +39,15 @@
       "media" : {
         "binaryEncoding": "base64"
       }
+    }  ,
+    "base64WithMinAndMaxLength" : {
+      "type" : "string",
+      "default": "//APAA==",
+      "media" : {
+        "binaryEncoding": "base64"
+      },
+      "minLength": 1,
+      "maxLength": 100
     }
   }
 }


### PR DESCRIPTION
This is a (relatively) straightforward fix of the issue where JSR 303 annotations are not generated for array types.

For example, the schema...

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "BinaryImageAttributes",
  "type": "object",
  "properties": {
    "bytes": {
      "type": "string",
      "media": {
        "binaryEncoding": "base64"
      },
      "description": "Base64-encoded binary image data.",
      "minLength": 1,
      "maxLength": 102400
    }
  },
  "required": ["bytes"]
}
```

...should generate a `@Size` annotation on the `bytes` field due to the presence of `minLength` and `maxLength`, but it does not.

The core issue was that the code (quite reasonably) assumed that `JType#fullName()` would always return values that could subsequently be loaded by `Class#forName()`, modulo any type parameters. However, for arrays (e.g., byte arrays), `JType#fullName()` would return `byte[]`, whereas `Class#forName()` expects `[B`. Simply checking for array types using `JType#isArray()` before inspecting names fixes the issue.

Fix includes tests.

Hopefully this all makes sense! Please send all questions, comments, and thoughts my way, and I will address ASAP.

Thank you for maintaining `jsonschema2pojo`!