### PR TITLE
Add plexus-utils dependency, as this is no longer provided in Maven 3.9

### DIFF
--- a/jsonschema2pojo-maven-plugin/pom.xml
+++ b/jsonschema2pojo-maven-plugin/pom.xml
@@ -52,6 +52,14 @@
             <artifactId>maven-shared-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,16 @@
                 <version>3.4.2</version>
             </dependency>
             <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-xml</artifactId>
+                <version>4.1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
                 <version>${ecj.version}</version>


### PR DESCRIPTION
We use the DirectoryScanner from plexus-utils. This was previously provided by Maven into the classpath for all plugins, but has now been removed.

See also:
* https://maven.apache.org/docs/3.9.0/release-notes.html#potentially-breaking-core-changes-if-migrating-from-3-8-x
* https://issues.apache.org/jira/browse/MNG-6965