### PR TITLE
Support type-use annotations for array item validation (List<@Valid T>)

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/model/JAnnotatedClass.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/model/JAnnotatedClass.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.model;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JFormatter;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JPrimitiveType;
+import com.sun.codemodel.JTypeVar;
+
+/**
+ * Represents a type with type-use annotations (Java 8+, JSR 308).
+ * <p>
+ * This class wraps a {@link JClass} and adds type-use annotations that are rendered
+ * directly before the type name. This enables generating code like:
+ * <pre>
+ * List&lt;@Valid Item&gt;
+ * Map&lt;String, @Nullable Object&gt;
+ * </pre>
+ * <p>
+ * <b>Type-use annotations vs declaration annotations:</b>
+ * <ul>
+ * <li>{@link com.sun.codemodel.JAnnotatable#annotate(Class)} adds annotations to <em>declarations</em> (the field,
+ * method, or class itself). Example: {@code @NotNull private List<String> items;}</li>
+ * <li>{@link JAnnotatedClass#annotated(Class)} creates a new <em>type</em> with embedded annotations.
+ * Example: {@code private List<@NotNull String> items;}</li>
+ * </ul>
+ * The implementation of this feature relies on reflection and hooking into the JAnnotationUse to access a
+ * package-private constructor. This helps us to avoid a breaking change and forking codemodel, but may be a fragile
+ * approach.
+ */
+public class JAnnotatedClass extends JClass {
+
+    private final JClass basis;
+    private final List<JAnnotationUse> annotations;
+
+    /**
+     * Creates a new annotated class wrapper for the given type.
+     *
+     * @param basis
+     *        The class to annotate. May not be <code>null</code>.
+     * @return A new JAnnotatedClass wrapping the basis type.
+     */
+    public static JAnnotatedClass of(JClass basis) {
+        if (basis == null) throw new IllegalArgumentException("basis for annotated class cannot be null");
+        return new JAnnotatedClass(basis, Collections.emptyList());
+    }
+
+    private JAnnotatedClass(JClass basis, List<JAnnotationUse> annotations) {
+        super(basis.owner());
+        this.basis = basis;
+        this.annotations = new ArrayList<>(annotations);
+    }
+
+    /**
+     * Creates a JAnnotationUse instance using reflection (since the constructor is package-private).
+     */
+    private static JAnnotationUse createAnnotationUse(JClass annotationClass) {
+        try {
+            Constructor<JAnnotationUse> c = JAnnotationUse.class.getDeclaredConstructor(JClass.class);
+            c.setAccessible(true);
+            return c.newInstance(annotationClass);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | InstantiationException e) {
+            throw new RuntimeException("Failed to create JAnnotationUse", e);
+        }
+    }
+
+    /**
+     * @return The underlying class without annotations.
+     */
+    public JClass basis() {
+        return basis;
+    }
+
+    /**
+     * @return An unmodifiable list of annotations on this type.
+     */
+    public List<JAnnotationUse> annotations() {
+        return Collections.unmodifiableList(annotations);
+    }
+
+    /**
+     * Returns a new JAnnotatedClass with the given annotation added.
+     *
+     * @param clazz the annotation class to add
+     * @return a new JAnnotatedClass with the annotation applied
+     */
+    public JAnnotatedClass annotated(Class<? extends Annotation> clazz) {
+        return annotated(owner().ref(clazz));
+    }
+
+    /**
+     * Returns a new JAnnotatedClass with the given annotation added.
+     *
+     * @param clazz the annotation class reference to add
+     * @return a new JAnnotatedClass with the annotation applied
+     */
+    public JAnnotatedClass annotated(JClass clazz) {
+        List<JAnnotationUse> newAnnotations = new ArrayList<>(annotations);
+        newAnnotations.add(createAnnotationUse(clazz));
+        return new JAnnotatedClass(basis, newAnnotations);
+    }
+
+    @Override
+    public String name() {
+        return basis.name();
+    }
+
+    @Override
+    public String fullName() {
+        return basis.fullName();
+    }
+
+    @Override
+    public String binaryName() {
+        return basis.binaryName();
+    }
+
+    @Override
+    public JPackage _package() {
+        return basis._package();
+    }
+
+    @Override
+    public JClass _extends() {
+        return basis._extends();
+    }
+
+    @Override
+    public Iterator<JClass> _implements() {
+        return basis._implements();
+    }
+
+    @Override
+    public boolean isInterface() {
+        return basis.isInterface();
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return basis.isAbstract();
+    }
+
+    @Override
+    public boolean isArray() {
+        return basis.isArray();
+    }
+
+    @Override
+    public JPrimitiveType getPrimitiveType() {
+        return basis.getPrimitiveType();
+    }
+
+    @Override
+    public JClass erasure() {
+        return basis.erasure();
+    }
+
+    @Override
+    public List<JClass> getTypeParameters() {
+        return basis.getTypeParameters();
+    }
+
+    @Override
+    public JTypeVar[] typeParams() {
+        return basis.typeParams();
+    }
+
+    @Override
+    public JClass outer() {
+        return basis.outer();
+    }
+
+    @Override
+    protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
+        JClass newBasis;
+        try {
+            Method m = JClass.class.getDeclaredMethod("substituteParams", JTypeVar[].class, List.class);
+            m.setAccessible(true);
+            newBasis = (JClass) m.invoke(basis, variables, bindings);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (newBasis == basis) {
+            return this;
+        }
+        return new JAnnotatedClass(newBasis, annotations);
+    }
+
+    @Override
+    public void generate(JFormatter f) {
+        for (JAnnotationUse annotation : annotations) {
+            f.g(annotation).p(' ');
+        }
+        f.t(basis);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || !getClass().equals(obj.getClass())) {
+            return false;
+        }
+        JAnnotatedClass that = (JAnnotatedClass) obj;
+        return basis.equals(that.basis) && annotations.equals(that.annotations);
+    }
+
+    @Override
+    public int hashCode() {
+        return basis.hashCode() * 37 + annotations.hashCode();
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
@@ -19,32 +19,65 @@ package org.jsonschema2pojo.rules;
 import java.lang.annotation.Annotation;
 
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.model.JAnnotatedClass;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JClass;
 import com.sun.codemodel.JFieldVar;
 
 import jakarta.validation.Valid;
 
+/**
+ * Applies the {@code @Valid} annotation to fields that require cascading validation.
+ * <p>
+ * For object fields, the annotation is placed on the field declaration.
+ * For array/collection fields, the annotation is placed on the item type parameter
+ * (e.g., {@code List<@Valid Item>}) to ensure proper cascading validation of elements.
+ */
 public class ValidRule implements Rule<JFieldVar, JFieldVar> {
-    
+
     private final RuleFactory ruleFactory;
-    
+
     public ValidRule(RuleFactory ruleFactory) {
         this.ruleFactory = ruleFactory;
     }
 
+    /**
+     * Applies the {@code @Valid} annotation to the given field if JSR-303 annotations are enabled.
+     *
+     * @param nodeName the name of the JSON property
+     * @param node the JSON schema node
+     * @param parent the parent JSON schema node
+     * @param field the field to annotate
+     * @param currentSchema the current schema being processed
+     * @return the field, potentially with {@code @Valid} annotation added
+     */
     @Override
     public JFieldVar apply(String nodeName, JsonNode node, JsonNode parent, JFieldVar field, Schema currentSchema) {
-        
+
         if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
-            final Class<? extends Annotation> validClass
-                    = ruleFactory.getGenerationConfig().isUseJakartaValidation()
-                    ? Valid.class
-                    : javax.validation.Valid.class;
-            field.annotate(validClass);
+            if (!isArray(node)) {
+                field.annotate(getValidClass());
+            } else {
+                // For arrays, the @Valid annotation is placed on the item type (e.g., List<@Valid Item>)
+                JClass existingArrayType = (JClass) field.type();
+                JClass existingItemType = existingArrayType.getTypeParameters().get(0);
+                JClass annotatedItemType = JAnnotatedClass.of(existingItemType).annotated(getValidClass());
+                field.type(existingArrayType.erasure().narrow(annotatedItemType));
+            }
         }
-        
+
         return field;
     }
-    
+
+    private Class<? extends Annotation> getValidClass() {
+        return ruleFactory.getGenerationConfig().isUseJakartaValidation()
+                ? Valid.class
+                : javax.validation.Valid.class;
+    }
+
+    private boolean isArray(JsonNode node) {
+        return node != null && node.path("type").asText().equals("array");
+    }
+
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/model/JAnnotatedClassTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/model/JAnnotatedClassTest.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JFormatter;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JMod;
+
+/**
+ * Unit tests for {@link JAnnotatedClass} - type-use annotation support.
+ */
+public final class JAnnotatedClassTest {
+
+    /**
+     * Helper method to generate code from a JClass using JFormatter.
+     */
+    private String generate(JClass type) {
+        StringWriter sw = new StringWriter();
+        JFormatter f = new JFormatter(sw);
+        type.generate(f);
+        return sw.toString();
+    }
+
+    /**
+     * Test basic type-use annotation: {@code @Deprecated String}
+     */
+    @Test
+    public void testSimpleTypeAnnotation() {
+        JCodeModel cm = new JCodeModel();
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+
+        assertThat(annotatedString.name(), is("String"));
+        assertThat(annotatedString.fullName(), is("java.lang.String"));
+        assertThat(annotatedString.annotations().size(), is(1));
+
+        String generated = generate(annotatedString);
+        assertThat(generated, is("@java.lang.Deprecated java.lang.String"));
+    }
+
+    /**
+     * Test type-use annotation on generic type parameter:
+     * {@code java.util.List<@java.lang.Deprecated java.lang.String>}
+     */
+    @Test
+    public void testAnnotatedTypeParameter() {
+        JCodeModel cm = new JCodeModel();
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+        JClass listOfAnnotatedString = cm.ref(List.class).narrow(annotatedString);
+
+        String generated = generate(listOfAnnotatedString);
+        assertThat(generated, is("java.util.List<@java.lang.Deprecated java.lang.String>"));
+    }
+
+    /**
+     * Test multiple type-use annotations: {@code @Deprecated @Override String}
+     */
+    @Test
+    public void testMultipleTypeAnnotations() {
+        JCodeModel cm = new JCodeModel();
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass)
+                .annotated(Deprecated.class)
+                .annotated(Override.class);
+
+        assertThat(annotatedString.annotations().size(), is(2));
+
+        String generated = generate(annotatedString);
+        assertThat(generated, is("@java.lang.Deprecated @java.lang.Override java.lang.String"));
+    }
+
+    /**
+     * Test annotated type with initializer.
+     */
+    @Test
+    public void testAnnotatedFieldWithInitializer() throws JClassAlreadyExistsException {
+        JCodeModel cm = new JCodeModel();
+        JDefinedClass testClass = cm._class("com.example.Test");
+
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+        JClass listType = cm.ref(List.class).narrow(annotatedString);
+        JClass arrayListType = cm.ref(ArrayList.class).narrow(annotatedString);
+
+        testClass.field(JMod.PRIVATE, listType, "items", JExpr._new(arrayListType));
+
+        StringWriter sw = new StringWriter();
+        testClass.declare(new JFormatter(sw));
+        String classOutput = sw.toString();
+
+        assertThat(classOutput, containsString("java.util.List<@java.lang.Deprecated java.lang.String>"));
+    }
+
+    /**
+     * Test that erasure returns the underlying class without annotations.
+     */
+    @Test
+    public void testErasure() {
+        JCodeModel cm = new JCodeModel();
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+
+        assertThat(annotatedString.erasure(), is(stringClass));
+    }
+
+    /**
+     * Test that basis() returns the wrapped class.
+     */
+    @Test
+    public void testBasis() {
+        JCodeModel cm = new JCodeModel();
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+
+        assertThat(annotatedString.basis(), is(stringClass));
+    }
+
+    /**
+     * Test annotating an already narrowed class.
+     */
+    @Test
+    public void testAnnotateNarrowedClass() {
+        JCodeModel cm = new JCodeModel();
+
+        // Create List<String>
+        JClass listOfString = cm.ref(List.class).narrow(String.class);
+
+        // Annotate the whole List<String> type
+        JAnnotatedClass annotatedListOfString = JAnnotatedClass.of(listOfString).annotated(Deprecated.class);
+
+        String generated = generate(annotatedListOfString);
+        assertThat(generated, is("@java.lang.Deprecated java.util.List<java.lang.String>"));
+    }
+
+    /**
+     * Test complex nested annotations: {@code Map<@A String, List<@B Integer>>}
+     */
+    @Test
+    public void testNestedAnnotatedTypes() {
+        JCodeModel cm = new JCodeModel();
+
+        // @Deprecated String
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(cm.ref(String.class)).annotated(Deprecated.class);
+
+        // @Override Integer
+        JAnnotatedClass annotatedInteger = JAnnotatedClass.of(cm.ref(Integer.class)).annotated(Override.class);
+
+        // List<@Override Integer>
+        JClass listOfAnnotatedInteger = cm.ref(List.class).narrow(annotatedInteger);
+
+        // Map<@Deprecated String, List<@Override Integer>>
+        JClass mapType = cm.ref(Map.class).narrow(annotatedString, listOfAnnotatedInteger);
+
+        String generated = generate(mapType);
+        assertThat(generated, is("java.util.Map<@java.lang.Deprecated java.lang.String, java.util.List<@java.lang.Override java.lang.Integer>>"));
+    }
+
+    /**
+     * Test that the annotated class works correctly in method parameters.
+     */
+    @Test
+    public void testAnnotatedMethodParameter() throws JClassAlreadyExistsException {
+        JCodeModel cm = new JCodeModel();
+        JDefinedClass testClass = cm._class("com.example.Test");
+
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+        JClass listType = cm.ref(List.class).narrow(annotatedString);
+
+        JMethod method = testClass.method(JMod.PUBLIC, cm.VOID, "process");
+        method.param(listType, "items");
+
+        StringWriter sw = new StringWriter();
+        testClass.declare(new JFormatter(sw));
+        String classOutput = sw.toString();
+
+        assertThat(classOutput, containsString("java.util.List<@java.lang.Deprecated java.lang.String> items"));
+    }
+
+    /**
+     * Test that the annotated class works correctly as method return type.
+     */
+    @Test
+    public void testAnnotatedReturnType() throws JClassAlreadyExistsException {
+        JCodeModel cm = new JCodeModel();
+        JDefinedClass testClass = cm._class("com.example.Test");
+
+        JClass stringClass = cm.ref(String.class);
+        JAnnotatedClass annotatedString = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+        JClass listType = cm.ref(List.class).narrow(annotatedString);
+
+        JMethod method = testClass.method(JMod.PUBLIC, listType, "getItems");
+        method.body()._return(JExpr._null());
+
+        StringWriter sw = new StringWriter();
+        testClass.declare(new JFormatter(sw));
+        String classOutput = sw.toString();
+
+        assertThat(classOutput, containsString("java.util.List<@java.lang.Deprecated java.lang.String> getItems()"));
+    }
+
+    /**
+     * Test equals and hashCode - two annotated classes with same basis and annotations should be
+     * equal.
+     */
+    @Test
+    public void testEqualsAndHashCode() {
+        JCodeModel cm = new JCodeModel();
+        JClass stringClass = cm.ref(String.class);
+
+        JAnnotatedClass annotated1 = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+        JAnnotatedClass annotated2 = JAnnotatedClass.of(stringClass).annotated(Deprecated.class);
+        JAnnotatedClass annotated3 = JAnnotatedClass.of(stringClass).annotated(Override.class);
+
+        // Same basis and same annotation class should produce equivalent results
+        assertThat(annotated1.basis(), is(annotated2.basis()));
+        assertThat(annotated1.annotations().size(), is(annotated2.annotations().size()));
+
+        // Different annotations should not be equal
+        assertThat(annotated1, not(equalTo(annotated3)));
+    }
+
+    /**
+     * Test annotated array type: {@code @Deprecated String[]}
+     */
+    @Test
+    public void testAnnotatedArrayType() {
+        JCodeModel cm = new JCodeModel();
+
+        // @Deprecated String[]
+        JClass stringArray = cm.ref(String.class).array();
+        JAnnotatedClass annotatedArray = JAnnotatedClass.of(stringArray).annotated(Deprecated.class);
+
+        String generated = generate(annotatedArray);
+        assertThat(generated, is("@java.lang.Deprecated java.lang.String[]"));
+    }
+
+    /**
+     * Test annotated primitive array type: {@code @Deprecated int[]}
+     */
+    @Test
+    public void testAnnotatedPrimitiveArrayType() {
+        JCodeModel cm = new JCodeModel();
+
+        // @Deprecated int[]
+        JClass intArray = cm.INT.array();
+        JAnnotatedClass annotatedIntArray = JAnnotatedClass.of(intArray).annotated(Deprecated.class);
+
+        String generated = generate(annotatedIntArray);
+        assertThat(generated, is("@java.lang.Deprecated int[]"));
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/config/IncludeJsr303AnnotationsIT.java
@@ -370,6 +370,42 @@ public class IncludeJsr303AnnotationsIT {
     }
 
     @Test
+    public void jsr303ValidAnnotationIsOnItemTypeNotField() throws ClassNotFoundException, NoSuchFieldException {
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/validArray.json", "com.example",
+                config("includeJsr303Annotations", true, "useJakartaValidation", useJakartaValidation));
+
+        final String validationPackage = useJakartaValidation ? "jakarta.validation" : "javax.validation";
+        Class<?> validArrayType = resultsClassLoader.loadClass("com.example.ValidArray");
+        java.lang.reflect.Field objectArrayField = validArrayType.getDeclaredField("objectarray");
+
+        // The @Valid annotation should be on the item type (e.g., List<@Valid Item>), not on the field
+        if (useJakartaValidation) {
+            assertThat("@Valid should not be on the field, but on the item type",
+                    objectArrayField.getAnnotation(jakarta.validation.Valid.class), is(nullValue()));
+        } else {
+            assertThat("@Valid should not be on the field, but on the item type",
+                    objectArrayField.getAnnotation(javax.validation.Valid.class), is(nullValue()));
+        }
+
+        // Verify the @Valid annotation IS present on the type parameter (item type)
+        java.lang.reflect.AnnotatedType annotatedType = objectArrayField.getAnnotatedType();
+        assertThat("Field type should be an AnnotatedParameterizedType",
+                annotatedType, is(instanceOf(java.lang.reflect.AnnotatedParameterizedType.class)));
+
+        java.lang.reflect.AnnotatedParameterizedType parameterizedType =
+                (java.lang.reflect.AnnotatedParameterizedType) annotatedType;
+        java.lang.reflect.AnnotatedType[] typeArguments = parameterizedType.getAnnotatedActualTypeArguments();
+
+        assertThat("Should have one type argument", typeArguments.length, is(1));
+
+        // Check that the type argument (item type) has exactly one annotation: @Valid
+        java.lang.annotation.Annotation[] itemTypeAnnotations = typeArguments[0].getAnnotations();
+        assertThat("Item type should have exactly one annotation", itemTypeAnnotations.length, is(1));
+        assertThat("@Valid annotation should be on the item type parameter",
+                itemTypeAnnotations[0].annotationType().getName(), is(validationPackage + ".Valid"));
+    }
+
+    @Test
     public void jsr303AnnotationsValidatedForAdditionalProperties() throws ReflectiveOperationException {
         ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/jsr303/validAdditionalProperties.json", "com.example",
                 config("includeJsr303Annotations", true, "useJakartaValidation", useJakartaValidation));


### PR DESCRIPTION
So this:

```java
@Valid
List<Item> items
```

becomes this

```java
List<@Valid Item> items
```

**Note: This change requires that those using javax.validation/validation-api must use version 2.0.0.Final or later.**

Closes #1770.