### PR TITLE
Handle null when generating from array example

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaGenerator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaGenerator.java
@@ -130,8 +130,8 @@ public class SchemaGenerator {
                 } else if (targetValue.isArray() && updateValue.isArray()) {
                     // Both values are arrays: concatenate them to be merged later
                     ((ArrayNode) targetValue).addAll((ArrayNode) updateValue);
-                } else {
-                    // Values have different types: use the one from the update node
+                } else if (!updateValue.isNull()) {
+                    // Values have different types and new value is not null: use the one from the update node
                     targetNode.set(fieldName, updateValue);
                 }
             }

--- a/jsonschema2pojo-core/src/test/resources/schema/array-null-field.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/array-null-field.json
@@ -1,0 +1,7 @@
+[
+    {"myfield": {"subfield1": "test"}},
+    {},
+    {"myfield": null},
+    {"myfield": {"subfield2": "test"}},
+    {"myfield": null}
+]


### PR DESCRIPTION
When schema is generated from an existing JSON array, null values are used to override existing field. If the item of the json array contains null field, generated field model use Object type. If json array contains null field for a given field, any previously discovered schema is lost.

This fix modifies mergeObjectNodes to ignore any null field when updating field schema. It allows to correctly merge all example schemas from array, and get rid of erroneous Object fallback when last example use a null value.

Example:

```json
[
{"field": {"subfield": "test"}},
{"field": null}
]
```

Before:

```java
class Type {
private Object field;
}
```

After:

```java
class Type {
private Field field;
}

class Field {
private String subfield;
}
```