### PR TITLE
Mirror "deprecated" annotations from json schema by including @deprecated in the generated POJO (opt-in behavior)

### DIFF
--- a/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
+++ b/jsonschema2pojo-cli/src/main/java/org/jsonschema2pojo/cli/Arguments.java
@@ -137,6 +137,9 @@ public class Arguments implements GenerationConfig {
     @Parameter(names = { "-305", "--jsr305-annotations" }, description = "Add JSR-305 annotations to generated Java types.")
     private boolean includeJsr305Annotations = false;
 
+    @Parameter(names = { "--deprecated-annotations" }, description = "Add @Deprecated annotations to fields marked as deprecated in JSON Schema.")
+    private boolean includeDeprecatedAnnotations = false;
+
     @Parameter(names = { "-o", "--use-optional-for-getters"}, description = "Use Optional for getters of non-required fields.")
     private boolean useOptionalForGetters = false;
 
@@ -399,6 +402,11 @@ public class Arguments implements GenerationConfig {
     @Override
     public boolean isIncludeJsr305Annotations() {
         return includeJsr305Annotations;
+    }
+
+    @Override
+    public boolean isIncludeDeprecatedAnnotations() {
+        return includeDeprecatedAnnotations;
     }
 
     @Override

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/DefaultGenerationConfig.java
@@ -179,6 +179,14 @@ public class DefaultGenerationConfig implements GenerationConfig {
         return false;
     }
 
+    /**
+     * @return {@code false}
+     */
+    @Override
+    public boolean isIncludeDeprecatedAnnotations() {
+        return false;
+    }
+
     @Override
     public boolean isUseOptionalForGetters() { return false; }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/GenerationConfig.java
@@ -255,6 +255,14 @@ public interface GenerationConfig {
   boolean isIncludeJsr305Annotations();
 
   /**
+   * Gets the 'includeDeprecatedAnnotations' configuration option.
+   *
+   * @return Whether to include {@code @Deprecated} annotations on fields
+   *         that are marked as deprecated in the JSON Schema.
+   */
+  boolean isIncludeDeprecatedAnnotations();
+
+  /**
    * Gets the 'useOptionalForGetters' configuration option.
    *
    * @return Whether to use {@link java.util.Optional} as return type for

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DeprecatedRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/DeprecatedRule.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import org.jsonschema2pojo.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JDocCommentable;
+import com.sun.codemodel.JFieldVar;
+
+/**
+ * Applies the "deprecated" schema rule.
+ *
+ * @see <a
+ *      href="https://json-schema.org/understanding-json-schema/reference/generic.html#deprecated">https://json-schema.org/understanding-json-schema/reference/generic.html#deprecated</a>
+ */
+public class DeprecatedRule implements Rule<JDocCommentable, JDocCommentable> {
+
+    private final RuleFactory ruleFactory;
+
+    protected DeprecatedRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    /**
+     * Applies this schema rule to take the required code generation steps.
+     * <p>
+     * The deprecated rule adds a @Deprecated annotation to fields that are
+     * marked as deprecated in the JSON Schema and also adds a note to the
+     * JavaDoc comment to mark a property as deprecated.
+     *
+     * @param nodeName
+     *            the name of the schema node for which this "deprecated" rule has
+     *            been added
+     * @param node
+     *            the "deprecated" node, having a value <code>true</code> or
+     *            <code>false</code>
+     * @param parent
+     *            the parent node
+     * @param generatableType
+     *            the class or method which may be marked as "deprecated"
+     * @return the JavaDoc comment attached to the generatableType, which
+     *         <em>may</em> have an added note to mark this construct as
+     *         deprecated.
+     */
+    @Override
+    public JDocCommentable apply(String nodeName, JsonNode node, JsonNode parent, JDocCommentable generatableType, Schema schema) {
+
+        if (node.asBoolean()) {
+            generatableType.javadoc().append("\n@deprecated");
+
+            if (ruleFactory.getGenerationConfig().isIncludeDeprecatedAnnotations()
+                    && generatableType instanceof JFieldVar) {
+                ((JFieldVar) generatableType).annotate(Deprecated.class);
+            }
+        }
+
+        return generatableType;
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -187,6 +187,10 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
         } else {
             ruleFactory.getNotRequiredRule().apply(nodeName, node.get("required"), node, generatedJavaConstruct, schema);
         }
+
+        if (node.has("deprecated")) {
+            ruleFactory.getDeprecatedRule().apply(nodeName, node.get("deprecated"), node, generatedJavaConstruct, schema);
+        }
     }
 
     private void formatAnnotation(JFieldVar field, JDefinedClass clazz, JsonNode node) {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -199,6 +199,16 @@ public class RuleFactory {
     }
 
     /**
+     * Provides a rule instance that should be applied when a "deprecated"
+     * declaration is found in the schema.
+     *
+     * @return a schema rule that can handle the "deprecated" declaration.
+     */
+    public Rule<JDocCommentable, JDocCommentable> getDeprecatedRule() {
+        return new DeprecatedRule(this);
+    }
+
+    /**
      * Provides a rule instance that should be applied to a node to find its
      * equivalent Java type. Typically invoked for properties, arrays, etc for
      * which a Java type must be found/generated.

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DeprecatedRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/DeprecatedRuleTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JDocCommentable;
+
+public class DeprecatedRuleTest {
+
+    private static final String TARGET_CLASS_NAME = DeprecatedRuleTest.class.getName() + ".DummyClass";
+
+    private final DeprecatedRule rule = new DeprecatedRule(new RuleFactory());
+
+    @Test
+    public void applyAddsTextWhenDeprecated() throws JClassAlreadyExistsException {
+
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        ObjectMapper mapper = new ObjectMapper();
+        BooleanNode deprecatedNode = mapper.createObjectNode().booleanNode(true);
+
+        JDocCommentable result = rule.apply("fooBar", deprecatedNode, null, jclass, null);
+
+        assertThat(result.javadoc(), sameInstance(jclass.javadoc()));
+        assertThat(result.javadoc().size(), is(1));
+        assertThat((String) result.javadoc().get(0), is("\n@deprecated"));
+
+    }
+
+    @Test
+    public void applySkipsTextWhenNotDeprecated() throws JClassAlreadyExistsException {
+
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        ObjectMapper mapper = new ObjectMapper();
+        BooleanNode deprecatedNode = mapper.createObjectNode().booleanNode(false);
+
+        JDocCommentable result = rule.apply("fooBar", deprecatedNode, null, jclass, null);
+
+        assertThat(result.javadoc(), sameInstance(jclass.javadoc()));
+        assertThat(result.javadoc().size(), is(0));
+    }
+
+}

--- a/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
+++ b/jsonschema2pojo-gradle-plugin/src/main/groovy/org/jsonschema2pojo/gradle/JsonSchemaExtension.groovy
@@ -63,6 +63,7 @@ public class JsonSchemaExtension implements GenerationConfig {
   boolean includeHashcodeAndEquals
   boolean includeJsr303Annotations
   boolean includeJsr305Annotations
+  boolean includeDeprecatedAnnotations
   boolean useOptionalForGetters
   boolean includeToString
   String[] toStringExcludes
@@ -125,6 +126,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     customRuleFactory = RuleFactory.class
     includeJsr303Annotations = false
     includeJsr305Annotations = false
+    includeDeprecatedAnnotations = false
     useOptionalForGetters = false
     sourceType = SourceType.JSONSCHEMA
     outputEncoding = 'UTF-8'
@@ -254,6 +256,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |customRuleFactory = ${customRuleFactory.getName()}
        |includeJsr303Annotations = ${includeJsr303Annotations}
        |includeJsr305Annotations = ${includeJsr305Annotations}
+       |includeDeprecatedAnnotations = ${includeDeprecatedAnnotations}
        |useOptionalForGetters = ${useOptionalForGetters}
        |sourceType = ${sourceType.toString().toLowerCase()}
        |removeOldOutput = ${removeOldOutput}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DeprecatedIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/DeprecatedIT.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.thoughtworks.qdox.JavaProjectBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaField;
+import com.thoughtworks.qdox.model.JavaMethod;
+import com.thoughtworks.qdox.model.JavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaClass;
+
+public class DeprecatedIT {
+
+    @RegisterExtension public static Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    private static JavaClass classWithDeprecated;
+
+    @BeforeAll
+    public static void generateClasses() throws IOException {
+        schemaRule.generateAndCompile("/schema/deprecated/deprecated.json", "com.example");
+        File generatedJavaFile = schemaRule.generated("com/example/Deprecated.java");
+
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
+        javaDocBuilder.addSource(generatedJavaFile);
+
+        classWithDeprecated = javaDocBuilder.getClassByName("com.example.Deprecated");
+    }
+
+    @Test
+    public void deprecatedAppearsInFieldJavadoc() {
+
+        JavaField javaField = classWithDeprecated.getFieldByName("deprecatedProperty");
+        String javaDocComment = javaField.getComment();
+
+        assertThat(javaDocComment, containsString("@deprecated"));
+
+    }
+
+    @Test
+    public void deprecatedAppearsInGetterJavadoc() {
+
+        JavaMethod javaMethod = classWithDeprecated.getMethodBySignature("getDeprecatedProperty", Collections.emptyList());
+        String javaDocComment = javaMethod.getComment();
+
+        assertThat(javaDocComment, containsString("@deprecated"));
+
+    }
+
+    @Test
+    public void deprecatedAppearsInSetterJavadoc() {
+
+        final List<JavaType> parameterTypes = Collections.singletonList(new DefaultJavaClass("java.lang.String"));
+        JavaMethod javaMethod = classWithDeprecated.getMethodBySignature("setDeprecatedProperty", parameterTypes);
+        String javaDocComment = javaMethod.getComment();
+
+        assertThat(javaDocComment, containsString("@deprecated"));
+
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/deprecated/deprecated.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/deprecated/deprecated.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "deprecatedProperty": {
+      "type": "string",
+      "deprecated": true
+    }
+  }
+}
+

--- a/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
+++ b/jsonschema2pojo-maven-plugin/src/main/java/org/jsonschema2pojo/maven/Jsonschema2PojoMojo.java
@@ -346,6 +346,9 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Parameter(property = "jsonschema2pojo.includeJsr305Annotations", defaultValue = "false")
     private boolean includeJsr305Annotations = false;
 
+    @Parameter(property = "jsonschema2pojo.includeDeprecatedAnnotations", defaultValue = "false")
+    private boolean includeDeprecatedAnnotations = false;
+
     /**
      * Whether to use {@link java.util.Optional} as return type for
      * getters of non-required fields.
@@ -992,6 +995,11 @@ public class Jsonschema2PojoMojo extends AbstractMojo implements GenerationConfi
     @Override
     public boolean isIncludeJsr305Annotations() {
         return includeJsr305Annotations;
+    }
+
+    @Override
+    public boolean isIncludeDeprecatedAnnotations() {
+        return includeDeprecatedAnnotations;
     }
 
     @Override


### PR DESCRIPTION
### Summary
This PR addresses [#1563](https://github.com/joelittlejohn/jsonschema2pojo/issues/1563): mirror the JSON Schema deprecated keyword in the generated POJO by adding @deprecated to the JavaDoc and, optionally, a Java @Deprecated annotation on the field.

### Behavior
When a property has "deprecated": true, an @deprecated tag is appended to the JavaDoc of the generated field, getter, and setter.
A new opt-in flag includeDeprecatedAnnotations (default false) additionally adds a @Deprecated annotation to the generated field.
Exposed on GenerationConfig, the CLI (--deprecated-annotations), the Maven mojo, and the Gradle extension.
Fully backward-compatible: with the flag at its default, nothing changes for schemas that don't use deprecated.

### Example
Schema:

{ "type": "object", "properties": { "legacyId": { "type": "string", "deprecated": true } } }
Generated with includeDeprecatedAnnotations = true:


/**
 * @deprecated
 */
@Deprecated
@JsonProperty("legacyId")
private String legacyId;

### Tests
The following new tests are added with this PR:

DeprecatedRuleTest (unit)
DeprecatedIT (integration) — asserts @deprecated JavaDoc on field, getter, and setter.