### PR TITLE
Migrate publishing from legacy OSSRH to Maven Central Portal

### DIFF
--- a/jsonschema2pojo-integration-tests/pom.xml
+++ b/jsonschema2pojo-integration-tests/pom.xml
@@ -53,20 +53,6 @@
         </plugins>
     </build>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Enforcer RequireUpperBoundDeps failed due to the Moshi dependency -->
-            <!-- Need to specify the exact Kotlin version to use -->
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>1.4.31</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jsonschema2pojo-jdk-annotation/pom.xml
+++ b/jsonschema2pojo-jdk-annotation/pom.xml
@@ -2,15 +2,27 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
-
     <groupId>org.jsonschema2pojo</groupId>
     <artifactId>jsonschema2pojo-jdk-annotation</artifactId>
     <version>0.0.2-SNAPSHOT</version>
+
+    <name>jsonschema2pojo-jdk-annotation</name>
+    <description>Library to easily acquire the JDK 8-compatible javax.annotation.Generated annotation, for cases when javax.annotation-api cannot be used</description>
+    <url>https://github.com/joelittlejohn/jsonschema2pojo</url>
+
+    <developers>
+        <developer>
+            <name>Joe Littlejohn</name>
+            <email>joe.littlejohn@gmail.com</email>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
 
     <scm>
         <url>https://github.com/joelittlejohn/jsonschema2pojo</url>
@@ -18,7 +30,28 @@
         <developerConnection>scm:git:git@github.com:joelittlejohn/jsonschema2pojo.git</developerConnection>
     </scm>
 
-    <name>jsonschema2pojo-jdk-annotation</name>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/jsonschema2pojo-upload-release
+++ b/jsonschema2pojo-upload-release
@@ -4,15 +4,11 @@
 #
 # To create a new release:
 #
-# 1. Maven release command:
+# 1. Maven release command (publishes directly to Maven Central Portal):
 #     export GPG_TTY=$(tty)
 #     ./mvnw clean release:clean release:prepare release:perform -DautoVersionSubmodules
 #
-# 2. Close and Release snapshots repo at oss.sonatype.org
-#
-# 3. Wait at least 2hrs for synchronization to central
-#
-# 4. Run this script to publish new release to github
+# 2. Run this script to publish new release to github
 #
 set -e
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,6 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
-
     <groupId>org.jsonschema2pojo</groupId>
     <artifactId>jsonschema2pojo</artifactId>
     <version>1.2.3-SNAPSHOT</version>
@@ -16,6 +10,13 @@
     <name>jsonschema2pojo</name>
     <description>Generate DTO style Java classes from JSON Schema documents</description>
     <url>https://github.com/joelittlejohn/jsonschema2pojo</url>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <modules>
         <module>jsonschema2pojo-cli</module>
@@ -142,6 +143,11 @@
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.9.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
@@ -290,12 +296,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>false</autoPublish>
+                    <waitUntil>validated</waitUntil>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
-            <id>release-sign-artifacts</id>
+            <id>release</id>
             <activation>
                 <property>
                     <name>performRelease</name>
@@ -316,13 +332,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
@@ -361,7 +370,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.13.2</version>
+                <version>5.13.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -405,6 +414,16 @@
                 <groupId>com.squareup.moshi</groupId>
                 <artifactId>moshi</artifactId>
                 <version>${moshi.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-reflect</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-jdk8</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.code.javaparser</groupId>
@@ -492,7 +511,7 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>2.2.1</version>
+                <version>3.9.11</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
A few steps involved here, which are hard to verify until we need to do a full release:

- Remove oss-parent:9 inheritance
- Add central-publishing-maven-plugin for direct Central Portal publishing
- Add distributionManagement for snapshot repository
- Consolidate release profiles (merge release-sign-artifacts into release)
- Update release script to remove manual OSSRH steps
- Fix dependency version conflicts:
  - JUnit BOM: 5.13.2 → 5.13.4 (match mockito requirement)
  - maven-shared-utils: 3.3.4 → 3.4.2 (match maven-core)
  - maven-plugin-api: 2.2.1 → 3.9.11 (match maven-core)