### PR TITLE
Support type-use annotations for map value validation (Map<String, @Valid T>)

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
@@ -24,6 +24,7 @@ import org.jsonschema2pojo.model.JAnnotatedClass;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JType;
 
 import jakarta.validation.Valid;
 
@@ -56,14 +57,26 @@ public class ValidRule implements Rule<JFieldVar, JFieldVar> {
     public JFieldVar apply(String nodeName, JsonNode node, JsonNode parent, JFieldVar field, Schema currentSchema) {
 
         if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
-            if (!isArray(node)) {
-                field.annotate(getValidClass());
-            } else {
+            if (isArray(node)) {
                 // For arrays, the @Valid annotation is placed on the item type (e.g., List<@Valid Item>)
-                JClass existingArrayType = (JClass) field.type();
-                JClass existingItemType = existingArrayType.getTypeParameters().get(0);
+                // We need to rebuild the type but the type param should become an annotated type param
+                JClass existingFieldType = (JClass) field.type();
+                JClass existingItemType = existingFieldType.getTypeParameters().get(0);
                 JClass annotatedItemType = JAnnotatedClass.of(existingItemType).annotated(getValidClass());
-                field.type(existingArrayType.erasure().narrow(annotatedItemType));
+                JClass newFieldType = existingFieldType.erasure().narrow(annotatedItemType);
+                field.type(newFieldType);
+            } else if (isMap(field.type())) {
+                // For maps (including additionalProperties), the @Valid annotation is placed on the value type
+                // (e.g. Map<String, @Valid Item>)
+                // We need to rebuild the type but the value type param should become an annotated type param
+                JClass existingFieldType = (JClass) field.type();
+                JClass existingKeyType = existingFieldType.getTypeParameters().get(0);
+                JClass existingValueType = existingFieldType.getTypeParameters().get(1);
+                JClass annotatedValueType = JAnnotatedClass.of(existingValueType).annotated(getValidClass());
+                JClass newFieldType = existingFieldType.erasure().narrow(existingKeyType).narrow(annotatedValueType);
+                field.type(newFieldType);
+            } else {
+                field.annotate(getValidClass());
             }
         }
 
@@ -78,6 +91,10 @@ public class ValidRule implements Rule<JFieldVar, JFieldVar> {
 
     private boolean isArray(JsonNode node) {
         return node != null && node.path("type").asText().equals("array");
+    }
+
+    private boolean isMap(JType jtype) {
+        return (jtype instanceof JClass) && ((JClass) jtype).erasure().isAssignableFrom(jtype.owner().ref(java.util.Map.class));
     }
 
 }


### PR DESCRIPTION
This affects additionalProperties or other fields where java.util.Map is used directly. Similar to #1771, the @Valid annotation is now supposed to go onto the value type, not the map field.

So this:

```java
@Valid
Map<String, Item> additionalProperties
```

becomes this

```java
Map<String, @Valid Item> additionalProperties
```

**Note: This change requires that those using javax.validation/validation-api must use version 2.0.0.Final or later.**

See also #1770.