### PR TITLE
Migrate from junit4 to junit5

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,7 +18,7 @@ jobs:
         java_version: [8]
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.14.0
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           checkout-fetch-depth: 0
           java-version: ${{ matrix.java_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test JDK ${{ matrix.java_version }}
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.14.0
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           checkout-fetch-depth: 0
           java-version: ${{ matrix.java_version }}

--- a/jsonschema2pojo-cli/pom.xml
+++ b/jsonschema2pojo-cli/pom.xml
@@ -122,7 +122,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/jsonschema2pojo-cli/pom.xml
+++ b/jsonschema2pojo-cli/pom.xml
@@ -117,8 +117,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -126,7 +126,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ArgumentsTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ArgumentsTest.java
@@ -27,9 +27,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import org.jsonschema2pojo.InclusionLevel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ArgumentsTest {
 
@@ -38,13 +38,13 @@ public class ArgumentsTest {
     private final ByteArrayOutputStream systemOutCapture = new ByteArrayOutputStream();
     private final ByteArrayOutputStream systemErrCapture = new ByteArrayOutputStream();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         System.setOut(new PrintStream(systemOutCapture));
         System.setErr(new PrintStream(systemErrCapture));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         System.setOut(SYSTEM_OUT);
         System.setErr(SYSTEM_ERR);

--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ClassConverterTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ClassConverterTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.cli;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.Annotator;
 import org.junit.Test;
@@ -26,7 +26,7 @@ import com.beust.jcommander.ParameterException;
 
 public class ClassConverterTest {
 
-    private ClassConverter converter = new ClassConverter("--custom-annotator");
+    private final ClassConverter converter = new ClassConverter("--custom-annotator");
 
     @Test
     @SuppressWarnings("unchecked")

--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ClassConverterTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/ClassConverterTest.java
@@ -18,9 +18,10 @@ package org.jsonschema2pojo.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jsonschema2pojo.Annotator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.beust.jcommander.ParameterException;
 
@@ -36,14 +37,14 @@ public class ClassConverterTest {
         assertThat(clazz, is(equalTo(Annotator.class)));
     }
 
-    @Test(expected = ParameterException.class)
+    @Test
     public void invalidClassNameThrowsParameterException() {
-        converter.convert("some garbage.name");
+        assertThrows(ParameterException.class, () -> converter.convert("some garbage.name"));
     }
 
-    @Test(expected = ParameterException.class)
+    @Test
     public void nullValueThrowsParameterException() {
-        converter.convert(null);
+        assertThrows(ParameterException.class, () -> converter.convert(null));
     }
 
 }

--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/UrlConverterTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/UrlConverterTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.cli;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.net.URL;
 
@@ -27,7 +27,7 @@ import com.beust.jcommander.ParameterException;
 
 public class UrlConverterTest {
 
-    private UrlConverter converter = new UrlConverter("--source");
+    private final UrlConverter converter = new UrlConverter("--source");
 
     @Test
     public void urlIsCreatedFromFilePath() {

--- a/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/UrlConverterTest.java
+++ b/jsonschema2pojo-cli/src/test/java/org/jsonschema2pojo/cli/UrlConverterTest.java
@@ -18,10 +18,11 @@ package org.jsonschema2pojo.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.beust.jcommander.ParameterException;
 
@@ -45,14 +46,14 @@ public class UrlConverterTest {
         assertThat(url.toString(), is("file:/path/to/something"));
     }
 
-    @Test(expected = ParameterException.class)
+    @Test
     public void invalidUrlThrowsParameterException() {
-        converter.convert("http:total nonsense");
+        assertThrows(ParameterException.class, () -> converter.convert("http:total nonsense"));
     }
 
-    @Test(expected = ParameterException.class)
+    @Test
     public void nullValueThrowsParameterException() {
-        converter.convert(null);
+        assertThrows(ParameterException.class, () -> converter.convert(null));
     }
 
 }

--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -72,8 +72,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -81,11 +81,11 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/AnnotatorFactoryTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/AnnotatorFactoryTest.java
@@ -19,12 +19,13 @@ package org.jsonschema2pojo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.AnnotationStyle.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class AnnotatorFactoryTest {
 
@@ -51,8 +52,8 @@ public class AnnotatorFactoryTest {
     @Test
     public void canCreateCompositeAnnotator() {
 
-        Annotator annotator1 = mock(Annotator.class);
-        Annotator annotator2 = mock(Annotator.class);
+        Annotator annotator1 = Mockito.mock(Annotator.class);
+        Annotator annotator2 = Mockito.mock(Annotator.class);
 
         CompositeAnnotator composite = factory.getAnnotator(annotator1, annotator2);
 
@@ -66,15 +67,14 @@ public class AnnotatorFactoryTest {
      * Test uses reflection to get passed the generic type constraints and
      * invoke as if invoked through typical configuration.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void attemptToCreateAnnotatorFromIncompatibleClassCausesIllegalArgumentException() throws Throwable {
-        try {
-            Method factoryMethod = AnnotatorFactory.class.getMethod("getAnnotator", Class.class);
-            factoryMethod.invoke(factory, String.class);
-        } catch (InvocationTargetException e) {
-            throw e.getTargetException();
-        }
-
+        Method factoryMethod = AnnotatorFactory.class.getMethod("getAnnotator", Class.class);
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> factoryMethod.invoke(factory, String.class));
+        assertThat(exception.getTargetException(), is(instanceOf(IllegalArgumentException.class)));
+        assertThat(
+                exception.getTargetException().getMessage(),
+                is(equalTo("The class name given as a custom annotator (java.lang.String) does not refer to a class that implements org.jsonschema2pojo.Annotator")));
     }
 
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/AnnotatorFactoryTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/AnnotatorFactoryTest.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.AnnotationStyle.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.InvocationTargetException;
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class AnnotatorFactoryTest {
 
-    private AnnotatorFactory factory = new AnnotatorFactory(new DefaultGenerationConfig());
+    private final AnnotatorFactory factory = new AnnotatorFactory(new DefaultGenerationConfig());
 
     @Test
     public void canCreateCorrectAnnotatorFromAnnotationStyle() {
@@ -67,10 +67,13 @@ public class AnnotatorFactoryTest {
      * invoke as if invoked through typical configuration.
      */
     @Test(expected = IllegalArgumentException.class)
-    public void attemptToCreateAnnotatorFromIncompatibleClassCausesIllegalArgumentException() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-
-        Method factoryMethod = AnnotatorFactory.class.getMethod("getAnnotator", Class.class);
-        factoryMethod.invoke(String.class);
+    public void attemptToCreateAnnotatorFromIncompatibleClassCausesIllegalArgumentException() throws Throwable {
+        try {
+            Method factoryMethod = AnnotatorFactory.class.getMethod("getAnnotator", Class.class);
+            factoryMethod.invoke(factory, String.class);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
 
     }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverNetworkTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverNetworkTest.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.net.URI;
 
@@ -30,7 +30,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 /**
-  * @author {@link "https://github.com/s13o" "s13o"}
+  * @author <a href="https://github.com/s13o">s13o</a>
   * @since 3/17/2017
   */
 public class ContentResolverNetworkTest {
@@ -52,7 +52,7 @@ public class ContentResolverNetworkTest {
         server.stop();
     }
 
-    private ContentResolver resolver = new ContentResolver();
+    private final ContentResolver resolver = new ContentResolver();
     
     @Test(expected=IllegalArgumentException.class)
     public void brokenLinkCausesIllegalArgumentException() {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
@@ -18,6 +18,7 @@ package org.jsonschema2pojo;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -26,7 +27,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -34,11 +35,10 @@ public class ContentResolverTest {
 
     private final ContentResolver resolver = new ContentResolver();
     
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void wrongProtocolCausesIllegalArgumentException() {
-
         URI uriWithUnrecognisedProtocol = URI.create("foobar://schema/address.json"); 
-        resolver.resolve(uriWithUnrecognisedProtocol);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(uriWithUnrecognisedProtocol));
     }
 
     @Test

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
@@ -16,14 +16,15 @@
 
 package org.jsonschema2pojo;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -31,7 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class ContentResolverTest {
 
-    private ContentResolver resolver = new ContentResolver();
+    private final ContentResolver resolver = new ContentResolver();
     
     @Test(expected=IllegalArgumentException.class)
     public void wrongProtocolCausesIllegalArgumentException() {
@@ -79,7 +80,7 @@ public class ContentResolverTest {
         tempFile.deleteOnExit();
 
         try (OutputStream outputStream = new FileOutputStream(tempFile)) {
-            outputStream.write("{\"type\" : \"string\"}".getBytes("utf-8"));
+            outputStream.write("{\"type\" : \"string\"}".getBytes(StandardCharsets.UTF_8));
         }
         
         return tempFile.toURI();

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class FragmentResolverTest {
 
-    private FragmentResolver resolver = new FragmentResolver();
+    private final FragmentResolver resolver = new FragmentResolver();
 
     @Test
     public void hashResolvesToRoot() {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
@@ -18,8 +18,9 @@ package org.jsonschema2pojo;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -117,25 +118,21 @@ public class FragmentResolverTest {
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missingPathThrowsIllegalArgumentException() {
-
         ObjectNode root = new ObjectMapper().createObjectNode();
 
-        resolver.resolve(root, "#/a/b/c", "#/.");
-
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(root, "#/a/b/c", "#/."));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void attemptToUsePropertyNameOnArrayNodeThrowsIllegalArgumentException() {
-
         ObjectNode root = new ObjectMapper().createObjectNode();
 
         ArrayNode a = root.arrayNode();
         root.set("a", a);
 
-        resolver.resolve(root, "#/a/b", "#/.");
-
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(root, "#/a/b", "#/."));
     }
 
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/JsonPointerUtilsTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/JsonPointerUtilsTest.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaMapperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaMapperTest.java
@@ -26,7 +26,7 @@ import java.net.URL;
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.rules.RuleFactory;
 import org.jsonschema2pojo.rules.SchemaRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
@@ -27,7 +27,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JType;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo;
 
 import static org.apache.commons.lang3.StringUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SourceSortOrderTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SourceSortOrderTest.java
@@ -24,9 +24,10 @@ import static org.mockito.Mockito.*;
 import java.io.File;
 import java.util.Comparator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SourceSortOrderTest {
+
     @Test
     public void testTwoFilesAreCompared_FILES_FIRST() {
         testTwoFilesAreCompared(SourceSortOrder.FILES_FIRST.getComparator());

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/AdditionalPropertiesRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/AdditionalPropertiesRuleTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import org.jsonschema2pojo.Schema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/AdditionalPropertiesRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/AdditionalPropertiesRuleTest.java
@@ -16,7 +16,8 @@
 
 package org.jsonschema2pojo.rules;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 import org.jsonschema2pojo.Schema;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class AdditionalPropertiesRuleTest {
         JDefinedClass result = rule.apply("node", node, parent, jclass, schema);
         JMethod method = result.getMethod("getAdditionalProperties", new JType[0]);
         JClass returnType = (JClass) method.type();
-        assertEquals("Map<String,Integer>", returnType.name());
+        assertThat(returnType.name(), is(equalTo("Map<String,Integer>")));
     }
 
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/CommentRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/CommentRuleTest.java
@@ -19,7 +19,7 @@ package org.jsonschema2pojo.rules;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -32,7 +32,7 @@ public class CommentRuleTest {
 
     private static final String TARGET_CLASS_NAME = CommentRuleTest.class.getName() + ".DummyClass";
 
-    private CommentRule rule = new CommentRule();
+    private final CommentRule rule = new CommentRule();
 
     @Test
     public void applyAddsCommentToJavadoc() throws JClassAlreadyExistsException {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DefaultRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DefaultRuleTest.java
@@ -39,9 +39,9 @@ import com.sun.codemodel.JFormatter;
 import com.sun.codemodel.JMod;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DefaultRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DefaultRuleTest.java
@@ -17,17 +17,15 @@
 package org.jsonschema2pojo.rules;
 
 import java.io.StringWriter;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -38,28 +36,20 @@ import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JFormatter;
 import com.sun.codemodel.JMod;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@ValueSource(classes = { Set.class, List.class })
 public class DefaultRuleTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
     private final DefaultRule rule = new DefaultRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
 
     private final Class<?> fieldTypeClass;
-
-    @Parameters
-    public static Collection<Object[]> data() {
-        return asList(new Object[][] {
-                { Set.class },
-                { List.class }
-        });
-    }
 
     public DefaultRuleTest(Class<?> fieldTypeClass) {
         this.fieldTypeClass = fieldTypeClass;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DescriptionRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DescriptionRuleTest.java
@@ -19,7 +19,7 @@ package org.jsonschema2pojo.rules;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -32,7 +32,7 @@ public class DescriptionRuleTest {
 
     private static final String TARGET_CLASS_NAME = DescriptionRuleTest.class.getName() + ".DummyClass";
 
-    private DescriptionRule rule = new DescriptionRule();
+    private final DescriptionRule rule = new DescriptionRule();
 
     @Test
     public void applyAddsDescriptionToJavadoc() throws JClassAlreadyExistsException {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DigitsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DigitsRuleTest.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -31,10 +31,10 @@ import java.util.stream.Stream;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -50,7 +50,8 @@ import jakarta.validation.constraints.Size;
 /**
  * Tests {@link DigitsRuleTest}
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class DigitsRuleTest {
 
     private final boolean isApplicable;
@@ -73,7 +74,6 @@ public class DigitsRuleTest {
     @Mock
     private JAnnotationUse annotation;
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { true, BigDecimal.class },
@@ -105,7 +105,7 @@ public class DigitsRuleTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         rule = new DigitsRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DynamicPropertiesRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DynamicPropertiesRuleTest.java
@@ -20,8 +20,8 @@ import static com.sun.codemodel.JMod.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sun.codemodel.JClassAlreadyExistsException;
 import com.sun.codemodel.JCodeModel;
@@ -41,7 +41,7 @@ public class DynamicPropertiesRuleTest {
 
     JDefinedClass type2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws JClassAlreadyExistsException {
         type = codeModel._class("org.jsonschema2pojo.rules.ExampleClass");
         numberGetter = type.method(PUBLIC, codeModel._ref(Integer.class), "getNumber");

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -24,10 +24,9 @@ import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.RuleLogger;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.util.NameHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -49,7 +48,7 @@ public class EnumRuleTest {
 
     private final EnumRule rule = new EnumRule(ruleFactory);
 
-    @Before
+    @BeforeEach
     public void wireUpConfig() {
         when(ruleFactory.getNameHelper()).thenReturn(nameHelper);
         when(ruleFactory.getLogger()).thenReturn(logger);
@@ -59,8 +58,7 @@ public class EnumRuleTest {
 
     @Test
     public void applyGeneratesUniqueEnumNamesForMultipleEnumNodesWithSameName() {
-
-        Answer<String> firstArgAnswer = new FirstArgAnswer<>();
+        final Answer<?> firstArgAnswer = invocation -> invocation.getArgument(0);
         when(nameHelper.getClassName(anyString(), ArgumentMatchers.any(JsonNode.class))).thenAnswer(firstArgAnswer);
         when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
         when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
@@ -86,13 +84,4 @@ public class EnumRuleTest {
         assertThat(result2.fullName(), is("org.jsonschema2pojo.rules.Status_"));
     }
 
-    private static class FirstArgAnswer<T> implements Answer<T> {
-        @SuppressWarnings("unchecked")
-        @Override
-        public T answer(InvocationOnMock invocation) {
-            Object[] args = invocation.getArguments();
-            //noinspection unchecked
-            return (T) args[0];
-        }
-    }
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleArraysTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleArraysTest.java
@@ -27,25 +27,23 @@ import java.util.Collections;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JType;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class FormatRuleArraysTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
     private final FormatRule rule;
 
-    private final String formatValue;
     private final Class<?> expectedType;
 
-    @Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { "byte[]", byte[].class },
@@ -53,7 +51,6 @@ public class FormatRuleArraysTest {
     }
 
     public FormatRuleArraysTest(String formatValue, Class<?> expectedType) {
-        this.formatValue = formatValue;
         this.expectedType = expectedType;
 
         when(config.getFormatTypeMapping()).thenReturn(Collections.singletonMap("test", formatValue));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleArraysTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleArraysTest.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Collection;
@@ -64,7 +64,7 @@ public class FormatRuleArraysTest {
     public void useArraysWithCustomTypeMapping() {
         JType result = rule.apply("fooBar", TextNode.valueOf("test"), null, new JCodeModel().ref(Object.class), null);
 
-        assertTrue(result.isArray());
+        assertThat(result.isArray(), is(true));
 
         JType expectedJType = new JCodeModel().ref(expectedType);
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
@@ -29,17 +29,17 @@ import org.joda.time.LocalTime;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JType;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class FormatRuleJodaTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
@@ -48,7 +48,6 @@ public class FormatRuleJodaTest {
     private final String formatValue;
     private final Class<?> expectedType;
 
-    @Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { "date-time", DateTime.class },
@@ -61,7 +60,7 @@ public class FormatRuleJodaTest {
         this.expectedType = expectedType;
     }
 
-    @Before
+    @BeforeEach
     public void setupConfig() {
         when(config.isUseJodaLocalTimes()).thenReturn(true);
         when(config.isUseJodaLocalDates()).thenReturn(true);

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Collection;
@@ -42,7 +42,7 @@ import com.sun.codemodel.JType;
 @RunWith(Parameterized.class)
 public class FormatRuleJodaTest {
 
-    private GenerationConfig config = mock(GenerationConfig.class);
+    private final GenerationConfig config = mock(GenerationConfig.class);
     private FormatRule rule;
 
     private final String formatValue;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRulePrimitivesTest.java
@@ -28,16 +28,16 @@ import java.util.Collections;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JType;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class FormatRulePrimitivesTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
@@ -46,7 +46,6 @@ public class FormatRulePrimitivesTest {
     private final Class<?> primitive;
     private final Class<?> wrapper;
 
-    @Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { boolean.class, Boolean.class },

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
@@ -30,16 +30,16 @@ import java.util.regex.Pattern;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JType;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class FormatRuleTest {
 
     private GenerationConfig config = mock(GenerationConfig.class);
@@ -48,7 +48,6 @@ public class FormatRuleTest {
     private final String formatValue;
     private final Class<?> expectedType;
 
-    @Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { "date-time", Date.class },

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinItemsMaxItemsRuleTest.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -31,10 +31,10 @@ import java.util.stream.Stream;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -49,7 +49,8 @@ import jakarta.validation.constraints.Size;
 /**
  * Tests {@link MinItemsMaxItemsRuleTest}
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class MinItemsMaxItemsRuleTest {
 
     private final boolean isApplicable;
@@ -68,7 +69,6 @@ public class MinItemsMaxItemsRuleTest {
     @Mock
     private JAnnotationUse annotation;
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { true, String.class },
@@ -93,7 +93,7 @@ public class MinItemsMaxItemsRuleTest {
         this.sizeClass = useJakartaValidation ? Size.class : javax.validation.constraints.Size.class;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         rule = new MinItemsMaxItemsRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinLengthMaxLengthRuleTest.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -31,10 +31,10 @@ import java.util.stream.Stream;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -49,7 +49,8 @@ import jakarta.validation.constraints.Size;
 /**
  * Tests {@link MinLengthMaxLengthRuleTest}
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class MinLengthMaxLengthRuleTest {
 
     private final boolean isApplicable;
@@ -68,7 +69,6 @@ public class MinLengthMaxLengthRuleTest {
     @Mock
     private JAnnotationUse annotation;
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { true, String.class },
@@ -93,7 +93,7 @@ public class MinLengthMaxLengthRuleTest {
         this.sizeClass = useJakartaValidation ? Size.class : javax.validation.constraints.Size.class;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         rule = new MinLengthMaxLengthRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinimumMaximumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/MinimumMaximumRuleTest.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -31,10 +31,10 @@ import java.util.stream.Stream;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -51,7 +51,8 @@ import jakarta.validation.constraints.Size;
 /**
  * Tests {@link MinimumMaximumRuleTest}
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class MinimumMaximumRuleTest {
 
     private final boolean isApplicable;
@@ -74,7 +75,6 @@ public class MinimumMaximumRuleTest {
     @Mock
     private JAnnotationUse annotationMin;
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { true, BigDecimal.class },
@@ -106,7 +106,7 @@ public class MinimumMaximumRuleTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         rule = new MinimumMaximumRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PatternRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PatternRuleTest.java
@@ -17,7 +17,7 @@
 package org.jsonschema2pojo.rules;
 
 import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -31,10 +31,10 @@ import java.util.stream.Stream;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -48,7 +48,8 @@ import jakarta.validation.constraints.Pattern;
 /**
  * Tests {@link PatternRuleTest}
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class PatternRuleTest {
 
     private final boolean isApplicable;
@@ -65,7 +66,6 @@ public class PatternRuleTest {
     @Mock
     private JAnnotationUse annotation;
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { true, String.class },
@@ -91,7 +91,7 @@ public class PatternRuleTest {
         this.patternClass = useJakartaValidation ? Pattern.class : javax.validation.constraints.Pattern.class;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         rule = new PatternRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredArrayRuleTest.java
@@ -26,9 +26,9 @@ import java.util.Collection;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -41,7 +41,8 @@ import com.sun.codemodel.JMod;
 
 import jakarta.validation.constraints.NotNull;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class RequiredArrayRuleTest {
 
     private static final String TARGET_CLASS_NAME = RequiredArrayRuleTest.class.getName() + ".DummyClass";
@@ -51,7 +52,6 @@ public class RequiredArrayRuleTest {
     private final boolean useJakartaValidation;
     private final Class<? extends Annotation> notNullClass;
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                 { false, javax.validation.constraints.NotNull.class },

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RequiredRuleTest.java
@@ -19,7 +19,7 @@ package org.jsonschema2pojo.rules;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -32,7 +32,7 @@ public class RequiredRuleTest {
 
     private static final String TARGET_CLASS_NAME = RequiredRuleTest.class.getName() + ".DummyClass";
 
-    private RequiredRule rule = new RequiredRule(new RuleFactory());
+    private final RequiredRule rule = new RequiredRule(new RuleFactory());
 
     @Test
     public void applyAddsTextWhenRequired() throws JClassAlreadyExistsException {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.rules;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.jsonschema2pojo.DefaultGenerationConfig;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
@@ -25,7 +25,7 @@ import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.NoopAnnotator;
 import org.jsonschema2pojo.RuleLogger;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RuleFactoryImplTest {
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -26,7 +26,7 @@ import java.net.URISyntaxException;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.rules;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TitleRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TitleRuleTest.java
@@ -19,7 +19,7 @@ package org.jsonschema2pojo.rules;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -32,7 +32,7 @@ public class TitleRuleTest {
 
     private static final String TARGET_CLASS_NAME = TitleRuleTest.class.getName() + ".DummyClass";
 
-    private TitleRule rule = new TitleRule();
+    private final TitleRule rule = new TitleRule();
 
     @Test
     public void applyAddsDescriptionToJavadoc() throws JClassAlreadyExistsException {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -24,8 +24,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.jsonschema2pojo.GenerationConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +44,7 @@ public class TypeRuleTest {
 
     private final TypeRule rule = new TypeRule(ruleFactory);
 
-    @Before
+    @BeforeEach
     public void wireUpConfig() {
         when(ruleFactory.getGenerationConfig()).thenReturn(config);
     }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
@@ -16,10 +16,10 @@
 
 package org.jsonschema2pojo.util;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-
-import org.junit.Test;
 
 public class InflectorTest {
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/InflectorTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import org.junit.Test;
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/JavaVersionTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/JavaVersionTest.java
@@ -16,10 +16,10 @@
 
 package org.jsonschema2pojo.util;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
-
-import org.junit.Test;
 
 public class JavaVersionTest {
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/MakeUniqueClassNameTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/MakeUniqueClassNameTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import org.junit.Test;
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/MakeUniqueClassNameTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/MakeUniqueClassNameTest.java
@@ -16,10 +16,10 @@
 
 package org.jsonschema2pojo.util;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-
-import org.junit.Test;
 
 public class MakeUniqueClassNameTest {
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
 
 import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.GenerationConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/NameHelperTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.jsonschema2pojo.DefaultGenerationConfig;
@@ -64,16 +64,16 @@ public class NameHelperTest {
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar").put("title", "abc")), is("bar"));
 
         // TITLE_ATTRIBUTE
-        NameHelper nameHelper = helper(true);
+        NameHelper nameHelper = helper();
         assertThat(nameHelper.getClassName("foo", node("title", "bar")), is("Bar"));
         assertThat(nameHelper.getClassName("foo", node("title", "i am bar")), is("IAmBar"));
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar")), is("bar"));
         assertThat(nameHelper.getClassName("foo", node("javaName", "bar").put("title", "abc")), is("bar"));
     }
 
-    private NameHelper helper(boolean useTitleAsClassname) {
+    private NameHelper helper() {
         GenerationConfig config = mock(GenerationConfig.class);
-        when(config.isUseTitleAsClassname()).thenReturn(useTitleAsClassname);
+        when(config.isUseTitleAsClassname()).thenReturn(true);
         return new NameHelper(config);
     }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/TypeUtilTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/TypeUtilTest.java
@@ -18,13 +18,15 @@ package org.jsonschema2pojo.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JPackage;
 
 public class TypeUtilTest {
 
@@ -52,8 +54,9 @@ public class TypeUtilTest {
         assertThat(_class.getTypeParameters().get(0)._extends(), is(equalTo(codeModel.ref(Number.class))));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testResolveTypeForSuperWildcardThrowsException() {
-        TypeUtil.resolveType(new JCodeModel().rootPackage(), "java.util.List<? super java.lang.String>");
+        final JPackage rootPackage = new JCodeModel().rootPackage();
+        assertThrows(IllegalArgumentException.class, () -> TypeUtil.resolveType(rootPackage, "java.util.List<? super java.lang.String>"));
     }
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/TypeUtilTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/util/TypeUtilTest.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.util.List;
 

--- a/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
+++ b/jsonschema2pojo-gradle-plugin/example/android/app/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     // Required if generating Jackson 2 annotations
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+
+    testImplementation 'androidx.test.ext:junit:1.2.1'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
 }
 
 // Each configuration is set to the default value
@@ -119,15 +122,19 @@ jsonSchema2Pojo {
     // that have been generated previously. <strong>Be warned</strong>, when activated this option
     // will cause jsonschema2pojo to <strong>indiscriminately delete the entire contents of the target
     // directory (all files and folders)</strong> before it begins generating sources.
-    boolean removeOldOutput = true
+    removeOldOutput = true
 
     // The character encoding that should be used when writing the generated Java source files
     String outputEncoding = 'UTF-8'
 
     // Whether to use {@link org.joda.time.DateTime} instead of {@link java.util.Date} when adding
     // date type fields to generated Java types.
-    boolean useJodaDates = false
+    useJodaDates = false
 
     // Whether to initialize Set and List fields as empty collections, or leave them as null.
-    boolean initializeCollections = true
+    initializeCollections = true
+
+    //  Whether to make the generated types 'parcelable' (for Android development)
+    parcelable = true
+
 }

--- a/jsonschema2pojo-gradle-plugin/example/android/app/src/test/java/com/example/parcelable/ParcelableTests.java
+++ b/jsonschema2pojo-gradle-plugin/example/android/app/src/test/java/com/example/parcelable/ParcelableTests.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.parcelable;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotSame;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.example.parcelable.Book;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest=Config.NONE, sdk=28)
+public class ParcelableTests {
+
+    @Test
+    public void testParcelable() {
+        Book book = new Book();
+        book.setAuthor("Author");
+        book.setTitle("Title");
+
+        Parcel parcel = parcelableWriteToParcel(book);
+
+        Book unparceledBook = Book.CREATOR.createFromParcel(parcel);
+        assertThat(unparceledBook.getAuthor(), equalTo(book.getAuthor()));
+        assertThat(unparceledBook.getTitle(), equalTo(book.getTitle()));
+        assertThat(unparceledBook, is(equalTo(book)));
+        assertNotSame(book, unparceledBook);
+    }
+
+    private Parcel parcelableWriteToParcel(Parcelable instance) {
+        Parcel parcel = Parcel.obtain();
+        instance.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        return parcel;
+    }
+
+}

--- a/jsonschema2pojo-gradle-plugin/example/android/gradle.properties
+++ b/jsonschema2pojo-gradle-plugin/example/android/gradle.properties
@@ -1,3 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
-android.jetifier.ignorelist=jackson-core
+android.jetifier.ignorelist=jackson-core,bcprov-jdk18on,error_prone_annotation

--- a/jsonschema2pojo-gradle-plugin/example/android/schema/book.json
+++ b/jsonschema2pojo-gradle-plugin/example/android/schema/book.json
@@ -1,0 +1,15 @@
+{
+    "id": "http://some.site.somewhere/entry-schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "javaType" : "com.example.parcelable.Book",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "author": {
+            "type": "string"
+        }
+    },
+    "required": ["title", "author"]
+}

--- a/jsonschema2pojo-gradle-plugin/pom.xml
+++ b/jsonschema2pojo-gradle-plugin/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jsonschema2pojo-gradle-plugin/pom.xml
+++ b/jsonschema2pojo-gradle-plugin/pom.xml
@@ -32,8 +32,8 @@
             <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jsonschema2pojo-gradle-plugin/src/integrationTest/groovy/org/jsonschema2pojo/gradle/GradleBuildIT.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/integrationTest/groovy/org/jsonschema2pojo/gradle/GradleBuildIT.groovy
@@ -18,7 +18,7 @@ package org.jsonschema2pojo.gradle
 import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class GradleBuildIT {
 

--- a/jsonschema2pojo-gradle-plugin/src/test/groovy/org/jsonschema2pojo/gradle/JsonSchemaPluginSpec.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/test/groovy/org/jsonschema2pojo/gradle/JsonSchemaPluginSpec.groovy
@@ -21,7 +21,7 @@ import java.lang.reflect.Field
 import java.nio.charset.StandardCharsets
 
 import org.apache.commons.io.FileUtils
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class JsonSchemaPluginSpec {
 

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -111,8 +111,8 @@
             <artifactId>maven-plugin-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -127,12 +127,8 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.android</groupId>
-            <artifactId>android</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
@@ -168,11 +164,15 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.robolectric</groupId>
             <artifactId>robolectric</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>android-all-instrumented</artifactId>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.qdox</groupId>

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -144,7 +144,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AdditionalPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AdditionalPropertiesIT.java
@@ -19,6 +19,7 @@ package org.jsonschema2pojo.integration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -30,8 +31,8 @@ import java.util.Map;
 
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,7 +42,7 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 public class AdditionalPropertiesIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -116,26 +117,22 @@ public class AdditionalPropertiesIT {
         assertThat(jsonNode.path("b").asInt(), is(2));
     }
 
-    @Test(expected = UnrecognizedPropertyException.class)
+    @Test
     public void additionalPropertiesAreNotDeserializableWhenDisallowed() throws ClassNotFoundException, SecurityException, IOException {
-
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/noAdditionalProperties.json", "com.example");
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.NoAdditionalProperties");
 
-        mapper.readValue("{\"a\":\"1\", \"b\":2}", classWithNoAdditionalProperties);
-
+        assertThrows(UnrecognizedPropertyException.class, () -> mapper.readValue("{\"a\":\"1\", \"b\":2}", classWithNoAdditionalProperties));
     }
 
-    @Test(expected = UnrecognizedPropertyException.class)
+    @Test
     public void additionalPropertiesAreNotDeserializableWhenDisabledGlobally() throws ClassNotFoundException, SecurityException, IOException {
-
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/defaultAdditionalProperties.json", "com.example", config("includeAdditionalProperties", false));
 
         Class<?> classWithNoAdditionalProperties = resultsClassLoader.loadClass("com.example.DefaultAdditionalProperties");
 
-        mapper.readValue("{\"a\":\"1\", \"b\":2}", classWithNoAdditionalProperties);
-
+        assertThrows(UnrecognizedPropertyException.class, () -> mapper.readValue("{\"a\":\"1\", \"b\":2}", classWithNoAdditionalProperties));
     }
 
     @Test
@@ -178,7 +175,7 @@ public class AdditionalPropertiesIT {
 
     }
 
-    @Test(expected = NoSuchMethodException.class)
+    @Test
     public void additionalPropertiesBuilderAbsentIfNotConfigured() throws SecurityException, NoSuchMethodException, ClassNotFoundException {
 
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/additionalProperties/additionalPropertiesObject.json", "com.example");
@@ -187,8 +184,10 @@ public class AdditionalPropertiesIT {
         Class<?> propertyValueType = resultsClassLoader.loadClass("com.example.AdditionalPropertiesObjectProperty");
 
         // builder with these types should not exist:
-        Method builderMethod = classWithNoAdditionalProperties.getMethod("withAdditionalProperty", String.class, propertyValueType);
-        assertThat("additional properties builder found when not requested", builderMethod, is(notNullValue()));
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> classWithNoAdditionalProperties.getMethod("withAdditionalProperty", String.class, propertyValueType),
+                "additional properties builder found when not requested");
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AdditionalPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AdditionalPropertiesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -43,7 +43,7 @@ public class AdditionalPropertiesIT {
 
     @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     @SuppressWarnings("unchecked")
@@ -188,9 +188,7 @@ public class AdditionalPropertiesIT {
 
         // builder with these types should not exist:
         Method builderMethod = classWithNoAdditionalProperties.getMethod("withAdditionalProperty", String.class, propertyValueType);
-        assertThat("the builder method returns this type", builderMethod.getReturnType(), typeEqualTo(classWithNoAdditionalProperties));
-
-        fail("additional properties builder found when not requested");
+        assertThat("additional properties builder found when not requested", builderMethod, is(notNullValue()));
     }
 
     @Test
@@ -269,9 +267,8 @@ public class AdditionalPropertiesIT {
         assertThat(jsonNode.has("additionalProperties"), is(false));
     }
 
-    @SuppressWarnings("rawtypes")
-    public static Matcher<Class> typeEqualTo(Class<?> type) {
-        return equalTo((Class) type);
+    public static Matcher<Class<?>> typeEqualTo(Class<?> type) {
+        return equalTo(type);
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ArrayIT.java
@@ -28,27 +28,24 @@ import java.util.List;
 import java.util.Set;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ArrayIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithArrayProperties;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileClass() throws ClassNotFoundException {
-
         ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/array/typeWithArrayProperties.json", "com.example");
 
         classWithArrayProperties = resultsClassLoader.loadClass("com.example.TypeWithArrayProperties");
-
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ArrayIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CommentsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CommentsIT.java
@@ -17,12 +17,12 @@
 package org.jsonschema2pojo.integration;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CommentsIT {
 
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
@@ -113,7 +113,7 @@ public class CompilerWarningIT {
     return warnings;
   }
 
-  public static Matcher<Iterable<Diagnostic<? extends JavaFileObject>>> onlyCastExceptions() {
+  public static Matcher<Iterable<? extends Diagnostic<? extends JavaFileObject>>> onlyCastExceptions() {
     return Matchers.everyItem(hasMessage(containsString("Type safety: Unchecked cast from")));
   }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
@@ -38,11 +38,10 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.jsonschema2pojo.integration.util.Compiler;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * <p>Tests looking for warning coming from generated output.</p>
@@ -55,11 +54,12 @@ import org.junit.runners.Parameterized.Parameters;
  * @author Christian Trimble
  *
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass(name="{0}")
+@MethodSource("parameters")
 public class CompilerWarningIT {
-  @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule().captureDiagnostics();
-  
-  @Parameters(name="{0}")
+
+  @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule().captureDiagnostics();
+
   public static Collection<Object[]> parameters() {
     JavaCompiler systemJavaCompiler = Compiler.systemJavaCompiler();
     JavaCompiler eclipseCompiler = Compiler.eclipseCompiler();
@@ -96,7 +96,7 @@ public class CompilerWarningIT {
   @Test
   public void checkWarnings() {
     schemaRule.generate(schema, "com.example", config);
-    schemaRule.compile(compiler, new NullWriter(), new ArrayList<>(), config);
+    schemaRule.compile(compiler, NullWriter.INSTANCE, new ArrayList<>(), config);
     
     List<Diagnostic<? extends JavaFileObject>> warnings = warnings(schemaRule.getDiagnostics());
     

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsJavadocIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ConstructorsJavadocIT.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -30,12 +29,11 @@ import java.util.stream.Collectors;
 
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.DocletTag;
@@ -43,21 +41,17 @@ import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaConstructor;
 import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
-@RunWith(Enclosed.class)
 public class ConstructorsJavadocIT {
 
     private static final DefaultJavaClass cString = new DefaultJavaClass(String.class.getName());
     private static final DefaultJavaClass cDouble = new DefaultJavaClass(Double.class.getName());
 
-    @RunWith(Parameterized.class)
-    public static class ConstructorWithRequiredPropertiesOnlyIT {
+    @Nested
+    @ParameterizedClass(name = "{0}")
+    @ValueSource(strings = { "constructorsRequiredPropertiesOnly", "includeRequiredPropertiesConstructor" })
+    class ConstructorWithRequiredPropertiesOnlyIT {
 
-        @Parameters(name = "{0}")
-        public static Collection<String> data() {
-            return asList("constructorsRequiredPropertiesOnly", "includeRequiredPropertiesConstructor");
-        }
-
-        @Rule
+        @RegisterExtension
         public final Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
         private final String configuration;
@@ -84,9 +78,10 @@ public class ConstructorsJavadocIT {
         }
     }
 
-    public static class ConstructorWithAllPropertiesIT {
+    @Nested
+    class ConstructorWithAllPropertiesIT {
 
-        @Rule
+        @RegisterExtension
         public final Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
         @Test
@@ -111,9 +106,10 @@ public class ConstructorsJavadocIT {
 
     }
 
-    public static class IncludeCopyConstructorIT {
+    @Nested
+    class IncludeCopyConstructorIT {
 
-        @Rule
+        @RegisterExtension
         public final Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
         @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -24,24 +24,24 @@ import java.util.Date;
 import java.util.Locale;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class CustomDateTimeFormatIT {
-    @ClassRule
+
+    @RegisterExtension
     public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWhenFormatDatesTrue;
     private static Class<?> classWhenFormatDatesFalse;
     private static Class<?> classWithCustomPatterns;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws ClassNotFoundException {
-
         classSchemaRule.generate("/schema/format/customDateTimeFormat.json", "com.example.config_true", config(
                 "dateType", "java.util.Date",
                 "timeType", "java.util.Date",

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomDateTimeFormatIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.util.Date;
 import java.util.Locale;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DefaultIT.java
@@ -31,25 +31,22 @@ import java.util.List;
 import java.util.Set;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DefaultIT {
     
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithDefaults;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileClass() throws ClassNotFoundException {
-
         ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/default/default.json", "com.example");
 
         classWithDefaults = resultsClassLoader.loadClass("com.example.Default");
-
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionEnumIT.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
@@ -36,11 +36,11 @@ import com.thoughtworks.qdox.model.JavaClass;
  */
 public class DescriptionEnumIT {
 
-    @ClassRule public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithDescription;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
 
         schemaRule.generateAndCompile("/schema/description/descriptionEnum.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
@@ -25,9 +25,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
@@ -38,13 +38,12 @@ import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class DescriptionIT {
 
-    @ClassRule public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithDescription;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
-
         schemaRule.generateAndCompile("/schema/description/description.json", "com.example");
         File generatedJavaFile = schemaRule.generated("com/example/Description.java");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DescriptionIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DollarCommentIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DollarCommentIT.java
@@ -24,9 +24,9 @@ import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,13 +38,12 @@ import static org.hamcrest.Matchers.*;
 
 public class DollarCommentIT {
 
-    @ClassRule public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithDescription;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
-
         schemaRule.generateAndCompile("/schema/dollar_comment/dollar_comment.json", "com.example");
         File generatedJavaFile = schemaRule.generated("com/example/DollarComment.java");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DollarCommentIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DollarCommentIT.java
@@ -33,8 +33,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
 public class DollarCommentIT {
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DynamicPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DynamicPropertiesIT.java
@@ -19,17 +19,18 @@ package org.jsonschema2pojo.integration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DynamicPropertiesIT {
     
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void shouldSetStringField() throws Throwable {
@@ -88,32 +89,28 @@ public class DynamicPropertiesIT {
                 "value");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionWhenSettingWrongType() throws Throwable {
-        setDeclaredPropertyTest(
-                "/schema/dynamic/childType.json",
-                "ChildType",
-                String.class,
-                "stringValue",
-                "getStringValue",
-                1L);
+    @Test
+    public void shouldThrowExceptionWhenSettingWrongType() {
+        final String schemaLocation = "/schema/dynamic/childType.json";
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> setDeclaredPropertyTest(schemaLocation, "ChildType", String.class, "stringValue", "getStringValue", 1L));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionWhenSettingUnknownField() throws Throwable {
-        setPropertyTest(
-                "/schema/dynamic/noAdditionalProperties.json",
-                "NoAdditionalProperties",
-                "unknownField",
-                1L);
+    @Test
+    public void shouldThrowExceptionWhenSettingUnknownField() {
+        final String schemaLocation = "/schema/dynamic/noAdditionalProperties.json";
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> setPropertyTest(schemaLocation, "NoAdditionalProperties", "unknownField", 1L));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenGettingUnknownField() throws Throwable {
-        getPropertyTest(
-                "/schema/dynamic/noAdditionalProperties.json",
-                "NoAdditionalProperties",
-                "unknownField");
+        final String schemaLocation = "/schema/dynamic/noAdditionalProperties.json";
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> getPropertyTest(schemaLocation, "NoAdditionalProperties", "unknownField"));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DynamicPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DynamicPropertiesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -17,9 +17,10 @@
 package org.jsonschema2pojo.integration;
 
 import static java.lang.reflect.Modifier.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/EnumIT.java
@@ -20,7 +20,7 @@ import static java.lang.reflect.Modifier.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -31,10 +31,9 @@ import java.math.BigInteger;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.IsInstanceOf;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -44,16 +43,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SuppressWarnings("rawtypes")
 public class EnumIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> parentClass;
     private static Class<Enum<?>> enumClass;
 
-    @BeforeClass
+    @BeforeAll
     @SuppressWarnings("unchecked")
     public static void generateAndCompileEnum() throws ClassNotFoundException {
-
         ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/enum/typeWithEnumProperty.json", "com.example", config("propertyWordDelimiters", "_"));
 
         parentClass = resultsClassLoader.loadClass("com.example.TypeWithEnumProperty");
@@ -111,13 +109,10 @@ public class EnumIT {
 
         Method fromValue = enumClass.getMethod("fromValue", String.class);
 
-        try {
-            fromValue.invoke(enumClass, "something invalid");
-            fail();
-        } catch (InvocationTargetException e) {
-            assertThat(e.getCause(), is(instanceOf(IllegalArgumentException.class)));
-        }
-
+        final InvocationTargetException exception = assertThrows(
+                InvocationTargetException.class,
+                () -> fromValue.invoke(enumClass, "something invalid"));
+        assertThat(exception.getCause(), is(instanceOf(IllegalArgumentException.class)));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
@@ -17,9 +17,9 @@
 package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExcludedFromEqualsAndHashCodeIT.java
@@ -26,18 +26,18 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ExcludedFromEqualsAndHashCodeIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> clazz;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileEnum() throws ClassNotFoundException {
-
         ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/excludedFromEqualsAndHashCode/excludedFromEqualsAndHashCode.json", "com.example");
 
         clazz = resultsClassLoader.loadClass("com.example.ExcludedFromEqualsAndHashCode");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -19,17 +19,19 @@ package org.jsonschema2pojo.integration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ExtendsIT {
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings("rawtypes")
@@ -70,12 +72,10 @@ public class ExtendsIT {
 
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void extendsStringCausesNoNewTypeToBeGenerated() throws ClassNotFoundException {
-
+    @Test
+    public void extendsStringCausesNoNewTypeToBeGenerated() {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsString.json", "com.example");
-        resultsClassLoader.loadClass("com.example.ExtendsString");
-
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.ExtendsString"));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ExtendsIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
@@ -93,7 +93,7 @@ public class ExtendsIT {
         new PropertyDescriptor("parent", generatedType).getWriteMethod().invoke(instance2, "not-equal");
         new PropertyDescriptor("child", generatedType).getWriteMethod().invoke(instance2, "2");
 
-        assertNotEquals(instance, instance2);
+        assertThat(instance, is(not(equalTo(instance2))));
     }
 
     @Test
@@ -103,10 +103,10 @@ public class ExtendsIT {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/extends/extendsSchemaWithinDefinitions.json", "com.example");
 
         Class subtype = resultsClassLoader.loadClass("com.example.Child");
-        assertNotNull("no propertyOfChild field", subtype.getDeclaredField("propertyOfChild"));
+        assertThat("no propertyOfChild field", subtype.getDeclaredField("propertyOfChild"), is(notNullValue()));
 
         Class supertype = resultsClassLoader.loadClass("com.example.Parent");
-        assertNotNull("no propertyOfParent field", supertype.getDeclaredField("propertyOfParent"));
+        assertThat("no propertyOfParent field", supertype.getDeclaredField("propertyOfParent"), is(notNullValue()));
 
         assertThat(subtype.getSuperclass(), is(equalTo(supertype)));
     }
@@ -121,8 +121,8 @@ public class ExtendsIT {
 
         assertThat(type.getSuperclass(), is(equalTo(supertype)));
 
-        assertNotNull("Parent constructor is missing", supertype.getConstructor(String.class));
-        assertNotNull("Constructor is missing", type.getConstructor(String.class, String.class));
+        assertThat("Parent constructor is missing", supertype.getConstructor(String.class), is(notNullValue()));
+        assertThat("Constructor is missing", type.getConstructor(String.class, String.class), is(notNullValue()));
 
         Object typeInstance = type.getConstructor(String.class, String.class).newInstance("String1", "String2");
 
@@ -148,9 +148,9 @@ public class ExtendsIT {
 
         assertThat(type.getSuperclass(), is(equalTo(supertype)));
 
-        assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class));
-        assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class));
-        assertNotNull("Constructor is missing", type.getDeclaredConstructor(String.class, String.class, String.class));
+        assertThat("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class), is(notNullValue()));
+        assertThat("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class), is(notNullValue()));
+        assertThat("Constructor is missing", type.getDeclaredConstructor(String.class, String.class, String.class), is(notNullValue()));
 
         Object typeInstance = type.getConstructor(String.class, String.class, String.class).newInstance("String1", "String2", "String3");
 
@@ -180,9 +180,9 @@ public class ExtendsIT {
 
         assertThat(type.getSuperclass(), is(equalTo(supertype)));
 
-        assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class));
-        assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class));
-        assertNotNull("Constructor is missing", type.getDeclaredConstructor(Integer.class, String.class, String.class));
+        assertThat("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class), is(notNullValue()));
+        assertThat("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, String.class), is(notNullValue()));
+        assertThat("Constructor is missing", type.getDeclaredConstructor(Integer.class, String.class, String.class), is(notNullValue()));
 
         Object typeInstance = type.getConstructor(Integer.class, String.class, String.class).newInstance(5, "String2", "String3");
 
@@ -210,9 +210,9 @@ public class ExtendsIT {
         Class supertype = resultsClassLoader.loadClass("com.example.SubtypeOfC");
         Class superSupertype = resultsClassLoader.loadClass("com.example.C");
 
-        assertNotNull("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class, Integer.class));
-        assertNotNull("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, Boolean.class, Integer.class));
-        assertNotNull("Constructor is missing", type.getDeclaredConstructor(String.class, Integer.class, Boolean.class, Integer.class));
+        assertThat("Parent Parent constructor is missing", superSupertype.getDeclaredConstructor(String.class, Integer.class), is(notNullValue()));
+        assertThat("Parent Constructor is missing", supertype.getDeclaredConstructor(String.class, Boolean.class, Integer.class), is(notNullValue()));
+        assertThat("Constructor is missing", type.getDeclaredConstructor(String.class, Integer.class, Boolean.class, Integer.class), is(notNullValue()));
 
         Object typeInstance = type.getConstructor(String.class, Integer.class, Boolean.class, Integer.class).newInstance("String1", 5, true, 6);
 
@@ -271,11 +271,11 @@ public class ExtendsIT {
         assertThat(type.getSuperclass(), is(equalTo(supertype)));
 
         Method builderMethod = supertype.getDeclaredMethod(builderMethodName, String.class);
-        assertNotNull("Builder method not found on super type: " + builderMethodName, builderMethod);
+        assertThat("Builder method not found on super type: " + builderMethodName, builderMethod, is(notNullValue()));
         assertThat(builderMethod.getReturnType(), is(equalTo(supertype)));
 
         Method builderMethodOverride = type.getDeclaredMethod(builderMethodName, String.class);
-        assertNotNull("Builder method not overridden on type: " + builderMethodName, builderMethodOverride);
+        assertThat("Builder method not overridden on type: " + builderMethodName, builderMethodOverride, is(notNullValue()));
         assertThat(builderMethodOverride.getReturnType(), is(equalTo(type)));
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/FormatIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/FormatIT.java
@@ -35,24 +35,24 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}")
+@MethodSource("data")
 public class FormatIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithFormattedProperties;
 
-    @Parameters(name="{0}")
     public static List<Object[]> data() {
         return asList(new Object[][] {
             /* { propertyName, expectedType, jsonValue, javaValue } */
@@ -87,9 +87,8 @@ public class FormatIT {
         this.javaValue = javaValue;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws ClassNotFoundException {
-
         Map<String,String> formatMapping = new HashMap<String,String>() {{
             put("int32", "int");
         }};
@@ -97,7 +96,6 @@ public class FormatIT {
         ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example", config("formatTypeMapping", formatMapping));
 
         classWithFormattedProperties = resultsClassLoader.loadClass("com.example.FormattedProperties");
-
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/GenericTypeIT.java
@@ -26,16 +26,17 @@ import java.lang.reflect.WildcardType;
 import java.util.Map;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class GenericTypeIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithGenericTypes;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
         classWithGenericTypes = classSchemaRule.generateAndCompile("/schema/type/genericJavaType.json", "com.example").loadClass("com.example.GenericJavaType");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
@@ -24,20 +24,20 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 public class JacksonViewIT {
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void javaJsonViewWithJackson2x() throws Exception {
-
-        com.fasterxml.jackson.annotation.JsonView jsonViewAnnotation
-                = (com.fasterxml.jackson.annotation.JsonView) jsonViewTest("jackson2", com.fasterxml.jackson.annotation.JsonView.class);
+        JsonView jsonViewAnnotation = (JsonView) jsonViewTest("jackson2", JsonView.class);
 
         assertThat(jsonViewAnnotation.value()[0].getSimpleName(), equalTo("MyJsonViewClass"));
-
     }
 
     private Annotation jsonViewTest(String annotationStyle, Class<? extends Annotation> annotationType) throws ClassNotFoundException, NoSuchFieldException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JacksonViewIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -18,6 +18,7 @@ package org.jsonschema2pojo.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -27,9 +28,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,15 +42,9 @@ import com.thoughtworks.qdox.model.JavaField;
  */
 public class JavaNameIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();
-
-    @BeforeClass
-    public static void generateAndCompileClass() {
-
-
-    }
 
     @Test
     public void propertiesHaveCorrectNames() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
@@ -154,18 +148,14 @@ public class JavaNameIT {
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void doesNotAllowDuplicateNames() {
-
-        schemaRule.generateAndCompile("/schema/javaName/duplicateName.json", "com.example");
-
+        assertThrows(IllegalArgumentException.class, () -> schemaRule.generateAndCompile("/schema/javaName/duplicateName.json", "com.example"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void doesNotAllowDuplicateDefaultNames() {
-
-        schemaRule.generateAndCompile("/schema/javaName/duplicateDefaultName.json", "com.example");
-
+        assertThrows(IllegalArgumentException.class, () -> schemaRule.generateAndCompile("/schema/javaName/duplicateDefaultName.json", "com.example"));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/JavaNameIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -205,21 +205,21 @@ public class JavaNameIT {
     }
 
     @Test
-    public void generateClassInTargetPackage() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
+    public void generateClassInTargetPackage() throws ClassNotFoundException {
 
         ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0.json", "com.example.javaname");
         Class<?> classWithTargetPackage = javaNameClassLoader.loadClass("com.example.javaname.OCSPRequestData");
 
-        assertEquals("com.example.javaname.OCSPRequestData", classWithTargetPackage.getName());
+        assertThat("com.example.javaname.OCSPRequestData", is(equalTo(classWithTargetPackage.getName())));
     }
 
     @Test
-    public void generateClassInJavaTypePackage() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
+    public void generateClassInJavaTypePackage() throws ClassNotFoundException {
 
         ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0.json", "com.example.javaname");
         Class<?> classWithJavaTypePackage = javaNameClassLoader.loadClass("com.apetecan.javaname.AdditionalInfo");
 
-        assertEquals("com.apetecan.javaname.AdditionalInfo", classWithJavaTypePackage.getName());
+        assertThat("com.apetecan.javaname.AdditionalInfo", is(equalTo(classWithJavaTypePackage.getName())));
     }
 
     @Test
@@ -228,7 +228,7 @@ public class JavaNameIT {
         ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0_2.json", "com.example.javaname");
         Class<?> classWithTargetPackage = javaNameClassLoader.loadClass("com.example.javaname.AuthorizeRequestV1p02");
 
-        assertEquals("com.example.javaname.AuthorizeRequestV1p02", classWithTargetPackage.getName());
+        assertThat(classWithTargetPackage.getName(), is(equalTo("com.example.javaname.AuthorizeRequestV1p02")));
 
         classWithTargetPackage.newInstance();
 
@@ -241,7 +241,7 @@ public class JavaNameIT {
         ClassLoader javaNameClassLoader = schemaRule.generateAndCompile("/schema/javaName/AuthorizeRequest_v1p0_2.json", "com.example.javaname");
         Class<?> classWithJavaTypePackage = javaNameClassLoader.loadClass("com.apetecan.javaname.IdToken");
 
-        assertEquals("com.apetecan.javaname.IdToken", classWithJavaTypePackage.getName());
+        assertThat(classWithJavaTypePackage.getName(), is(equalTo("com.apetecan.javaname.IdToken")));
 
         classWithJavaTypePackage.newInstance();
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
@@ -33,9 +33,9 @@ import org.apache.commons.codec.net.QuotedPrintableCodec;
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.AbstractAnnotator;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -54,11 +54,12 @@ import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
 
 public class MediaIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
     private static Class<?> classWithMediaProperties;
     private static Class<byte[]> BYTE_ARRAY = byte[].class;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
         ClassLoader resultsClassLoader = classSchemaRule.generateAndCompile("/schema/media/mediaProperties.json", "com.example", config("customAnnotator", QuotedPrintableAnnotator.class.getName()));
@@ -213,9 +214,8 @@ public class MediaIT {
      * @param type the type to check.
      * @return a matcher that tests for equality to the specified type.
      */
-    @SuppressWarnings("rawtypes")
-    public static Matcher<Class> equalToType( Class<?> type ) {
-        return equalTo((Class)type);
+    public static Matcher<Class<?>> equalToType( Class<?> type ) {
+        return equalTo(type);
     }
 
     public static void roundTripAssertions( ObjectMapper objectMapper, String propertyName, String jsonValue, Object javaValue) throws Exception {
@@ -275,7 +275,7 @@ public class MediaIT {
     public static class QuotedPrintableSerializer
     extends StdSerializer<byte[]>
     {
-        private static QuotedPrintableCodec codec = new QuotedPrintableCodec();
+        private static final QuotedPrintableCodec codec = new QuotedPrintableCodec();
 
         public QuotedPrintableSerializer() {
             super(byte[].class);
@@ -288,11 +288,10 @@ public class MediaIT {
 
     }
 
-    @SuppressWarnings("serial")
     public static class QuotedPrintableDeserializer
     extends StdDeserializer<byte[]>
     {
-        private static QuotedPrintableCodec codec = new QuotedPrintableCodec();
+        private static final QuotedPrintableCodec codec = new QuotedPrintableCodec();
 
         public QuotedPrintableDeserializer() {
             super(byte[].class);
@@ -303,7 +302,7 @@ public class MediaIT {
             try {
                 return codec.decode(jp.getText().getBytes(StandardCharsets.UTF_8));
             } catch (DecoderException e) {
-                throw new IOException(format("could not decode quoted string in %s", jp.getCurrentName()), e);
+                throw new IOException(format("could not decode quoted string in %s", jp.currentName()), e);
             }
         }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/MediaIT.java
@@ -17,9 +17,9 @@
 package org.jsonschema2pojo.integration;
 
 import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.beans.PropertyDescriptor;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PolymorphicIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PolymorphicIT.java
@@ -31,18 +31,20 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class PolymorphicIT {
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
-    
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
     @Test
     public void extendsWithPolymorphicDeserializationWithDefaultAnnotationStyle() throws ClassNotFoundException {
 
@@ -51,7 +53,7 @@ public class PolymorphicIT {
         Class<?> subtype = resultsClassLoader.loadClass("com.example.ExtendsSchema");
         Class<?> supertype = subtype.getSuperclass();
 
-        assertNotNull(supertype.getAnnotation(JsonTypeInfo.class));
+        assertThat(supertype.getAnnotation(JsonTypeInfo.class), is(notNullValue()));
     }
 
     @Test
@@ -63,6 +65,6 @@ public class PolymorphicIT {
         Class<?> subtype = resultsClassLoader.loadClass("com.example.ExtendsSchema");
         Class<?> supertype = subtype.getSuperclass();
 
-        assertNotNull(supertype.getAnnotation(JsonTypeInfo.class));
+        assertThat(supertype.getAnnotation(JsonTypeInfo.class), is(notNullValue()));
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
@@ -27,14 +27,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class PropertiesIT {
-    @Rule
+
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/PropertiesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -167,10 +167,10 @@ public class PropertiesIT {
 
         JsonNode jsonified = mapper.valueToTree(instance);
 
-        assertNotNull(generatedType.getDeclaredField("property1"));
-        assertNotNull(generatedType.getDeclaredField("propertyTwo"));
-        assertNotNull(generatedType.getDeclaredField("propertyThreeWithSpace"));
-        assertNotNull(generatedType.getDeclaredField("propertyFour"));
+        assertThat(generatedType.getDeclaredField("property1"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyTwo"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyThreeWithSpace"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyFour"), is(notNullValue()));
 
         assertThat(jsonified.has("Property1"), is(true));
         assertThat(jsonified.has("PropertyTwo"), is(true));
@@ -192,10 +192,10 @@ public class PropertiesIT {
 
         JsonNode jsonified = mapper.valueToTree(instance);
 
-        assertNotNull(generatedType.getDeclaredField("propertyOne"));
-        assertNotNull(generatedType.getDeclaredField("propertyOneTwo"));
-        assertNotNull(generatedType.getDeclaredField("propertyOneTwoThree"));
-        assertNotNull(generatedType.getDeclaredField("pROPERTYONETWOTHREEFour"));
+        assertThat(generatedType.getDeclaredField("propertyOne"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyOneTwo"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyOneTwoThree"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("pROPERTYONETWOTHREEFour"), is(notNullValue()));
 
         assertThat(jsonified.has("PROPERTY_ONE"), is(true));
         assertThat(jsonified.has("PROPERTY_ONE_TWO"), is(true));
@@ -208,10 +208,10 @@ public class PropertiesIT {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/propertiesWithSpecialCharacters.json", "com.example");
         Class<?> generatedType = resultsClassLoader.loadClass("com.example.PropertiesWithSpecialCharacters");
 
-        assertNotNull(generatedType.getDeclaredMethod("getVersv"));
-        assertNotNull(generatedType.getDeclaredMethod("getFooBar"));
-        assertNotNull(generatedType.getDeclaredMethod("get$RfcNumber"));
-        assertNotNull(generatedType.getDeclaredMethod("getOrgHispDhisCommonFileTypeValueOptions"));
-        assertNotNull(generatedType.getDeclaredMethod("getGood"));
+        assertThat(generatedType.getDeclaredMethod("getVersv"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredMethod("getFooBar"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredMethod("get$RfcNumber"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredMethod("getOrgHispDhisCommonFileTypeValueOptions"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredMethod("getGood"), is(notNullValue()));
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RegressionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RegressionIT.java
@@ -28,12 +28,12 @@ import java.net.URL;
 import java.util.Collections;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RegressionIT {
     
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void pathWithSpacesInTheNameDoesNotFail() throws ClassNotFoundException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RegressionIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RegressionIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.lang.reflect.ParameterizedType;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredArrayIT.java
@@ -25,9 +25,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
@@ -36,14 +36,14 @@ import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
-public class RequiredArrayIT extends RequiredIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+public class RequiredArrayIT {
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithRequired;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
-
         classSchemaRule.generateAndCompile("/schema/required/requiredArray.json", "com.example");
         File generatedJavaFile = classSchemaRule.generated("com/example/RequiredArray.java");
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/RequiredIT.java
@@ -25,9 +25,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
@@ -37,11 +37,12 @@ import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class RequiredIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithRequired;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
 
         classSchemaRule.generateAndCompile("/schema/required/required.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleEnumIT.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
@@ -35,11 +35,12 @@ import com.thoughtworks.qdox.model.JavaClass;
   added to root-level enums is added to the javadoc.
  */
 public class TitleEnumIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithTitle;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
 
         classSchemaRule.generateAndCompile("/schema/title/titleEnum.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TitleIT.java
@@ -25,9 +25,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
@@ -37,11 +37,12 @@ import com.thoughtworks.qdox.model.JavaType;
 import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
 
 public class TitleIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static JavaClass classWithTitle;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateClasses() throws IOException {
 
         classSchemaRule.generateAndCompile("/schema/title/title.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ToStringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ToStringIT.java
@@ -16,7 +16,8 @@
 
 package org.jsonschema2pojo.integration;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,8 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -33,7 +34,7 @@ public class ToStringIT {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
@@ -41,8 +42,9 @@ public class ToStringIT {
         Class<?> scalarTypesClass = schemaRule.generateAndCompile("/schema/toString/scalarTypes.json", "com.example")
                 .loadClass("com.example.ScalarTypes");
 
-        assertEquals("com.example.ScalarTypes@<ref>[stringField=<null>,numberField=<null>,integerField=<null>,booleanField=<null>,nullField=<null>,bytesField=<null>]",
-                toStringAndReplaceAddress(Collections.emptyMap(), scalarTypesClass));
+        assertThat(
+                toStringAndReplaceAddress(Collections.emptyMap(), scalarTypesClass),
+                is(equalTo("com.example.ScalarTypes@<ref>[stringField=<null>,numberField=<null>,integerField=<null>,booleanField=<null>,nullField=<null>,bytesField=<null>]")));
 
         Map<String, Object> scalarTypes = new HashMap<>();
         scalarTypes.put("stringField", "hello");
@@ -52,8 +54,9 @@ public class ToStringIT {
         scalarTypes.put("bytesField", "YWJj");
         scalarTypes.put("nullField", null);
 
-        assertEquals("com.example.ScalarTypes@<ref>[stringField=hello,numberField=4.25,integerField=42,booleanField=true,nullField=<null>,bytesField={97,98,99}]",
-                toStringAndReplaceAddress(scalarTypes, scalarTypesClass));
+        assertThat(
+                toStringAndReplaceAddress(scalarTypes, scalarTypesClass),
+                is(equalTo("com.example.ScalarTypes@<ref>[stringField=hello,numberField=4.25,integerField=42,booleanField=true,nullField=<null>,bytesField={97,98,99}]")));
     }
 
     @Test
@@ -61,8 +64,9 @@ public class ToStringIT {
         Class<?> compositeTypesClass = schemaRule.generateAndCompile("/schema/toString/compositeTypes.json", "com.example")
                 .loadClass("com.example.CompositeTypes");
 
-        assertEquals("com.example.CompositeTypes@<ref>[mapField=<null>,objectField=<null>,arrayField=[],uniqueArrayField=[]]",
-                toStringAndReplaceAddress(Collections.emptyMap(), compositeTypesClass));
+        assertThat(
+                toStringAndReplaceAddress(Collections.emptyMap(), compositeTypesClass),
+                is(equalTo("com.example.CompositeTypes@<ref>[mapField=<null>,objectField=<null>,arrayField=[],uniqueArrayField=[]]")));
 
         Map<String, Integer> intPair = new HashMap<>();
         intPair.put("l", 0);
@@ -74,12 +78,12 @@ public class ToStringIT {
         compositeTypes.put("arrayField", Collections.singleton(intPair));
         compositeTypes.put("uniqueArrayField", Collections.singleton(intPair));
 
-        assertEquals("com.example.CompositeTypes@<ref>"
+        assertThat(toStringAndReplaceAddress(compositeTypes, compositeTypesClass),
+                is(equalTo("com.example.CompositeTypes@<ref>"
                         + "[mapField={intPair=com.example.IntPair@<ref>[l=0,r=1]}"
                         + ",objectField=com.example.IntPair@<ref>[l=0,r=1]"
                         + ",arrayField=[com.example.IntPair@<ref>[l=0,r=1]]"
-                        + ",uniqueArrayField=[com.example.IntPair@<ref>[l=0,r=1]]]",
-                toStringAndReplaceAddress(compositeTypes, compositeTypesClass));
+                        + ",uniqueArrayField=[com.example.IntPair@<ref>[l=0,r=1]]]")));
     }
 
     @Test
@@ -89,16 +93,18 @@ public class ToStringIT {
 
         Map<String, ?> arrayOfNullArrays = Collections.singletonMap("grid", Arrays.asList(null, null));
 
-        assertEquals("com.example.ArrayOfArrays@<ref>[grid=[null, null]]",
-                toStringAndReplaceAddress(arrayOfNullArrays, arrayOfArraysClass));
+        assertThat(
+                toStringAndReplaceAddress(arrayOfNullArrays, arrayOfArraysClass),
+                is(equalTo("com.example.ArrayOfArrays@<ref>[grid=[null, null]]")));
 
         Map<String, ?> arrayOfArrays = Collections.singletonMap("grid", Arrays.asList(
                 Arrays.asList(1, 2, 3),
                 Arrays.asList(4, 5, 6),
                 Arrays.asList(7, 8, 9)));
 
-        assertEquals("com.example.ArrayOfArrays@<ref>[grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]",
-                toStringAndReplaceAddress(arrayOfArrays, arrayOfArraysClass));
+        assertThat(
+                toStringAndReplaceAddress(arrayOfArrays, arrayOfArraysClass),
+                is(equalTo("com.example.ArrayOfArrays@<ref>[grid=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]")));
     }
 
     @Test
@@ -111,8 +117,9 @@ public class ToStringIT {
         square.put("diagonals", Arrays.asList(Math.sqrt(2.0), Math.sqrt(2.0)));
         square.put("length", 1.0);
 
-        assertEquals("com.example.Square@<ref>[sides=4,diagonals=[1.4142135623730951, 1.4142135623730951],length=1.0]",
-                toStringAndReplaceAddress(square, squareClass));
+        assertThat(
+                toStringAndReplaceAddress(square, squareClass),
+                is(equalTo("com.example.Square@<ref>[sides=4,diagonals=[1.4142135623730951, 1.4142135623730951],length=1.0]")));
     }
 
     private static String toStringAndReplaceAddress(Object object, Class<?> clazz) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/TypeIT.java
@@ -27,19 +27,18 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TypeIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithManyTypes;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileClass() throws ClassNotFoundException {
 
         classWithManyTypes = classSchemaRule.generateAndCompile("/schema/type/types.json", "com.example")

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ant/Jsonschema2PojoTaskIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ant/Jsonschema2PojoTaskIT.java
@@ -16,6 +16,7 @@
 
 package org.jsonschema2pojo.integration.ant;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -31,12 +32,12 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.ProjectHelper;
 import org.jsonschema2pojo.ant.Jsonschema2PojoTask;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class Jsonschema2PojoTaskIT {
     
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void antTaskExecutesSuccessfullyWithValidSchemas() throws URISyntaxException, ClassNotFoundException {
@@ -63,7 +64,7 @@ public class Jsonschema2PojoTaskIT {
     @Test
     public void antTaskDocumentationIncludesAllProperties() throws IOException {
 
-        String documentation = FileUtils.readFileToString(new File("../jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html"));
+        String documentation = FileUtils.readFileToString(new File("../jsonschema2pojo-ant/src/site/Jsonschema2PojoTask.html"), UTF_8);
 
         for (Field f : Jsonschema2PojoTask.class.getDeclaredFields()) {
             assertThat(documentation, containsString(">"+f.getName()+"<"));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ant/Jsonschema2PojoTaskIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ant/Jsonschema2PojoTaskIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration.ant;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/AnnotationStyleIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/AnnotationStyleIT.java
@@ -16,10 +16,11 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/AnnotationStyleIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/AnnotationStyleIT.java
@@ -20,15 +20,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class AnnotationStyleIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -116,15 +116,14 @@ public class AnnotationStyleIT {
 
     @Test
     public void invalidAnnotationStyleCausesMojoException() {
+        final String schema = "/schema/properties/primitiveProperties.json";
 
-        try {
-            schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example", config("annotationStyle", "invalidstyle"));
-            fail();
-        } catch (RuntimeException e) {
-            assertThat(e.getCause(), is(instanceOf(MojoExecutionException.class)));
-            assertThat(e.getCause().getMessage(), is(containsString("invalidstyle")));
-        }
+        final RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> schemaRule.generate(schema, "com.example", config("annotationStyle", "invalidstyle")));
 
+        assertThat(exception.getCause(), is(instanceOf(MojoExecutionException.class)));
+        assertThat(exception.getCause().getMessage(), is(containsString("invalidstyle")));
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLangRemovalIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLangRemovalIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLangRemovalIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CommonsLangRemovalIT.java
@@ -23,12 +23,12 @@ import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
 import java.io.File;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CommonsLangRemovalIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void hashCodeAndEqualsDontUseCommonsLang() throws SecurityException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -19,15 +19,15 @@ package org.jsonschema2pojo.integration.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Method;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jsonschema2pojo.Annotator;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -40,7 +40,7 @@ import com.sun.codemodel.JMethod;
 
 public class CustomAnnotatorIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -96,15 +96,13 @@ public class CustomAnnotatorIT {
 
     @Test
     public void invalidCustomAnnotatorClassCausesMojoException() {
+        final String schema = "/schema/properties/primitiveProperties.json";
 
-        try {
-            schemaRule.generate("/schema/properties/primitiveProperties.json", "com.example", config("customAnnotator", "java.lang.String"));
-            fail();
-        } catch (RuntimeException e) {
-            assertThat(e.getCause(), is(instanceOf(MojoExecutionException.class)));
-            assertThat(e.getCause().getMessage(), is(containsString("annotator")));
-        }
-
+        final RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> schemaRule.generate(schema, "com.example", config("customAnnotator", "java.lang.String")));
+        assertThat(exception.getCause(), is(instanceOf(MojoExecutionException.class)));
+        assertThat(exception.getCause().getMessage(), is(containsString("annotator")));
     }
 
     /**

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomAnnotatorIT.java
@@ -16,9 +16,10 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Method;
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomDatesIT.java
@@ -19,6 +19,7 @@ package org.jsonschema2pojo.integration.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -28,12 +29,14 @@ import java.util.List;
 
 import org.jsonschema2pojo.exception.GenerationException;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CustomDatesIT {
-    
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    private static final String UNKNOWN_TYPE = "org.jsonschema2pojo.integration.config.UnknownType";
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void defaultTypesAreNotCustom() throws ClassNotFoundException, IntrospectionException {
@@ -103,22 +106,28 @@ public class CustomDatesIT {
         assertTypeIsExpected(classWithTime, "stringAsTime", "java.lang.String");
     }
 
-    @Test(expected=GenerationException.class)
+    @Test
     public void throwsGenerationExceptionForUnknownDateTimeType() {
-        schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
-                config("dateTimeType", "org.jsonschema2pojo.integration.config.UnknownType"));
+        final String schema = "/schema/format/formattedProperties.json";
+        assertThrows(
+                GenerationException.class,
+                () -> schemaRule.generateAndCompile(schema, "com.example", config("dateTimeType", UNKNOWN_TYPE)));
     }
 
-    @Test(expected=GenerationException.class)
+    @Test
     public void throwsGenerationExceptionForUnknownDateType() {
-        schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
-                config("dateType", "org.jsonschema2pojo.integration.config.UnknownType"));
+        final String schema = "/schema/format/formattedProperties.json";
+        assertThrows(
+                GenerationException.class,
+                () -> schemaRule.generateAndCompile(schema, "com.example", config("dateType", UNKNOWN_TYPE)));
     }
 
-    @Test(expected=GenerationException.class)
+    @Test
     public void throwsGenerationExceptionForUnknownTimeType() {
-        schemaRule.generateAndCompile("/schema/format/formattedProperties.json", "com.example",
-                config("timeType", "org.jsonschema2pojo.integration.config.UnknownType"));
+        final String schema = "/schema/format/formattedProperties.json";
+        assertThrows(
+                GenerationException.class,
+                () -> schemaRule.generateAndCompile(schema, "com.example", config("timeType", UNKNOWN_TYPE)));
     }
 
     private void assertTypeIsExpected(Class<?> classInstance, String propertyName, String expectedType)

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryIT.java
@@ -28,14 +28,15 @@ import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.jsonschema2pojo.rules.FormatRule;
 import org.jsonschema2pojo.rules.Rule;
 import org.jsonschema2pojo.rules.RuleFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JType;
 
 public class CustomRuleFactoryIT {
 
-    @org.junit.Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void customAnnotatorIsAbleToAddCustomAnnotations() throws ClassNotFoundException, SecurityException, NoSuchMethodException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/CustomRuleFactoryIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/EmptyPackageNameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/EmptyPackageNameIT.java
@@ -19,12 +19,12 @@ package org.jsonschema2pojo.integration.config;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class EmptyPackageNameIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void shouldAllowEmptyPackageName() throws ClassNotFoundException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FileExtensionsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FileExtensionsIT.java
@@ -21,12 +21,12 @@ import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import java.net.URL;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class FileExtensionsIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void extensionsCanBeRemovedFromNames() throws ClassNotFoundException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FormatTypeMappingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FormatTypeMappingIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 import java.net.URL;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FormatTypeMappingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/FormatTypeMappingIT.java
@@ -30,12 +30,12 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class FormatTypeMappingIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
@@ -16,11 +16,11 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
 import static org.jsonschema2pojo.integration.util.JsonAssert.*;
-import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/GsonIT.java
@@ -29,8 +29,8 @@ import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,7 +39,7 @@ import com.google.gson.Gson;
 
 public class GsonIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsIT.java
@@ -16,9 +16,10 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsIT.java
@@ -19,21 +19,21 @@ package org.jsonschema2pojo.integration.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IncludeAccessorsIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void beansIncludeGettersAndSettersByDefault() throws ClassNotFoundException, SecurityException, NoSuchMethodException, NoSuchFieldException {
@@ -55,17 +55,14 @@ public class IncludeAccessorsIT {
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
-        try {
-            generatedType.getDeclaredMethod("getA");
-            fail("Disabled accessors but getter was generated");
-        } catch (NoSuchMethodException e) {
-        }
-
-        try {
-            generatedType.getDeclaredMethod("setA", Integer.class);
-            fail("Disabled accessors but setter was generated");
-        } catch (NoSuchMethodException e) {
-        }
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> generatedType.getDeclaredMethod("getA"),
+                "Disabled accessors but getter was generated");
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> generatedType.getDeclaredMethod("setA", Integer.class),
+                "Disabled accessors but setter was generated");
 
         assertThat(generatedType.getDeclaredField("a").getModifiers(), is(Modifier.PUBLIC));
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsPropertiesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
@@ -167,11 +167,11 @@ public class IncludeAccessorsPropertiesIT {
     }
 
     private static <M extends Member> Matcher<M> methodWhitelist() {
-        return nameMatches(isIn(Arrays.asList("setAdditionalProperty", "getAdditionalProperties")));
+        return nameMatches(is(in(Arrays.asList("setAdditionalProperty", "getAdditionalProperties"))));
     }
 
     private static <M extends Member> Matcher<M> fieldWhitelist() {
-        return nameMatches(isIn(Collections.singletonList("additionalProperties")));
+        return nameMatches(is(in(Collections.singletonList("additionalProperties"))));
     }
 
     private static <M extends Member> Matcher<M> fieldGetterOrSetter() {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeAccessorsPropertiesIT.java
@@ -33,11 +33,10 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Checks general properties of includeAccessors and different configurations.
@@ -46,13 +45,14 @@ import org.junit.runners.Parameterized.Parameters;
  *
  */
 @SuppressWarnings({ "rawtypes" })
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("parameters")
 public class IncludeAccessorsPropertiesIT {
+
     public static final String PACKAGE = "com.example";
     public static final String PRIMITIVE_JSON = "/schema/properties/primitiveProperties.json";
     public static final String PRIMITIVE_TYPE = "com.example.PrimitiveProperties";
 
-    @Parameters
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
             { PRIMITIVE_JSON, PRIMITIVE_TYPE, config() },
@@ -61,7 +61,7 @@ public class IncludeAccessorsPropertiesIT {
         });
     }
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private String path;
     private String typeName;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeConstructorPropertiesAnnotationIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeConstructorPropertiesAnnotationIT.java
@@ -16,11 +16,10 @@
 
 package org.jsonschema2pojo.integration.config;
 
-import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.*;
+import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.beans.ConstructorProperties;
 import java.lang.annotation.Annotation;
@@ -28,11 +27,12 @@ import java.lang.reflect.Constructor;
 import java.util.StringJoiner;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class IncludeConstructorPropertiesAnnotationIT {
-  @Rule
+
+  @RegisterExtension
   public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
   private String[] expectedValueForAllValuesConstructor = { "x", "y", "z" };
@@ -127,10 +127,10 @@ public class IncludeConstructorPropertiesAnnotationIT {
     return joiner.toString();
   }
 
-  private String paramTypesJoin(Class[] parameterTypes) {
+  private String paramTypesJoin(Class<?>[] parameterTypes) {
     StringJoiner joiner = new StringJoiner(",");
 
-    for (Class clazz : parameterTypes)
+    for (Class<?> clazz : parameterTypes)
     {
       joiner.add(clazz.getCanonicalName());
     }
@@ -146,7 +146,7 @@ public class IncludeConstructorPropertiesAnnotationIT {
       if (constructor.getParameterCount() == paramCount)
       {
         ConstructorProperties constructorPropertiesAnnotation = constructor.getAnnotation(ConstructorProperties.class);
-        assertNotNull(constructorPropertiesAnnotation);
+        assertThat(constructorPropertiesAnnotation, is(notNullValue()));
         assertThat(constructorPropertiesAnnotation.value(), is(expectedValue));
         return;
       }
@@ -158,7 +158,7 @@ public class IncludeConstructorPropertiesAnnotationIT {
   private void validateNoAnnotationPresentOnAnyConstructors(Class<?> testObjectClass) {
     Constructor<?>[] constructors = testObjectClass.getConstructors();
 
-    for (Constructor constructor : constructors)
+    for (Constructor<?> constructor : constructors)
     {
       Annotation annotation = constructor.getAnnotation(ConstructorProperties.class);
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeGeneratedAnnotationIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeGeneratedAnnotationIT.java
@@ -24,14 +24,14 @@ import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
 import java.io.File;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class IncludeGeneratedAnnotationIT {
 
     private static final String SCHEMA_PATH = "/schema/includeGeneratedAnnotation/includeGeneratedAnnotation.json";
 
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
@@ -50,14 +50,14 @@ public class IncludeGeneratedAnnotationIT {
     }
 
     @Test
-    public void disabled() throws ClassNotFoundException {
+    public void disabled() {
         File source = schemaRule.generate(SCHEMA_PATH, "com.example", config("includeGeneratedAnnotation", false));
 
         assertThat(source, not(containsText("@Generated")));
     }
 
     @Test
-    public void enabled() throws ClassNotFoundException {
+    public void enabled() {
         File source = schemaRule.generate(SCHEMA_PATH, "com.example", config("includeGeneratedAnnotation", true));
 
         assertThat(source, containsText("@Generated"));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -32,35 +32,30 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.bval.jsr.ApacheValidationProvider;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("rawtypes")
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@ValueSource(booleans = { true, false })
 public class IncludeJsr303AnnotationsIT {
 
     private final boolean useJakartaValidation;
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static final javax.validation.Validator javaxValidator = javax.validation.Validation.byProvider(ApacheValidationProvider.class)
             .configure()
             .buildValidatorFactory()
             .getValidator();
     private static final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-
-    @Parameterized.Parameters
-    public static Collection<Object> data() {
-        return asList(true, false);
-    }
 
     public IncludeJsr303AnnotationsIT(boolean useJakartaValidation) {
         this.useJakartaValidation = useJakartaValidation;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -17,9 +17,9 @@
 package org.jsonschema2pojo.integration.config;
 
 import static java.util.Arrays.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.FileSearchMatcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
@@ -20,7 +20,6 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -32,19 +31,19 @@ import javax.annotation.Nullable;
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.FileSearchMatcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class IncludeJsr305AnnotationsIT {
 
     private final boolean useJakartaValidation;
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
-    @Parameterized.Parameters
     public static Collection<Object> data() {
         return asList(true, false);
     }
@@ -73,52 +72,40 @@ public class IncludeJsr305AnnotationsIT {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void jsr305NonnullAnnotationIsAddedForSchemaRuleRequired() throws ClassNotFoundException {
+    public void jsr305NonnullAnnotationIsAddedForSchemaRuleRequired() throws ReflectiveOperationException {
 
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/required.json", "com.example",
                                                                        config("includeJsr305Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.Required");
 
-        try {
-            validateNonnullField(generatedType.getDeclaredField("required"));
-        } catch (NoSuchFieldException e) {
-            fail("Field is missing in generated class.");
-        }
+        validateNonnullField(generatedType.getDeclaredField("required"));
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void jsr305NullableAnnotationIsAddedByDefault() throws ClassNotFoundException {
+    public void jsr305NullableAnnotationIsAddedByDefault() throws ReflectiveOperationException {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/required/required.json", "com.example",
                                                                        config("includeJsr305Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.Required");
 
-        try {
-            validateNonnullField(generatedType.getDeclaredField("requiredProperty"));
-            validateNullableField(generatedType.getDeclaredField("nonRequiredProperty"));
-            validateNullableField(generatedType.getDeclaredField("defaultNotRequiredProperty"));
-        } catch (NoSuchFieldException e) {
-            fail("Expected field is missing in generated class.");
-        }
+        validateNonnullField(generatedType.getDeclaredField("requiredProperty"));
+        validateNullableField(generatedType.getDeclaredField("nonRequiredProperty"));
+        validateNullableField(generatedType.getDeclaredField("defaultNotRequiredProperty"));
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void jsr305RequiredArrayIsTakenIntoConsideration() throws ClassNotFoundException {
+    public void jsr305RequiredArrayIsTakenIntoConsideration() throws ReflectiveOperationException {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/required/requiredArray.json", "com.example",
                                                                        config("includeJsr305Annotations", true));
 
         Class generatedType = resultsClassLoader.loadClass("com.example.RequiredArray");
 
-        try {
-            validateNonnullField(generatedType.getDeclaredField("requiredProperty"));
-            validateNullableField(generatedType.getDeclaredField("nonRequiredProperty"));
-            validateNullableField(generatedType.getDeclaredField("defaultNotRequiredProperty"));
-        } catch (NoSuchFieldException e) {
-            fail("Expected field is missing in generated class.");
-        }
+        validateNonnullField(generatedType.getDeclaredField("requiredProperty"));
+        validateNullableField(generatedType.getDeclaredField("nonRequiredProperty"));
+        validateNullableField(generatedType.getDeclaredField("defaultNotRequiredProperty"));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr305AnnotationsIT.java
@@ -17,9 +17,10 @@
 package org.jsonschema2pojo.integration.config;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -148,16 +149,16 @@ public class IncludeJsr305AnnotationsIT {
         Nonnull nonnullAnnotation = nonnullField.getAnnotation(Nonnull.class);
         Nullable nullableAnnotation = nonnullField.getAnnotation(Nullable.class);
 
-        assertNotNull("Expected @Nonnull annotation is missing.", nonnullAnnotation);
-        assertNull("Unexpected @Nullable annotation found.", nullableAnnotation);
+        assertThat("Expected @Nonnull annotation is missing.", nonnullAnnotation, is(notNullValue()));
+        assertThat("Unexpected @Nullable annotation found.", nullableAnnotation, is(nullValue()));
     }
 
     private static void validateNullableField(Field nullableField) {
         Nonnull nonnullAnnotation = nullableField.getAnnotation(Nonnull.class);
         Nullable nullableAnnotation = nullableField.getAnnotation(Nullable.class);
 
-        assertNull("Unexpected @Nonnull annotation found.", nonnullAnnotation);
-        assertNotNull("Expected @Nullable annotation is missing.", nullableAnnotation);
+        assertThat("Unexpected @Nonnull annotation found.", nonnullAnnotation, is(nullValue()));
+        assertThat("Expected @Nullable annotation is missing.", nullableAnnotation, is(notNullValue()));
     }
 
     private static Matcher<File> containsText(String searchText) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeToStringIT.java
@@ -17,15 +17,15 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class IncludeToStringIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -47,11 +47,10 @@ public class IncludeToStringIT {
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
-        try {
-            generatedType.getDeclaredMethod("toString");
-            fail(".toString method is present, it should have been omitted");
-        } catch (NoSuchMethodException e) {
-        }
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> generatedType.getDeclaredMethod("toString"),
+                ".toString method is present, it should have been omitted");
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeTypeInfoIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeTypeInfoIT.java
@@ -17,19 +17,18 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.*;
+import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class IncludeTypeInfoIT
 {
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
@@ -40,7 +39,7 @@ public class IncludeTypeInfoIT
 
         Class<?> classWithTypeInfo = classLoader.loadClass("com.example.TypeInfo");
 
-        assertNull(classWithTypeInfo.getAnnotation(JsonTypeInfo.class));
+        assertThat(classWithTypeInfo.getAnnotation(JsonTypeInfo.class), is(nullValue()));
     }
 
     @Test
@@ -51,7 +50,7 @@ public class IncludeTypeInfoIT
 
         Class<?> classWithTypeInfo = classLoader.loadClass("com.example.TypeInfoWithSchemaProperty");
 
-        assertNotNull(classWithTypeInfo.getAnnotation(JsonTypeInfo.class));
+        assertThat(classWithTypeInfo.getAnnotation(JsonTypeInfo.class), is(notNullValue()));
 
         JsonTypeInfo jsonTypeInfo = classWithTypeInfo.getAnnotation(JsonTypeInfo.class);
         assertThat(jsonTypeInfo.use(), is(JsonTypeInfo.Id.CLASS));
@@ -68,7 +67,7 @@ public class IncludeTypeInfoIT
 
         Class<?> classWithTypeInfo = classLoader.loadClass("com.example.TypeInfo");
 
-        assertNull(classWithTypeInfo.getAnnotation(JsonTypeInfo.class));
+        assertThat(classWithTypeInfo.getAnnotation(JsonTypeInfo.class), is(nullValue()));
     }
 
     @Test
@@ -79,7 +78,7 @@ public class IncludeTypeInfoIT
                                                                 config("includeTypeInfo", false));
         Class<?> classWithTypeInfo = classLoader.loadClass("com.example.TypeInfoWithSchemaProperty");
 
-        assertNotNull(classWithTypeInfo.getAnnotation(JsonTypeInfo.class));
+        assertThat(classWithTypeInfo.getAnnotation(JsonTypeInfo.class), is(notNullValue()));
 
         JsonTypeInfo jsonTypeInfo = classWithTypeInfo.getAnnotation(JsonTypeInfo.class);
         assertThat(jsonTypeInfo.use(), is(JsonTypeInfo.Id.CLASS));
@@ -96,7 +95,7 @@ public class IncludeTypeInfoIT
 
         Class<?> classWithTypeInfo = classLoader.loadClass("com.example.TypeInfo");
 
-        assertNotNull(classWithTypeInfo.getAnnotation(JsonTypeInfo.class));
+        assertThat(classWithTypeInfo.getAnnotation(JsonTypeInfo.class), is(notNullValue()));
 
         JsonTypeInfo jsonTypeInfo = classWithTypeInfo.getAnnotation(JsonTypeInfo.class);
         assertThat(jsonTypeInfo.use(), is(JsonTypeInfo.Id.CLASS));
@@ -112,7 +111,7 @@ public class IncludeTypeInfoIT
                                                                 config("includeTypeInfo", true));
         Class<?> classWithTypeInfo = classLoader.loadClass("com.example.TypeInfoWithSchemaProperty");
 
-        assertNotNull(classWithTypeInfo.getAnnotation(JsonTypeInfo.class));
+        assertThat(classWithTypeInfo.getAnnotation(JsonTypeInfo.class), is(notNullValue()));
 
         JsonTypeInfo jsonTypeInfo = classWithTypeInfo.getAnnotation(JsonTypeInfo.class);
         assertThat(jsonTypeInfo.use(), is(JsonTypeInfo.Id.CLASS));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InclusionLevelIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InclusionLevelIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.Rule;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InclusionLevelIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InclusionLevelIT.java
@@ -21,14 +21,14 @@ import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class InclusionLevelIT {
 
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InitializeCollectionsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InitializeCollectionsIT.java
@@ -28,16 +28,15 @@ import java.util.Map;
 
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name="{0}")
+@MethodSource("parameters")
 public class InitializeCollectionsIT {
     
-    @Parameters(name="{0}")
     public static Collection<Object[]> parameters() {
         Map<String, Object> withOptionFalse = config("initializeCollections", false);
         Map<String, Object> withOptionAbsent = config();
@@ -50,7 +49,7 @@ public class InitializeCollectionsIT {
         });
     }
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private Map<String, Object> config;
     private Matcher<Object> resultMatcher;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InitializeCollectionsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/InitializeCollectionsIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/JodaDatesIT.java
@@ -31,12 +31,12 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class JodaDatesIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void defaultTypesAreNotJoda() throws ClassNotFoundException, IntrospectionException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb1IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb1IT.java
@@ -24,9 +24,9 @@ import static org.jsonschema2pojo.integration.util.JsonAssert.assertEqualsJson;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -36,16 +36,15 @@ import javax.json.bind.annotation.JsonbPropertyOrder;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
 
 public class Jsonb1IT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private Jsonb jsonb;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         jsonb = JsonbBuilder.create();
     }
@@ -94,10 +93,10 @@ public class Jsonb1IT {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private void assertJsonRoundTrip(ClassLoader resultsClassLoader, String className, String jsonResource) throws ClassNotFoundException, IOException, IOException {
+    private void assertJsonRoundTrip(ClassLoader resultsClassLoader, String className, String jsonResource) throws ClassNotFoundException, IOException {
         Class generatedType = resultsClassLoader.loadClass(className);
 
-        String expectedJson = IOUtils.toString(getClass().getResource(jsonResource), Charset.forName("UTF-8"));
+        String expectedJson = IOUtils.toString(getClass().getResource(jsonResource), StandardCharsets.UTF_8);
         Object javaInstance = jsonb.fromJson(expectedJson, generatedType);
         String actualJson = jsonb.toJson(javaInstance);
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb1IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb1IT.java
@@ -16,11 +16,11 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.containsText;
 import static org.jsonschema2pojo.integration.util.JsonAssert.assertEqualsJson;
-import static org.junit.Assert.assertThat;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb2IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb2IT.java
@@ -24,13 +24,13 @@ import static org.jsonschema2pojo.integration.util.JsonAssert.assertEqualsJson;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -40,11 +40,12 @@ import jakarta.json.bind.annotation.JsonbPropertyOrder;
 
 public class Jsonb2IT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private Jsonb jsonb;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         jsonb = JsonbBuilder.create();
     }
@@ -93,10 +94,10 @@ public class Jsonb2IT {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private void assertJsonRoundTrip(ClassLoader resultsClassLoader, String className, String jsonResource) throws ClassNotFoundException, IOException, IOException {
+    private void assertJsonRoundTrip(ClassLoader resultsClassLoader, String className, String jsonResource) throws ClassNotFoundException, IOException {
         Class generatedType = resultsClassLoader.loadClass(className);
 
-        String expectedJson = IOUtils.toString(getClass().getResource(jsonResource), Charset.forName("UTF-8"));
+        String expectedJson = IOUtils.toString(getClass().getResource(jsonResource), StandardCharsets.UTF_8);
         Object javaInstance = jsonb.fromJson(expectedJson, generatedType);
         String actualJson = jsonb.toJson(javaInstance);
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb2IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Jsonb2IT.java
@@ -16,11 +16,11 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.containsText;
 import static org.jsonschema2pojo.integration.util.JsonAssert.assertEqualsJson;
-import static org.junit.Assert.assertThat;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Moshi1IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Moshi1IT.java
@@ -29,9 +29,9 @@ import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -42,12 +42,12 @@ import com.squareup.moshi.Moshi;
 
 public class Moshi1IT {
 
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private Moshi moshi;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         moshi = new Moshi.Builder().build();
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Moshi1IT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/Moshi1IT.java
@@ -16,11 +16,11 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.jsonschema2pojo.integration.util.FileSearchMatcher.*;
 import static org.jsonschema2pojo.integration.util.JsonAssert.*;
-import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OutputEncodingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OutputEncodingIT.java
@@ -27,12 +27,12 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class OutputEncodingIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void writeExtendedCharactersAsUtf8SourceCodeByDefault() throws IOException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OutputEncodingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/OutputEncodingIT.java
@@ -16,13 +16,14 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
@@ -37,7 +38,7 @@ public class OutputEncodingIT {
     public void writeExtendedCharactersAsUtf8SourceCodeByDefault() throws IOException {
         File outputDirectory = schemaRule.generate("/schema/regression/extendedCharacters.json", "com.example");
         File sourceFile = new File(outputDirectory, "com/example/ExtendedCharacters.java");
-        String javaSource = IOUtils.toString(new FileInputStream(sourceFile), "utf-8");
+        String javaSource = IOUtils.toString(new FileInputStream(sourceFile), StandardCharsets.UTF_8);
 
         assertThat(javaSource, containsString("ЫЩДђиЊЉЯ"));
     }
@@ -52,7 +53,7 @@ public class OutputEncodingIT {
 
             File outputDirectory = schemaRule.generate("/schema/regression/extendedCharacters.json", "com.example");
             File sourceFile = new File(outputDirectory, "com/example/ExtendedCharacters.java");
-            String javaSource = IOUtils.toString(new FileInputStream(sourceFile), "utf-8");
+            String javaSource = IOUtils.toString(new FileInputStream(sourceFile), StandardCharsets.UTF_8);
 
             assertThat(javaSource, containsString("ЫЩДђиЊЉЯ"));
         } finally {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/ParcelableIT.java
@@ -20,39 +20,52 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import static org.jsonschema2pojo.integration.util.ParcelUtils.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ServiceLoader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.robolectric.android.AndroidInterceptors;
+import org.robolectric.internal.ShadowProvider;
+import org.robolectric.internal.bytecode.Interceptors;
+import org.robolectric.internal.bytecode.Sandbox;
+import org.robolectric.internal.bytecode.ShadowMap;
+import org.robolectric.internal.bytecode.ShadowWrangler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE, sdk=23)
 public class ParcelableIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @BeforeAll
+    public static void setUp() {
+        final Interceptors interceptors = new Interceptors(AndroidInterceptors.all());
+        final ShadowMap shadowMap = ShadowMap.createFromShadowProviders(ServiceLoader.load(ShadowProvider.class));
+        new Sandbox(ParcelableIT.class.getClassLoader()).configure(new ShadowWrangler(shadowMap, 23, interceptors), interceptors);
+    }
 
     @Test
     public void parcelableTreeIsParcelable() throws ClassNotFoundException, IOException {
-        Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-schema.json", "com.example",
-                config("parcelable", true))
-                .loadClass("com.example.ParcelableSchema");
-
-        Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-data.json"), parcelableType);
+        Class<? extends Parcelable> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-schema.json", "com.example",
+                                                                config("parcelable", true))
+                .loadClass("com.example.ParcelableSchema")
+                .asSubclass(Parcelable.class);
+        Parcelable instance = new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-data.json"), parcelableType);
         String key = "example";
         Parcel parcel = writeToParcel(instance, key);
         Parcelable unparceledInstance = readFromParcel(parcel, parcelableType, key);
@@ -61,10 +74,10 @@ public class ParcelableIT {
     }
 
     @Test
-    public void parcelableTypeDoesNotHaveAnyDuplicateImports() throws ClassNotFoundException, IOException {
+    public void parcelableTypeDoesNotHaveAnyDuplicateImports() throws IOException {
         schemaRule.generate("/schema/parcelable/parcelable-schema.json", "com.example", config("parcelable", true));
         File generated = schemaRule.generated("com/example/ParcelableSchema.java");
-        String content = FileUtils.readFileToString(generated);
+        String content = FileUtils.readFileToString(generated, StandardCharsets.UTF_8);
 
         Matcher m = Pattern.compile("(import [^;]+);").matcher(content);
         while (m.find()) {
@@ -76,27 +89,24 @@ public class ParcelableIT {
     @Test
     public void parcelableSuperclassIsUnparceled() throws ClassNotFoundException, IOException {
         // Explicitly set includeConstructors to false if default value changes in the future
-        Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-superclass-schema.json", "com.example",
+        Class<? extends Parcelable> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-superclass-schema.json", "com.example",
                 config("parcelable", true, "includeConstructors", false))
-                .loadClass("com.example.ParcelableSuperclassSchema");
+                .loadClass("com.example.ParcelableSuperclassSchema")
+                .asSubclass(Parcelable.class);
 
-        Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-superclass-data.json"), parcelableType);
+        Parcelable instance = new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-superclass-data.json"), parcelableType);
         Parcel parcel = parcelableWriteToParcel(instance);
-        Parcelable unparceledInstance = parcelableReadFromParcel(parcel, parcelableType, instance);
+        Parcelable unparceledInstance = parcelableReadFromParcel(parcel, instance);
 
         assertThat(instance, is(equalTo(unparceledInstance)));
     }
 
     @Test
-    public void parcelableDefaultConstructorDoesNotConflict() throws ClassNotFoundException, IOException {
-        Class<?> parcelableType = schemaRule.generateAndCompile("/schema/parcelable/parcelable-superclass-schema.json", "com.example",
-                config("parcelable", true, "includeConstructors", true))
-                .loadClass("com.example.ParcelableSuperclassSchema");
-
-        Parcelable instance = (Parcelable) new ObjectMapper().readValue(ParcelableIT.class.getResourceAsStream("/schema/parcelable/parcelable-superclass-data.json"), parcelableType);
-        Parcel parcel = parcelableWriteToParcel(instance);
-        Parcelable unparceledInstance = parcelableReadFromParcel(parcel, parcelableType, instance);
-
-        assertThat(instance, is(equalTo(unparceledInstance)));
+    public void parcelableDefaultConstructorDoesNotConflict() {
+        schemaRule.generate("/schema/parcelable/parcelable-superclass-schema.json", "com.example",
+                                      config("parcelable", true, "includeConstructors", true));
+        // Compilation would if there are multiple constructors with the same signature
+        assertDoesNotThrow(() -> schemaRule.compile());
     }
+
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/PrefixSuffixIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/PrefixSuffixIT.java
@@ -17,14 +17,15 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrefixSuffixIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void defaultClassPrefix() throws ClassNotFoundException {
@@ -40,12 +41,11 @@ public class PrefixSuffixIT {
         resultsClassLoader.loadClass("com.example.AbstractPrimitiveProperties");
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void customClassPrefixExistingClass() throws ClassNotFoundException {
-
+    @Test
+    public void customClassPrefixExistingClass() {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/objectPropertiesJavaType.json",
                 "com.example", config("classNamePrefix", "SomePrefix"));
-        resultsClassLoader.loadClass("org.jsonschema2pojo.SomePrefixNoopAnnotator");
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("org.jsonschema2pojo.SomePrefixNoopAnnotator"));
     }
     
     @Test
@@ -75,30 +75,28 @@ public class PrefixSuffixIT {
         resultsClassLoader.loadClass("com.example.PrimitivePropertiesdao");
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void NotExistingClassPrefix() throws ClassNotFoundException{
-
+    @Test
+    public void NotExistingClassPrefix() {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNamePrefix","Abstract"));
-        resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties"));
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void NotExistingClassSufix() throws ClassNotFoundException{
-
+    @Test
+    public void NotExistingClassSufix() {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "com.example", config("classNameSuffix","Dao"));
-        resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties"));
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void SuffixWithDefaultPackageName() throws ClassNotFoundException{
+    @Test
+    public void SuffixWithDefaultPackageName() {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "", config("classNameSuffix","Dao"));
-        resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties"));
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void PrefixWithDefaultPackageName() throws ClassNotFoundException{
+    @Test
+    public void PrefixWithDefaultPackageName() {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/properties/primitiveProperties.json", "", config("classNamePrefix","Abstract"));
-        resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties");
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.NotExistingPrimitiveProperties"));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RefFragmentPathDelimitersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RefFragmentPathDelimitersIT.java
@@ -19,12 +19,12 @@ package org.jsonschema2pojo.integration.config;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RefFragmentPathDelimitersIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void refFragmentPathDelimitersUsedInAPropertyIsReadSuccessfully() throws ClassNotFoundException, SecurityException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RemoveOldOutputIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/RemoveOldOutputIT.java
@@ -17,19 +17,21 @@
 package org.jsonschema2pojo.integration.config;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RemoveOldOutputIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
-    @Test(expected = ClassNotFoundException.class)
-    public void removeOldOutputCausesOldTypesToBeDeleted() throws ClassNotFoundException {
+    @Test
+    public void removeOldOutputCausesOldTypesToBeDeleted() {
 
         URL schema1 = getClass().getResource("/schema/properties/primitiveProperties.json");
         URL schema2 = getClass().getResource("/schema/properties/orderedProperties.json");
@@ -37,13 +39,11 @@ public class RemoveOldOutputIT {
         schemaRule.generate(schema1, "com.example", config("removeOldOutput", true));
         schemaRule.generate(schema2, "com.example", config("removeOldOutput", true));
 
-        schemaRule.compile().loadClass("com.example.PrimitiveProperties");
-
+        assertThrows(ClassNotFoundException.class, () -> schemaRule.compile().loadClass("com.example.PrimitiveProperties"));
     }
 
     @Test
     public void byDefaultPluginDoesNotRemoveOldOutput() throws ClassNotFoundException {
-
         URL schema1 = getClass().getResource("/schema/properties/primitiveProperties.json");
         URL schema2 = getClass().getResource("/schema/properties/orderedProperties.json");
 
@@ -51,7 +51,6 @@ public class RemoveOldOutputIT {
         schemaRule.generate(schema2, "com.example", config());
 
         schemaRule.compile().loadClass("com.example.PrimitiveProperties");
-
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/SerializableIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/SerializableIT.java
@@ -16,12 +16,13 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.io.Serializable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SerializableIT {
 
@@ -33,8 +34,7 @@ public class SerializableIT {
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
-        assertFalse("Beans should not implement serializable by default", Serializable.class.isAssignableFrom(generatedType));
-
+        assertThat("Beans should not implement serializable by default", generatedType, is(instanceOf(Serializable.class)));
     }
 
     @Test
@@ -44,7 +44,7 @@ public class SerializableIT {
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
-        assertTrue("Beans should implement serializable when config is set", Serializable.class.isAssignableFrom(generatedType));
+        assertThat("Beans should implement serializable when config is set", generatedType, is(instanceOf(Serializable.class)));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class SerializableIT {
 
         Class generatedType = resultsClassLoader.loadClass("com.example.PrimitiveProperties");
 
-        assertTrue("Beans should implement serializable when config is set", Serializable.class.isAssignableFrom(generatedType));
+        assertThat("Beans should implement serializable when config is set", generatedType, is(instanceOf(Serializable.class)));
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/SourceSortOrderIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/SourceSortOrderIT.java
@@ -16,19 +16,20 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 
 import org.jsonschema2pojo.SourceSortOrder;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SourceSortOrderIT {
 
-    @Rule
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
@@ -80,6 +81,6 @@ public class SourceSortOrderIT {
     }
 
     private void assertInPackage(String expectedPackage, Class<?> generatedClass) {
-        assertEquals("Unexpected package", expectedPackage, generatedClass.getPackage().getName());
+        assertThat("Unexpected package", generatedClass.getPackage().getName(), is(equalTo(expectedPackage)));
     }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
@@ -19,6 +19,7 @@ package org.jsonschema2pojo.integration.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -30,13 +31,12 @@ import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Matcher;
 import org.jsonschema2pojo.integration.util.FileSearchMatcher;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@SuppressWarnings("rawtypes")
 public class UseInnerClassBuildersIT {
 
-  @Rule
+  @RegisterExtension
   public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
   private static Matcher<File> containsText(String searchText) {
@@ -57,7 +57,7 @@ public class UseInnerClassBuildersIT {
    * This method confirms that if you choose to generate builders, but don't indicate that useInnerBuilders is true, they will be generated using the
    * chaining setters instead of the inner classes
    */
-  @Test(expected = ClassNotFoundException.class)
+  @Test
   public void defaultBuilderIsChainedSetters() throws ClassNotFoundException {
     ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema.useInnerClassBuilders/child.json", "com.example",
         config("generateBuilders", true));
@@ -69,7 +69,7 @@ public class UseInnerClassBuildersIT {
 
     assertThat("Generated class missing any builders at all", containsWithMethod, is(true));
 
-    resultsClassLoader.loadClass("com.example.Child.ChildBuilder");
+    assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.Child.ChildBuilder"));
   }
 
   /**

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseInnerClassBuildersIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -67,7 +67,7 @@ public class UseInnerClassBuildersIT {
         .map(Method::getName)
         .anyMatch(methodName -> StringUtils.contains(methodName, "with"));
 
-    assertTrue("Generated class missing any builders at all", containsWithMethod);
+    assertThat("Generated class missing any builders at all", containsWithMethod, is(true));
 
     resultsClassLoader.loadClass("com.example.Child.ChildBuilder");
   }
@@ -85,9 +85,9 @@ public class UseInnerClassBuildersIT {
         .map(Method::getName)
         .anyMatch(methodName -> StringUtils.contains(methodName, "with"));
 
-    assertFalse("Generated contains unexpected builders", containsWithMethod);
+    assertThat("Generated contains unexpected builders", containsWithMethod, is(false));
 
-    assertNotNull(resultsClassLoader.loadClass("com.example.Child$ChildBuilder"));
+    assertThat(resultsClassLoader.loadClass("com.example.Child$ChildBuilder"), is(notNullValue()));
   }
 
   /**
@@ -104,9 +104,9 @@ public class UseInnerClassBuildersIT {
     Method buildMethod = builderClass.getMethod("build");
 
     Object builder = builderClass.newInstance();
-    assertNotNull(builder);
+    assertThat(builder, is(notNullValue()));
 
-    assertNotNull(buildMethod.invoke(builder));
+    assertThat(buildMethod.invoke(builder), is(notNullValue()));
   }
 
   /**
@@ -140,9 +140,9 @@ public class UseInnerClassBuildersIT {
     Method getParentProperty = childClass.getMethod("getParentProperty");
     Method getSharedProperty = childClass.getMethod("getSharedProperty");
 
-    assertEquals(childProperty, getChildProperty.invoke(childObject));
-    assertEquals(parentProperty, getParentProperty.invoke(childObject));
-    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+    assertThat(childProperty, is(equalTo(getChildProperty.invoke(childObject))));
+    assertThat(parentProperty, is(equalTo(getParentProperty.invoke(childObject))));
+    assertThat(sharedProperty, is(equalTo(getSharedProperty.invoke(childObject))));
   }
 
   /**
@@ -154,10 +154,10 @@ public class UseInnerClassBuildersIT {
         config("generateBuilders", true, "useInnerClassBuilders", true));
 
     Class<?> builderClass = resultsClassLoader.loadClass("com.example.Child$ChildBuilder");
-    assertEquals(1, builderClass.getConstructors().length);
+    assertThat(builderClass.getConstructors().length, is(equalTo(1)));
 
     Constructor<?> constructor = builderClass.getConstructors()[0];
-    assertEquals(0, constructor.getParameterCount());
+    assertThat(constructor.getParameterCount(), is(equalTo(0)));
   }
 
   /**
@@ -185,9 +185,9 @@ public class UseInnerClassBuildersIT {
     Method getParentProperty = childClass.getMethod("getParentProperty");
     Method getSharedProperty = childClass.getMethod("getSharedProperty");
 
-    assertEquals(childProperty, getChildProperty.invoke(childObject));
-    assertEquals(parentProperty, getParentProperty.invoke(childObject));
-    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+    assertThat(getChildProperty.invoke(childObject), is(equalTo(childProperty)));
+    assertThat(getParentProperty.invoke(childObject), is(equalTo(parentProperty)));
+    assertThat(getSharedProperty.invoke(childObject), is(equalTo(sharedProperty)));
   }
 
   /**
@@ -220,9 +220,9 @@ public class UseInnerClassBuildersIT {
     Method getParentProperty = childClass.getMethod("getParentProperty");
     Method getSharedProperty = childClass.getMethod("getSharedProperty");
 
-    assertEquals(childProperty, getChildProperty.invoke(childObject));
-    assertEquals(parentProperty, getParentProperty.invoke(childObject));
-    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+    assertThat(getChildProperty.invoke(childObject), is(equalTo(childProperty)));
+    assertThat(getParentProperty.invoke(childObject), is(equalTo(parentProperty)));
+    assertThat(getSharedProperty.invoke(childObject), is(equalTo(sharedProperty)));
   }
 
   /**
@@ -261,9 +261,9 @@ public class UseInnerClassBuildersIT {
     Method getParentProperty = childClass.getMethod("getParentProperty");
     Method getSharedProperty = childClass.getMethod("getSharedProperty");
 
-    assertEquals(childProperty, getChildProperty.invoke(childObject));
-    assertEquals(parentProperty, getParentProperty.invoke(childObject));
-    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+    assertThat(getChildProperty.invoke(childObject), is(equalTo(childProperty)));
+    assertThat(getParentProperty.invoke(childObject), is(equalTo(parentProperty)));
+    assertThat(getSharedProperty.invoke(childObject), is(equalTo(sharedProperty)));
   }
 
   /**
@@ -299,8 +299,8 @@ public class UseInnerClassBuildersIT {
     Method getParentProperty = childClass.getMethod("getParentProperty");
     Method getSharedProperty = childClass.getMethod("getSharedProperty");
 
-    assertEquals(childProperty, getChildProperty.invoke(childObject));
-    assertEquals(parentProperty, getParentProperty.invoke(childObject));
-    assertEquals(sharedProperty, getSharedProperty.invoke(childObject));
+    assertThat(childProperty, is(equalTo(getChildProperty.invoke(childObject))));
+    assertThat(parentProperty, is(equalTo(getParentProperty.invoke(childObject))));
+    assertThat(getSharedProperty.invoke(childObject), is(equalTo(sharedProperty)));
   }
 }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseTitleAsClassnameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseTitleAsClassnameIT.java
@@ -23,12 +23,12 @@ import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
 import java.lang.reflect.Method;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class UseTitleAsClassnameIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseTitleAsClassnameIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/UseTitleAsClassnameIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/filtering/FilteringIT.java
@@ -17,15 +17,16 @@
 package org.jsonschema2pojo.integration.filtering;
 
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the filtering of files in the source directory.
@@ -33,12 +34,13 @@ import org.junit.Test;
  * @author Christian Trimble
  */
 public class FilteringIT {
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     URL filteredSchemaUrl;
     URL subSchemaUrl;
     
-    @Before
+    @BeforeEach
     public void setUp() throws MalformedURLException {
         filteredSchemaUrl = new File("./src/test/resources/schema/filtering").toURI().toURL();
         subSchemaUrl = new File("./src/test/resources/schema/filtering/sub").toURI().toURL();
@@ -52,12 +54,12 @@ public class FilteringIT {
         resultsClassLoader.loadClass("com.example.Included");
     }
     
-    @Test(expected=ClassNotFoundException.class)
-    public void shouldNotProcessExcludedFiles() throws ClassNotFoundException {
+    @Test
+    public void shouldNotProcessExcludedFiles() {
         ClassLoader resultsClassLoader =schemaRule. generateAndCompile(filteredSchemaUrl, "com.example",
                 config("includes", new String[] { "**/*.json" }, "excludes", new String[] { "excluded.json" }));
 
-        resultsClassLoader.loadClass("com.example.Excluded");
+        assertThrows(ClassNotFoundException.class, () -> resultsClassLoader.loadClass("com.example.Excluded"));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/RealJsonExamplesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/RealJsonExamplesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.json;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/RealJsonExamplesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/json/RealJsonExamplesIT.java
@@ -24,26 +24,26 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name="{0}")
+@MethodSource("data")
 public class RealJsonExamplesIT {
 
-    @Parameterized.Parameters(name="{0}")
     public static List<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "json", new ObjectMapper()},
+                { "json", new ObjectMapper() },
                 { "yaml", new ObjectMapper(new YAMLFactory()) }
         });
     }
 
-    @Rule 
+    @RegisterExtension
     public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final String format;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/AbsoluteRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/AbsoluteRefIT.java
@@ -26,11 +26,12 @@ import java.net.URL;
 
 import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AbsoluteRefIT {
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     public void absoluteRefIsReadSuccessfully() throws ClassNotFoundException, NoSuchMethodException, IOException {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/AbsoluteRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/AbsoluteRefIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration.ref;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
@@ -20,17 +20,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ClasspathRefIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classpathRefsClass;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
         ClassLoader classpathRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/classpathRefs.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/ClasspathRefIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration.ref;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/CyclicalRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/CyclicalRefIT.java
@@ -27,8 +27,8 @@ import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.jsonschema2pojo.rules.RuleFactory;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,7 +37,7 @@ import com.sun.codemodel.JPackage;
 
 public class CyclicalRefIT {
 
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/FragmentRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/FragmentRefIT.java
@@ -26,9 +26,9 @@ import java.lang.reflect.Type;
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.jsonschema2pojo.rules.RuleFactory;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,11 +37,11 @@ import com.sun.codemodel.JPackage;
 
 public class FragmentRefIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> fragmentRefsClass;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompile() throws ClassNotFoundException {
 
         ClassLoader fragmentRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/fragmentRefs.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/HttpRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/HttpRefIT.java
@@ -20,17 +20,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class HttpRefIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> httpRefsClass;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
         ClassLoader httpRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/httpRefs.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/HttpRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/HttpRefIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration.ref;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.BeforeClass;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RelativeRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RelativeRefIT.java
@@ -23,17 +23,17 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RelativeRefIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> relativeRefsClass;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
         ClassLoader relativeRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/refsToA.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RelativeRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RelativeRefIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration.ref;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
@@ -16,8 +16,8 @@
 
 package org.jsonschema2pojo.integration.ref;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/SelfRefIT.java
@@ -27,21 +27,20 @@ import org.apache.commons.io.IOUtils;
 import org.jsonschema2pojo.SchemaMapper;
 import org.jsonschema2pojo.integration.util.CodeGenerationHelper;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.sun.codemodel.JCodeModel;
 
 public class SelfRefIT {
 
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> selfRefsClass;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileEnum() throws ClassNotFoundException {
 
         ClassLoader selfRefsClassLoader = classSchemaRule.generateAndCompile("/schema/ref/selfRefs.json", "com.example");

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/CodeGenerationHelper.java
@@ -17,9 +17,9 @@
 package org.jsonschema2pojo.integration.util;
 
 import static org.apache.commons.io.FileUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.Compiler.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
@@ -246,7 +246,7 @@ public class CodeGenerationHelper {
     }
 
     private static List<File> classpathToFileArray( String classpath ) {
-        List<File> files = new ArrayList();
+        List<File> files = new ArrayList<>();
         
         if (StringUtils.isEmpty(classpath)) return files;
         

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Compiler.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Compiler.java
@@ -17,8 +17,8 @@
 package org.jsonschema2pojo.integration.util;
 
 import static org.apache.commons.io.FileUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/FileSearchMatcher.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/FileSearchMatcher.java
@@ -38,7 +38,7 @@ public class FileSearchMatcher extends BaseMatcher<File> {
      * Create a new matcher with the given search text.
      * 
      * @param searchText
-     *            text that the matched file should contains
+     *            text that the matched file should contain
      */
     public FileSearchMatcher(String searchText) {
         this.searchText = searchText;
@@ -63,11 +63,9 @@ public class FileSearchMatcher extends BaseMatcher<File> {
     }
 
     private boolean isSearchTextPresentInLinesOfFile(File f) {
-        LineIterator it = null;
-        try {
-            it = FileUtils.lineIterator(f, "UTF-8");
+        try (LineIterator it = FileUtils.lineIterator(f, "UTF-8")) {
             while (it.hasNext()) {
-                String line = it.nextLine();
+                String line = it.next();
                 if (line.contains(searchText)) {
                     return true;
                 }
@@ -75,8 +73,6 @@ public class FileSearchMatcher extends BaseMatcher<File> {
             return false;
         } catch (IOException e) {
             throw new RuntimeException(e);
-        } finally {
-            LineIterator.closeQuietly(it);
         }
     }
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/JsonAssert.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/JsonAssert.java
@@ -16,7 +16,7 @@
 
 package org.jsonschema2pojo.integration.util;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.skyscreamer.jsonassert.JSONCompare.*;
 
 import org.json.JSONException;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
@@ -37,9 +37,12 @@ import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * A JUnit rule that executes JsonSchema2Pojo.
@@ -47,7 +50,7 @@ import org.junit.runners.model.Statement;
  * @author Christian Trimble
  *
  */
-public class Jsonschema2PojoRule implements TestRule {
+public class Jsonschema2PojoRule implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
 
     private File generateDir;
     private File compileDir;
@@ -55,6 +58,7 @@ public class Jsonschema2PojoRule implements TestRule {
     private boolean captureDiagnostics = false;
     private boolean sourceDirInitialized = false;
     private boolean classesDirInitialized = false;
+    private boolean isStatic = false;
     private List<Diagnostic<? extends JavaFileObject>> diagnostics;
 
     public Jsonschema2PojoRule captureDiagnostics() {
@@ -89,32 +93,58 @@ public class Jsonschema2PojoRule implements TestRule {
         return diagnostics;
     }
 
-    @Override
-    public Statement apply(final Statement base, final Description description) {
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                active = true;
-                diagnostics = new ArrayList<>();
-                boolean captureDiagnosticsStart = captureDiagnostics;
-                try {
-                    File testRoot = methodNameDir(classNameDir(rootDirectory(), description.getClassName()),
-                            description.getMethodName());
-                    generateDir = new File(testRoot, "generate");
-                    compileDir = new File(testRoot, "compile");
+    private void setUp(String className, String methodName) {
+        active = true;
+        diagnostics = new ArrayList<>();
 
-                    base.evaluate();
-                } finally {
-                    generateDir = null;
-                    compileDir = null;
-                    sourceDirInitialized = false;
-                    classesDirInitialized = false;
-                    captureDiagnostics = captureDiagnosticsStart;
-                    diagnostics = null;
-                    active = false;
-                }
-            }
-        };
+        final File testRoot = methodNameDir(classNameDir(rootDirectory(), className), methodName);
+        generateDir = new File(testRoot, "generate");
+        compileDir = new File(testRoot, "compile");
+    }
+
+    private void cleanUp() {
+        generateDir = null;
+        compileDir = null;
+        sourceDirInitialized = false;
+        classesDirInitialized = false;
+        diagnostics = null;
+        active = false;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        isStatic = true;
+        setUp(context.getRequiredTestClass().getName(), null);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        if (isStatic) {
+            return;
+        }
+
+        final String contextDisplayName = context.getParent().map(ExtensionContext::getDisplayName).orElse(context.getDisplayName());
+        final String displayName = StringUtils.removeEnd(contextDisplayName, "()");
+        String methodName = context.getRequiredTestMethod().getName();
+        if (!StringUtils.equals(displayName, methodName)
+               // displayName may differ from methodName in case of nested test classes, e.g. when using @Nested
+               && !StringUtils.equals(displayName, context.getRequiredTestClass().getSimpleName())) {
+            methodName = methodName + "[" + displayName + "]";
+        }
+        setUp(context.getRequiredTestClass().getName(), methodName);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        if (isStatic) {
+            return;
+        }
+        cleanUp();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        cleanUp();
     }
 
     public File generate(String schema, String targetPackage) {
@@ -182,10 +212,12 @@ public class Jsonschema2PojoRule implements TestRule {
     }
 
     class CapturingDiagnosticListener implements DiagnosticListener<JavaFileObject> {
+
         @Override
         public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
             diagnostics.add(diagnostic);
         }
+
     }
 
     private static List<File> emptyClasspath() {
@@ -225,9 +257,10 @@ public class Jsonschema2PojoRule implements TestRule {
         }
     }
 
-    static File methodNameDir(File baseDir, String methodName) throws IOException {
-        if (methodName == null)
+    static File methodNameDir(File baseDir, String methodName) {
+        if (methodName == null) {
             methodName = "class";
+        }
         Matcher matcher = methodNamePattern.matcher(methodName);
 
         if (matcher.matches()) {
@@ -236,7 +269,7 @@ public class Jsonschema2PojoRule implements TestRule {
             }
             return new File(baseDir, safeDirName(matcher.group(1)));
         } else {
-            throw new IOException("cannot transform methodName (" + methodName + ") into path");
+            throw new IllegalArgumentException("cannot transform methodName (" + methodName + ") into path");
         }
     }
 
@@ -253,7 +286,7 @@ public class Jsonschema2PojoRule implements TestRule {
     }
 
     static String safeDirName(String label) {
-        return label.replaceAll("[^a-zA-Z1-9]+", "_");
+        return label.replaceAll("[^a-zA-Z0-9]+", "_");
     }
 
     static String classNameToPath(String className) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/util/Jsonschema2PojoRule.java
@@ -17,9 +17,9 @@
 package org.jsonschema2pojo.integration.util;
 
 import static org.apache.commons.io.FileUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.Compiler.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -176,7 +176,7 @@ public class Jsonschema2PojoRule implements TestRule {
     }
 
     private void checkActive() {
-        if (active != true) {
+        if (!active) {
             throw new IllegalStateException("cannot access Jsonschema2PojoRule state when inactive");
         }
     }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlPropertiesIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.yaml;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -142,10 +142,10 @@ public class YamlPropertiesIT {
 
         JsonNode jsonified = mapper.valueToTree(instance);
 
-        assertNotNull(generatedType.getDeclaredField("property1"));
-        assertNotNull(generatedType.getDeclaredField("propertyTwo"));
-        assertNotNull(generatedType.getDeclaredField("propertyThreeWithSpace"));
-        assertNotNull(generatedType.getDeclaredField("propertyFour"));
+        assertThat(generatedType.getDeclaredField("property1"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyTwo"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyThreeWithSpace"), is(notNullValue()));
+        assertThat(generatedType.getDeclaredField("propertyFour"), is(notNullValue()));
 
         assertThat(jsonified.has("Property1"), is(true));
         assertThat(jsonified.has("PropertyTwo"), is(true));

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlPropertiesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlPropertiesIT.java
@@ -27,15 +27,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class YamlPropertiesIT {
  
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private final ObjectMapper mapper = new ObjectMapper();
 

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlTypeIT.java
@@ -16,9 +16,9 @@
 
 package org.jsonschema2pojo.integration.yaml;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
-import static org.junit.Assert.*;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlTypeIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/yaml/YamlTypeIT.java
@@ -27,18 +27,18 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class YamlTypeIT {
-    @ClassRule public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
-    @Rule public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @RegisterExtension public static Jsonschema2PojoRule classSchemaRule = new Jsonschema2PojoRule();
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
 
     private static Class<?> classWithManyTypes;
 
-    @BeforeClass
+    @BeforeAll
     public static void generateAndCompileClass() throws ClassNotFoundException {
         classWithManyTypes = classSchemaRule.generateAndCompile("/schema/yaml/type/types.yaml", "com.example", config("sourceType", "yamlschema"))
                 .loadClass("com.example.Types");

--- a/jsonschema2pojo-maven-plugin/pom.xml
+++ b/jsonschema2pojo-maven-plugin/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/jsonschema2pojo-maven-plugin/pom.xml
+++ b/jsonschema2pojo-maven-plugin/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>

--- a/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
+++ b/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
@@ -36,7 +36,6 @@ public class MatchPatternsFileFilterTest {
         basedir = new File("./src/test/resources/filtered/schema");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldIncludeAllIfEmpty() throws IOException {
         fileFilter = new MatchPatternsFileFilter.Builder()
@@ -53,7 +52,6 @@ public class MatchPatternsFileFilterTest {
                         equalTo(file("README.md"))));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldIncludeMatchesAndDirectoriesWhenIncluding() throws IOException {
         fileFilter = new MatchPatternsFileFilter.Builder()
@@ -70,7 +68,6 @@ public class MatchPatternsFileFilterTest {
                         equalTo(file("example.json"))));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldIncludeMatchesAndDirectoriesWhenIncludingAndDefaultExcludes() throws IOException {
         fileFilter = new MatchPatternsFileFilter.Builder()

--- a/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
+++ b/jsonschema2pojo-maven-plugin/src/test/java/org/jsonschema2pojo/maven/MatchPatternsFileFilterTest.java
@@ -23,15 +23,15 @@ import static org.hamcrest.MatcherAssert.*;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MatchPatternsFileFilterTest {
 
     File basedir;
     MatchPatternsFileFilter fileFilter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         basedir = new File("./src/test/resources/filtered/schema");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.5.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
@@ -138,7 +138,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.5.3</version>
                 </plugin>
                 <plugin>
                     <groupId>com.bluetrainsoftware.maven</groupId>
@@ -320,17 +320,6 @@
                 <version>${jackson2x.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-rules</artifactId>
-                <version>1.19.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.android</groupId>
-                <artifactId>android</artifactId>
-                <version>4.1.1.4</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
@@ -402,16 +391,10 @@
                 <version>2.13.0</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.13.2</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -421,8 +404,8 @@
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>2.27.2</version>
+                <artifactId>wiremock-jre8</artifactId>
+                <version>2.35.2</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -467,6 +450,12 @@
                 <artifactId>maven-project</artifactId>
                 <version>2.2.1</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>
@@ -499,8 +488,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>3.12.4</version>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>4.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -513,7 +502,19 @@
                <groupId>org.robolectric</groupId>
                <artifactId>robolectric</artifactId>
                <version>3.8</version>
+               <exclusions>
+                   <exclusion>
+                       <groupId>junit</groupId>
+                       <artifactId>junit</artifactId>
+                   </exclusion>
+               </exclusions>
                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.robolectric</groupId>
+                <artifactId>android-all-instrumented</artifactId>
+                <version>9-robolectric-4913185-2-i1</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.skyscreamer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,12 @@
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -475,8 +481,8 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>3.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Another attempt at migrating to junit5, while attempting to:

* make as little changes as possible
* preserve logic of `Jsonschema2PojoRule` (with respect to generated/compiled output structure) as much as possible  eg.
    `target/jsonschema2pojo/IncludeJsr303AnnotationsIT/_1_true/jsr303AnnotationsValidatedForAdditionalProperties`
    `target/jsonschema2pojo/IncludeJsr303AnnotationsIT/_2_false/jsr303AnnotationsValidatedForAdditionalProperties`