### PR TITLE
Handle allOf, anyOf, oneOf, and not by repeated merging of properties.

### DIFF
--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -97,6 +97,33 @@
             <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.karneim</groupId>
+            <artifactId>pojobuilder</artifactId>
+            <version>4.3.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- 
+              We can remove this before merge.  Included to make iteration faster.
+            -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>net.karneim</groupId>
+                        <artifactId>pojobuilder</artifactId>
+                        <version>4.3.0</version>
+                    </path>
+                </annotationProcessorPaths>
+                <annotationProcessors>net.karneim.pojobuilder.processor.AnnotationProcessor</annotationProcessors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/transform/SchemaReducer.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/transform/SchemaReducer.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.transform;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.karneim.pojobuilder.GeneratePojoBuilder;
+
+@GeneratePojoBuilder(excludeProperties = "inputSchemas")
+public class SchemaReducer {
+
+  List<MutablePair<URI, ObjectNode>> inputSchemas = new ArrayList<>();
+  BiFunction<Context, Pair<URI, ObjectNode>, ObjectNode> reducer;
+
+  public SchemaReducer add(URI uri, ObjectNode node) {
+    inputSchemas.add(MutablePair.of(uri, node));
+    return this;
+  }
+
+  /**
+   * Applies transform the the input Schemas until 
+   */
+  public List<Pair<Integer, ReductionResult>> approach(
+    BiFunction<Context, Pair<URI, ObjectNode>, ObjectNode> transform,
+    int maxSteps
+  )
+  {
+
+    LinkedList<Pair<Integer, ReductionResult>> results = new LinkedList<>();
+    for( int i = 0; i < maxSteps; i++ ) {
+      ReductionResult result = gatherScatter();
+
+      results.add(Pair.of(i, result));
+
+      if ( result.getErrors().size() > 0 ) {
+        Pair<Pair<URI, ObjectNode>, Throwable> toThrow = result.getErrors().get(0);
+
+        throw new RuntimeException("Error: "+toThrow.getLeft().getLeft(), toThrow.getRight());
+      }
+
+      if ( result.getUpdates() == 0 ) {
+        return results;
+      }
+    }
+
+    return results;
+  }
+
+  public ReductionResult gatherScatter() {
+    // create a context for the cycle
+
+    Context context = new Context();
+
+    // go over the pairs.
+    List<Triple<Pair<URI, ObjectNode>, Boolean, Optional<Throwable>>> results = inputSchemas.stream()
+      // apply the reducer
+      .map(pair->applyReducer(reducer, context, pair))
+      .collect(Collectors.toList());
+    
+    Integer updates = (int)results.stream().filter(e->e.getMiddle()).count();
+    
+    List<Pair<Pair<URI, ObjectNode>, Throwable>> errors = results.stream()
+      .filter(t->t.getRight().isPresent())
+      .map(e->Pair.of(e.getLeft(), e.getRight().get()))
+      .collect(Collectors.toList());
+
+    // scatter the results
+    results.stream()
+      .filter(e->e.getMiddle())
+      .forEach(result->{
+        inputSchemas.stream()
+          .filter(e->e.getLeft().equals(result.getLeft().getLeft()))
+          .findFirst()
+          .ifPresent(
+            e->e.setRight(result.getLeft().getRight())
+          );
+      });
+
+    return new ReductionResultBuilder()
+      .withUpdates(updates)
+      .withErrors(errors)
+      .build();
+  }
+
+  public Triple<Pair<URI, ObjectNode>, Boolean, Optional<Throwable>> applyReducer(BiFunction<Context, Pair<URI, ObjectNode>, ObjectNode> reducer, Context context, Pair<URI, ObjectNode> value) {
+    Optional<ObjectNode> result = Optional.empty();
+    Optional<Throwable> exception = Optional.empty();
+    try {
+      result = Optional.of(reducer.apply(context, value));
+    } catch ( Throwable t ) {
+      exception = Optional.of(t);
+    }
+
+    Boolean changed = result
+      .map(resultValue->!resultValue.equals(value.getRight()))
+      .orElse(false);
+
+    return Triple.of(Pair.of(value.getLeft(), result.orElse(value.getRight())), changed, exception);
+  }
+
+  @GeneratePojoBuilder
+  public static class Context {
+    List<Pair<URI, ObjectNode>> inputSchemas;
+    public Optional<ObjectNode> findByURI(URI uri) throws URISyntaxException {
+      URI documentUri = new URI(
+        uri.getScheme(),
+        uri.getUserInfo(),
+        uri.getHost(),
+        uri.getPort(),
+        uri.getPath(),
+        null,
+        null);
+      
+      return inputSchemas.stream()
+        .filter(p->p.getLeft().equals(documentUri))
+        .findFirst()
+        .map(Pair::getRight);
+    }
+    public List<Pair<URI, ObjectNode>> getInputSchemas() {
+      return inputSchemas;
+    }
+    void setInputSchemas(List<Pair<URI, ObjectNode>> inputSchemas) {
+      this.inputSchemas = inputSchemas;
+    }
+  }
+
+  @GeneratePojoBuilder
+  public static class ReductionResult {
+    Integer updates;
+    List<Pair<Pair<URI, ObjectNode>, Throwable>> errors;
+    public Integer getUpdates() {
+      return updates;
+    }
+    public List<Pair<Pair<URI, ObjectNode>, Throwable>> getErrors() {
+      return errors;
+    }
+  }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/transform/SchemaReducerTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/transform/SchemaReducerTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.transform;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doNothing;
+
+import java.net.URI;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jsonschema2pojo.transform.SchemaReducer.Context;
+import org.jsonschema2pojo.transform.SchemaReducer.ReductionResult;
+
+
+public class SchemaReducerTest {
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void firstTest() throws JsonMappingException, JsonProcessingException {
+    SchemaReducer reducer = new SchemaReducerBuilder()
+      .withReducer(this::transform)
+      .build()
+      .add(
+        URI.create("http://example.com/schema"),
+        createObject(node->{
+          ObjectNode properties = node
+            .put("type", "object")
+            .putObject("properties");
+          
+          properties.putObject("first")
+            .put("type", "string");
+
+          ArrayNode allOf = node.putArray("allOf");
+          allOf.addObject()
+            .put("type", "object")
+            .putObject("properties")
+            .putObject("second")
+            .put("type", "string");
+          
+          allOf.addObject()
+            .put("type", "object")
+            .putObject("properties")
+            .putObject("third")
+            .put("type", "string");
+        })
+      );
+
+    List<Pair<Integer, ReductionResult>> results = reducer
+        .approach(this::transform, 5);
+
+    assertThat(results.size(), equalTo(2));
+
+    ObjectNode finalState = reducer.inputSchemas.get(0).getRight();
+    ObjectNode finalStateProperties = (ObjectNode)finalState.get("properties");
+    assertThat(finalStateProperties, hasProperty("first"));
+    assertThat(finalStateProperties, hasProperty("second"));
+    assertThat(finalStateProperties, hasProperty("third"));
+  }
+
+  public ObjectNode transform( Context context, Pair<URI, ObjectNode> node ) {
+    ObjectNode output = (ObjectNode)node.getRight().deepCopy();
+
+    Optional<JsonNode> type = output.get("type").asOptional();
+    Optional<ArrayNode> possibleAllOf = output.get("allOf").asOptional().map(ArrayNode.class::cast);
+
+    Function<ObjectNode, Stream<ObjectNode>> streamProperties = 
+      schema->schema
+        .get("properties")
+        .asOptional()
+        .map(Stream::of)
+        .orElseGet(Stream::empty)
+        .map(ObjectNode.class::cast);
+
+    Predicate<JsonNode> isNotEmpty = n->!n.isEmpty();
+    
+    List<ObjectNode> allOfProperties = possibleAllOf
+      .filter(JsonNode::isArray)
+      .map(JsonNode::valueStream)
+      .orElse(Stream.empty())
+      .map(ObjectNode.class::cast)
+      .flatMap(streamProperties)
+      .filter(isNotEmpty)
+      .collect(Collectors.toList());
+
+    if( !allOfProperties.isEmpty() ) {
+      ObjectNode outputProperties = output.has("properties") ? (ObjectNode)output.get("properties") : output.putObject("properties");
+      
+      allOfProperties.stream()
+        .map(JsonNode::properties)
+        .flatMap(Set::stream)
+        .forEach(entry->{
+          if( outputProperties.has(entry.getKey()) ) {
+            JsonNode outputProperty = outputProperties.get(entry.getKey());
+            // TODO: merge rule goes here.
+          } else {
+            outputProperties.set(entry.getKey(), entry.getValue().deepCopy());
+          }
+        });
+    }
+    return output;
+  }
+
+  public ObjectNode createObject(Consumer<ObjectNode> addProperties) {
+    ObjectNode node = mapper.createObjectNode();
+    addProperties.accept(node);
+    return node;
+  }
+  public ArrayNode createArray(Consumer<ArrayNode> addItems) {
+    ArrayNode node = mapper.createArrayNode();
+    addItems.accept(node);
+    return node;
+  }
+
+  public ObjectNode createStringSchema(Consumer<ObjectNode> addProperties) {
+    return createObject(props->{
+      props.put("type", "string");
+      addProperties.accept(props);
+    });
+  }
+
+  public <T> Consumer<T> noChanges() {
+    return (t)->{};
+  }
+
+  public static Matcher<ObjectNode> hasProperty(String name) {
+    return new TypeSafeMatcher<ObjectNode>() {
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("obejct did not have "+name);
+      }
+
+      @Override
+      protected boolean matchesSafely(ObjectNode item) {
+        return item.has(name);
+      }
+
+    };
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
         <gradle.version>5.6</gradle.version>
         <gson.version>2.11.0</gson.version>
         <moshi.version>1.12.0</moshi.version>
-        <jackson2x.version>2.17.2</jackson2x.version>
-        <jackson2x.databind.version>2.17.2</jackson2x.databind.version>
+        <jackson2x.version>2.20.0</jackson2x.version>
+        <jackson2x.databind.version>2.20.0</jackson2x.databind.version>
         <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
     </properties>
 


### PR DESCRIPTION
This PR shows how we could scatter properties from keywords like `allOf` into the containing schema.  The algorithm will work in parallel and will handle cyclic references that may exist in the schemas.  The idea is to place something like this between the schema store and the existing rules, converting these keywords into schemas with all of their properties expanded.

The current implementation contains a `maxSteps` property, but we could convert this into a `maxSeconds`, if we want to bound the algorithm by time as opposed to complexity of the schemas.