### PR TITLE
Add field type rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 .project
 .metadata
 
+#VSCode files
+.vscode
+jsonschema2pojo-gradle-plugin/bin
+
 # Maven derived files #
 target/
 apidocs

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/IdentityFieldTypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/IdentityFieldTypeRule.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+import org.jsonschema2pojo.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JType;
+
+/**
+ * This implementation instructs the generator to use the schema's type
+ * as the type for the field definition.
+ */
+public class IdentityFieldTypeRule implements Rule<JType, JType> {
+  /**
+   * This implementation returns the schemaType parameter.
+   *
+   * @param nodeName the name of the field
+   * @param node the field's node
+   * @param parent the object contianing the field
+   * @param schemaType the type derived from the field's schema
+   * @param schema the schema for the property.
+   * @return the type that should be used for the field.
+   */
+  @Override
+  public JType apply(String nodeName, JsonNode node, JsonNode parent, JType schemaType, Schema schema) {
+    return schemaType;
+  }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -82,8 +82,10 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         }
 
         Schema propertySchema = ruleFactory.getSchemaStore().create(schema, pathToProperty, ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
-        JType propertyType = ruleFactory.getSchemaRule().apply(nodeName, node, parent, jclass, propertySchema);
-        propertySchema.setJavaTypeIfEmpty(propertyType);
+        JType propertySchemaType = ruleFactory.getSchemaRule().apply(nodeName, node, parent, jclass, propertySchema);
+        propertySchema.setJavaTypeIfEmpty(propertySchemaType);
+
+        JType propertyType = ruleFactory.getFieldTypeRule().apply(nodeName, node, parent, propertySchemaType, propertySchema);
 
         boolean isIncludeGetters = ruleFactory.getGenerationConfig().isIncludeGetters();
         boolean isIncludeSetters = ruleFactory.getGenerationConfig().isIncludeSetters();

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -446,4 +446,14 @@ public class RuleFactory {
         return new JavaNameRule();
     }
 
+    /**
+     * A rule that generates the field type used to represent the type for a schema.  This
+     * is indended to provide a way to inject wrapper types like java.util.Optional.
+     * 
+     * @return the rule used to map schema types to field types.
+     */
+    public Rule<JType, JType> getFieldTypeRule() {
+        return new IdentityFieldTypeRule();
+    }
+
 }

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -196,6 +196,12 @@
             <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson2x.databind.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CompilerWarningIT.java
@@ -39,6 +39,7 @@ import org.hamcrest.Matchers;
 import org.jsonschema2pojo.integration.util.Compiler;
 import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -94,6 +95,7 @@ public class CompilerWarningIT {
   }
 
   @Test
+  @EnabledIfSystemProperty(named = "java.version", matches = "1\\.8\\..*")
   public void checkWarnings() {
     schemaRule.generate(schema, "com.example", config);
     schemaRule.compile(compiler, NullWriter.INSTANCE, new ArrayList<>(), config);

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomFieldTypesIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/CustomFieldTypesIT.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.*;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import org.jsonschema2pojo.rules.Rule;
+import org.apache.tools.ant.util.StreamUtils;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.jsonschema2pojo.rules.RuleFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.sun.codemodel.JType;
+
+/**
+ * This test shows how the FieldTypeRule can be used to alter the
+ * type declaration for fields.
+ */
+public class CustomFieldTypesIT {
+
+    @RegisterExtension
+    public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    public static class NullAsOptionalFieldTypeRule implements Rule<JType, JType> {
+        public NullAsOptionalFieldTypeRule(RuleFactory ruleFactory) {
+            super();
+        }
+
+        @Override
+        public JType apply(String nodeName, JsonNode node, JsonNode parent, JType schemaType, Schema schema) {
+            Optional<JsonNode> possibleTypeNode = Optional.ofNullable(node.get("type"));
+
+            boolean canBeNull = possibleTypeNode
+              .map(typeNode->typeNode.isArray()
+                ? StreamSupport.stream(typeNode.spliterator(), false)
+                  .anyMatch(n->"null".equals(n.asText()))
+                : "null".equals(typeNode.asText())
+            ).orElse(false);
+            
+            if( canBeNull ) {
+              return schemaType.owner()
+                  .ref(Optional.class)
+                  .narrow(schemaType);
+            }
+            return schemaType;
+        }
+    }
+
+    public static class ExtendedRuleFactory extends RuleFactory {
+        private NullAsOptionalFieldTypeRule fieldTypeRule = new NullAsOptionalFieldTypeRule(this);
+
+        @Override
+        public Rule<JType, JType> getFieldTypeRule() {
+            return fieldTypeRule;
+        }
+    }
+
+    @Test
+    public void nullFieldsForOptional() throws Exception {
+        final String filePath = "/schema/type/types.json";
+        ClassLoader resultClassLoader = schemaRule.generateAndCompile(
+            filePath, 
+            "com.example",
+            config(
+            "customRuleFactory", ExtendedRuleFactory.class.getName()
+            )
+        );
+
+        Class<?> rootType = resultClassLoader.loadClass("com.example.Types");
+        assertThat(rootType.getDeclaredField("nullableStringProperty").getType(), typeCompatibleWith(Optional.class));
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new Jdk8Module());
+
+        Object value = mapper.readValue("{\"nullableStringProperty\": null}", rootType);
+
+        @SuppressWarnings("unchecked")
+        Optional<String> nullableString = (Optional<String>)rootType.getDeclaredMethod("getNullableStringProperty").invoke(value);
+        assertThat(nullableString.isPresent(), is(false));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,18 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>define-root</id>
+                        <goals>
+                            <goal>rootlocation</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>
@@ -190,7 +202,7 @@
                     <failIfMissing>true</failIfMissing>
                     <header>NOTICE</header>
                     <headerDefinitions>
-                        <headerDefinition>license-plugin-definition.xml</headerDefinition>
+                        <headerDefinition>${rootlocation}/license-plugin-definition.xml</headerDefinition>
                     </headerDefinitions>
                     <includes>
                         <include>**/src/main/java/**</include>


### PR DESCRIPTION
  This PR introduces a new rule that can change the type of fields created for properties based on the type determined from that property's schema.  This is intended to help wrap fields with types like `java.util.Optional` or `org.openapitools.jackson.nullable.JsonNullable` when creating custom rule sets.

  The default implementation is an identity transform of the schema type and results in no change to the generated code when not using a custom rule factory.