### PR TITLE
Avoid duplicate "is" prefix for boolean getters

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -219,13 +219,24 @@ public class NameHelper {
     public String getGetterName(String propertyName, JType type, JsonNode node) {
         propertyName = getPropertyNameForAccessor(propertyName, node);
 
-        String prefix = type.equals(type.owner()._ref(boolean.class)) ? "is" : "get";
+        boolean isBoolean = type.equals(type.owner()._ref(boolean.class));
+
+        boolean nameAlreadyHasIsPrefix = isBoolean &&
+                                        propertyName.startsWith("is") &&
+                                        propertyName.length() > 2 &&
+                                        Character.isUpperCase(propertyName.charAt(2));
 
         String getterName;
-        if (propertyName.length() > 1 && Character.isUpperCase(propertyName.charAt(1))) {
-            getterName = prefix + propertyName;
+        if (nameAlreadyHasIsPrefix) {
+            getterName = propertyName;
         } else {
-            getterName = prefix + capitalize(propertyName);
+            String prefix = isBoolean ? "is" : "get";
+
+            if (propertyName.length() > 1 && Character.isUpperCase(propertyName.charAt(1))) {
+                getterName = prefix + propertyName;
+            } else {
+                getterName = prefix + capitalize(propertyName);
+            }
         }
 
         if (getterName.equals("getClass")) {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
@@ -37,6 +37,7 @@ public class NameHelperTest {
     @Test
     public void testGetterNamedCorrectly() {
         assertThat(nameHelper.getGetterName("foo", new JCodeModel().BOOLEAN, NODE), is("isFoo"));
+        assertThat(nameHelper.getGetterName("isFoo", new JCodeModel().BOOLEAN, NODE), is("isFoo"));
         assertThat(nameHelper.getGetterName("foo", new JCodeModel().INT, NODE), is("getFoo"));
         assertThat(nameHelper.getGetterName("oAuth2State", new JCodeModel().INT, NODE), is("getoAuth2State"));
         assertThat(nameHelper.getGetterName("URL", new JCodeModel().INT, NODE), is("getUrl"));
@@ -45,6 +46,7 @@ public class NameHelperTest {
     @Test
     public void testSetterNamedCorrectly() {
         assertThat(nameHelper.getSetterName("foo", NODE), is("setFoo"));
+        assertThat(nameHelper.getSetterName("isFoo", NODE), is("setIsFoo"));
         assertThat(nameHelper.getSetterName("oAuth2State", NODE), is("setoAuth2State"));
         assertThat(nameHelper.getSetterName("URL", NODE), is("setUrl"));
     }


### PR DESCRIPTION
Boolean property names that start with the prefix "is" currently receive another "is" prefix, generating, for example, the getter `isIsValid` for the property name "isValid".

This merge request aims to avoid these duplicate prefixes.