### PR TITLE
Dependency improvements to prepare for Java 11/17/21 support

### DIFF
--- a/jsonschema2pojo-cli/pom.xml
+++ b/jsonschema2pojo-cli/pom.xml
@@ -31,9 +31,9 @@
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>
-                    <!-- 
-                        Fixes filtering in files that contain single '@' characters (e.g. .bat files 
-                        containing @echo off) by removing the '@' character as a delimiter   
+                    <!--
+                        Fixes filtering in files that contain single '@' characters (e.g. .bat files
+                        containing @echo off) by removing the '@' character as a delimiter
                     -->
                     <useDefaultDelimiters>false</useDefaultDelimiters>
                     <delimiters>
@@ -114,14 +114,17 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -70,18 +70,22 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -88,6 +88,20 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Enforcer RequireUpperBoundDeps failed due to the Moshi dependency -->
+            <!-- Need to specify the exact Kotlin version to use -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>1.4.31</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
         <gradle.version>5.6</gradle.version>
         <gson.version>2.11.0</gson.version>
         <moshi.version>1.12.0</moshi.version>
-        <jackson2x.version>2.17.2</jackson2x.version>
-        <jackson2x.databind.version>2.17.2</jackson2x.databind.version>
+        <jackson.version>2.17.2</jackson.version>
+        <!--
+            Version 3.25.0 is the last version supporting Java 8.
+            Starting at 3.26.0, the Eclipse Compiler is looking for MODULE_SOURCE_PATH (Part of Jigsaw).
+        -->
+        <ecj.version>3.25.0</ecj.version>
+        <mockito.version>4.11.0</mockito.version>
         <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
     </properties>
 
@@ -222,9 +228,13 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireJavaVersion>
+                                    <version>[${java.version},)</version>
+                                </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.3</version>
                                 </requireMavenVersion>
+                                <requireUpperBoundDeps/>
                             </rules>
                         </configuration>
                     </execution>
@@ -269,8 +279,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <compilerArgs>
                         <arg>-Xlint</arg>
                     </compilerArgs>
@@ -385,7 +395,6 @@
                 </dependencies>
             </dependencyManagement>
         </profile>
-
     </profiles>
 
     <dependencies>
@@ -401,19 +410,44 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.13.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-bom</artifactId>
+                <version>3.0.22</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-parent</artifactId>
+                <version>1.17.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
                 <version>1.82</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson2x.databind.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson2x.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -480,12 +514,6 @@
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
                 <version>2.13.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>5.13.2</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -556,7 +584,7 @@
             <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>3.42.0</version>
+                <version>${ecj.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -575,12 +603,6 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
                 <version>4.0.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>4.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR was extracted from work done by @juherr on #1599.  It does the following:

1. Moves some dependencies to BOM files.
2. Marks junit dependencies as test dependencies, since this is no longer happening in depenency management.
3. Improves enforcer support.
4. Adds variables to help in managing the java version.