### PR TITLE
Implement allOf/anyOf/oneOf

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/AbstractAnnotator.java
@@ -101,6 +101,7 @@ public abstract class AbstractAnnotator implements Annotator {
         return false;
     }
 
+
     public GenerationConfig getGenerationConfig() {
         return generationConfig;
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Annotator.java
@@ -255,4 +255,19 @@ public interface Annotator {
      *         deserializationClassProperty is present in this schema
      */
     boolean isPolymorphicDeserializationSupported(JsonNode node);
+
+    /**
+     * Add the necessary annotations to a marker interface and its child types
+     * to support polymorphic deserialization of anyOf/oneOf schemas with a
+     * discriminator property.
+     *
+     * @param markerInterface
+     *            the generated marker interface for the anyOf/oneOf
+     * @param discriminatorProperty
+     *            the JSON property name used to distinguish subtypes
+     * @param childTypes
+     *            the generated classes that implement the marker interface
+     */
+    default void subTypeInfo(JDefinedClass markerInterface, String discriminatorProperty, JDefinedClass[] childTypes) {
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/CompositeAnnotator.java
@@ -167,4 +167,11 @@ public class CompositeAnnotator implements Annotator {
             annotator.timeField(field, clazz, propertyNode);
         }
     }
+
+    @Override
+    public void subTypeInfo(JDefinedClass markerInterface, String discriminatorProperty, JDefinedClass[] childTypes) {
+        for (Annotator annotator : annotators) {
+            annotator.subTypeInfo(markerInterface, discriminatorProperty, childTypes);
+        }
+    }
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AllOfRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AllOfRule.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.jsonschema2pojo.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JClassContainer;
+import com.sun.codemodel.JType;
+
+/**
+ * Applies the "allOf" schema rule.
+ * <p>
+ * When "allOf" is found in a schema, all sub-schemas are deep-merged into a
+ * single schema and then processed as if it were a regular schema. Any sibling
+ * keywords (properties, required, type, etc.) that appear alongside "allOf"
+ * are also merged into the result.
+ *
+ * @see <a href="https://json-schema.org/understanding-json-schema/reference/combining#allOf">allOf</a>
+ */
+public class AllOfRule implements Rule<JClassContainer, JType> {
+
+    private final RuleFactory ruleFactory;
+
+    protected AllOfRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    /**
+     * Applies this schema rule to take the required code generation steps.
+     * <p>
+     * The allOf sub-schemas are resolved (including any $ref), deep-merged
+     * into a single schema node, and then re-entered through
+     * {@link SchemaRule#apply} so that the merged result is processed
+     * through the normal pipeline (including enum detection, type
+     * determination, etc.).
+     */
+    @Override
+    public JType apply(String nodeName, JsonNode node, JsonNode parent, JClassContainer generatableType, Schema currentSchema) {
+
+        JsonNode allOfNode = node.get("allOf");
+        ObjectNode mergedSchema = JsonNodeFactory.instance.objectNode();
+
+        for (JsonNode subSchema : allOfNode) {
+            JsonNode resolved = resolveSubSchema(subSchema, currentSchema);
+            mergedSchema = deepMerge(mergedSchema, resolved);
+        }
+
+        // Merge sibling keywords from the parent schema (everything except "allOf" itself)
+        ObjectNode siblingNode = ((ObjectNode) node.deepCopy());
+        siblingNode.remove("allOf");
+        mergedSchema = deepMerge(mergedSchema, siblingNode);
+
+        // Create a new root Schema wrapping the merged content. Using a null
+        // ID makes this a self-referencing root, so that downstream rules
+        // (e.g. PropertyRule) that resolve "#/properties/..." via
+        // SchemaStore.create() will navigate this merged content rather than
+        // the original schema file content.
+        Schema mergedSchemaWrapper = new Schema(null, mergedSchema, null);
+
+        // Re-enter through SchemaRule so enum, $ref, etc. are handled correctly.
+        // The merged node no longer has "allOf", so there is no infinite loop.
+        return ruleFactory.getSchemaRule().apply(nodeName, mergedSchema, parent, generatableType, mergedSchemaWrapper);
+    }
+
+    private JsonNode resolveSubSchema(JsonNode subSchema, Schema currentSchema) {
+        if (subSchema.has("$ref")) {
+            String refPath = subSchema.get("$ref").asText();
+            Schema resolved = ruleFactory.getSchemaStore().create(
+                    currentSchema, refPath,
+                    ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            return resolved.getContent();
+        }
+        // Recursively flatten nested allOf
+        if (subSchema.has("allOf")) {
+            ObjectNode flattened = JsonNodeFactory.instance.objectNode();
+            for (JsonNode nested : subSchema.get("allOf")) {
+                JsonNode resolved = resolveSubSchema(nested, currentSchema);
+                flattened = deepMerge(flattened, resolved);
+            }
+            ObjectNode siblingNode = ((ObjectNode) subSchema.deepCopy());
+            siblingNode.remove("allOf");
+            flattened = deepMerge(flattened, siblingNode);
+            return flattened;
+        }
+        return subSchema;
+    }
+
+    private ObjectNode deepMerge(ObjectNode base, JsonNode overrideNode) {
+        if (!overrideNode.isObject()) {
+            return base;
+        }
+
+        ObjectNode result = base.deepCopy();
+        Iterator<String> fieldNames = overrideNode.fieldNames();
+        while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode overrideValue = overrideNode.get(fieldName);
+
+            if (result.has(fieldName)) {
+                JsonNode baseValue = result.get(fieldName);
+
+                if (baseValue.isObject() && overrideValue.isObject()) {
+                    // Recursive merge for nested objects (e.g. "properties")
+                    result.set(fieldName, deepMerge((ObjectNode) baseValue.deepCopy(), overrideValue));
+                } else if (baseValue.isArray() && overrideValue.isArray()) {
+                    // Union for arrays (e.g. "required") with deduplication
+                    ArrayNode merged = (ArrayNode) baseValue.deepCopy();
+                    Set<String> existing = new HashSet<>();
+                    for (JsonNode n : merged) {
+                        existing.add(n.asText());
+                    }
+                    for (JsonNode n : overrideValue) {
+                        if (!existing.contains(n.asText())) {
+                            merged.add(n.deepCopy());
+                        }
+                    }
+                    result.set(fieldName, merged);
+                } else {
+                    // Scalars: last value wins
+                    result.set(fieldName, overrideValue.deepCopy());
+                }
+            } else {
+                result.set(fieldName, overrideValue.deepCopy());
+            }
+        }
+        return result;
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AnyOfRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AnyOfRule.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.apache.commons.lang3.StringUtils.*;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jsonschema2pojo.Jsonschema2Pojo;
+import org.jsonschema2pojo.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.ClassType;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JClassContainer;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
+
+/**
+ * Applies the "anyOf" and "oneOf" schema rules.
+ * <p>
+ * Both keywords are handled identically: a marker interface is generated
+ * and each child schema produces a class that implements it. When any
+ * child schema is a non-object type, the rule falls back to
+ * {@link Object java.lang.Object}.
+ *
+ * @see <a href="https://json-schema.org/understanding-json-schema/reference/combining#anyOf">anyOf</a>
+ * @see <a href="https://json-schema.org/understanding-json-schema/reference/combining#oneOf">oneOf</a>
+ */
+public class AnyOfRule implements Rule<JClassContainer, JType> {
+
+    private final RuleFactory ruleFactory;
+
+    protected AnyOfRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    @Override
+    public JType apply(String nodeName, JsonNode node, JsonNode parent, JClassContainer generatableType, Schema currentSchema) {
+
+        String keyword = node.has("anyOf") ? "anyOf" : "oneOf";
+        JsonNode subSchemas = node.get(keyword);
+
+        // Empty array or non-array: fall back to Object
+        if (!subSchemas.isArray() || subSchemas.size() == 0) {
+            return generatableType.owner().ref(Object.class);
+        }
+
+        // Check if all children are object-like schemas
+        for (JsonNode subSchema : subSchemas) {
+            JsonNode resolved = resolveIfRef(subSchema, currentSchema);
+            if (!isObjectSchema(resolved)) {
+                return generatableType.owner().ref(Object.class);
+            }
+        }
+
+        // Create marker interface
+        JPackage _package = generatableType.getPackage();
+        String interfaceName = ruleFactory.getNameHelper().getUniqueClassName(nodeName, node, _package);
+        JDefinedClass markerInterface;
+        try {
+            markerInterface = _package._class(JMod.PUBLIC, interfaceName, ClassType.INTERFACE);
+        } catch (JClassAlreadyExistsException e) {
+            return e.getExistingClass();
+        }
+
+        // Generate a type for each child schema that implements the interface
+        List<JDefinedClass> generatedChildTypes = new ArrayList<>();
+        for (int i = 0; i < subSchemas.size(); i++) {
+            JsonNode subSchema = subSchemas.get(i);
+            String childName = deriveChildName(nodeName, subSchema, i);
+
+            // For inline schemas (no $ref), create a self-referencing root
+            // Schema so that PropertyRule can resolve #/properties/... within
+            // the child's own content. For $ref schemas, SchemaRule's own
+            // $ref resolution will replace the schema appropriately.
+            Schema childSchema = subSchema.has("$ref") ? currentSchema
+                    : new Schema(null, subSchema, null);
+
+            JType childType = ruleFactory.getSchemaRule().apply(
+                    childName, subSchema, node, generatableType, childSchema);
+
+            if (childType instanceof JDefinedClass) {
+                JDefinedClass childClass = (JDefinedClass) childType;
+                childClass._implements(markerInterface);
+                generatedChildTypes.add(childClass);
+            }
+        }
+
+        // If a discriminator is specified, add polymorphic type annotations
+        if (node.has("discriminator") && node.get("discriminator").has("propertyName")) {
+            String discriminatorProperty = node.get("discriminator").get("propertyName").asText();
+            ruleFactory.getAnnotator().subTypeInfo(
+                    markerInterface, discriminatorProperty,
+                    generatedChildTypes.toArray(new JDefinedClass[0]));
+        }
+
+        return markerInterface;
+    }
+
+    private JsonNode resolveIfRef(JsonNode subSchema, Schema currentSchema) {
+        if (subSchema.has("$ref")) {
+            String refPath = subSchema.get("$ref").asText();
+            Schema resolved = ruleFactory.getSchemaStore().create(
+                    currentSchema, refPath,
+                    ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            return resolved.getContent();
+        }
+        return subSchema;
+    }
+
+    private boolean isObjectSchema(JsonNode node) {
+        if (node.path("type").asText().equals("object")) {
+            return true;
+        }
+        if (node.has("properties")) {
+            return true;
+        }
+        // No type specified and no indication of a primitive type: treat as object
+        if (!node.has("type")) {
+            return true;
+        }
+        return false;
+    }
+
+    private String deriveChildName(String parentName, JsonNode subSchema, int index) {
+        // Prefer $ref target name
+        if (subSchema.has("$ref")) {
+            String ref = subSchema.get("$ref").asText();
+            if (!"#".equals(ref)) {
+                String name;
+                if (!contains(ref, "#")) {
+                    name = Jsonschema2Pojo.getNodeName(ref, ruleFactory.getGenerationConfig());
+                } else {
+                    String[] parts = split(ref, "/\\#");
+                    name = parts[parts.length - 1];
+                }
+                return URLDecoder.decode(name, StandardCharsets.UTF_8);
+            }
+        }
+
+        // Use title if available
+        if (subSchema.has("title")) {
+            return subSchema.get("title").asText();
+        }
+
+        // Fallback to parent name + Option + index
+        return parentName + "Option" + index;
+    }
+
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -446,4 +446,24 @@ public class RuleFactory {
         return new JavaNameRule();
     }
 
+    /**
+     * Provides a rule instance that should be applied when an "allOf"
+     * declaration is found in the schema.
+     *
+     * @return a schema rule that can handle the "allOf" declaration.
+     */
+    public Rule<JClassContainer, JType> getAllOfRule() {
+        return new AllOfRule(this);
+    }
+
+    /**
+     * Provides a rule instance that should be applied when an "anyOf" or
+     * "oneOf" declaration is found in the schema.
+     *
+     * @return a schema rule that can handle the "anyOf"/"oneOf" declaration.
+     */
+    public Rule<JClassContainer, JType> getAnyOfRule() {
+        return new AnyOfRule(this);
+    }
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -83,6 +83,10 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
         JType javaType;
         if (schemaNode.has("enum")) {
             javaType = ruleFactory.getEnumRule().apply(nodeName, schemaNode, parent, generatableType, schema);
+        } else if (schemaNode.has("allOf")) {
+            javaType = ruleFactory.getAllOfRule().apply(nodeName, schemaNode, parent, generatableType, schema);
+        } else if (schemaNode.has("anyOf") || schemaNode.has("oneOf")) {
+            javaType = ruleFactory.getAnyOfRule().apply(nodeName, schemaNode, parent, generatableType, schema);
         } else {
             javaType = ruleFactory.getTypeRule().apply(nodeName, schemaNode, parent, generatableType.getPackage(), schema);
         }

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AllOfIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AllOfIT.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AllOfIT {
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void simpleAllOfMergesProperties() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/simpleAllOf.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.SimpleAllOf");
+
+        assertThat(type.getDeclaredField("name"), is(notNullValue()));
+        assertThat(type.getDeclaredField("age"), is(notNullValue()));
+
+        assertThat(type.getDeclaredField("name").getType(), is(equalTo(String.class)));
+        assertThat(type.getDeclaredField("age").getType(), is(equalTo(Integer.class)));
+    }
+
+    @Test
+    public void allOfWithRefMergesReferencedSchemaProperties() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithRef.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithRef");
+
+        // Property from the $ref'd base.json
+        assertThat(type.getDeclaredField("baseProperty"), is(notNullValue()));
+        assertThat(type.getDeclaredField("baseProperty").getType(), is(equalTo(String.class)));
+
+        // Property from the inline sub-schema
+        assertThat(type.getDeclaredField("extraProperty"), is(notNullValue()));
+        assertThat(type.getDeclaredField("extraProperty").getType(), is(equalTo(Integer.class)));
+    }
+
+    @Test
+    public void allOfWithSiblingPropertiesMergesBoth() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithSiblingProperties.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithSiblingProperties");
+
+        // Direct sibling property
+        assertThat(type.getDeclaredField("directProperty"), is(notNullValue()));
+        // Property from allOf sub-schema
+        assertThat(type.getDeclaredField("mergedProperty"), is(notNullValue()));
+    }
+
+    @Test
+    public void allOfWithThreeSchemasHasAllProperties() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithThreeSchemas.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithThreeSchemas");
+
+        assertThat(type.getDeclaredField("first"), is(notNullValue()));
+        assertThat(type.getDeclaredField("second"), is(notNullValue()));
+        assertThat(type.getDeclaredField("third"), is(notNullValue()));
+
+        assertThat(type.getDeclaredField("first").getType(), is(equalTo(String.class)));
+        assertThat(type.getDeclaredField("second").getType(), is(equalTo(Integer.class)));
+        assertThat(type.getDeclaredField("third").getType(), is(equalTo(Boolean.class)));
+    }
+
+    @Test
+    public void allOfWithOverlappingRequiredDeduplicates() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithOverlappingRequired.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithOverlappingRequired");
+
+        // All three properties should be present
+        assertThat(type.getDeclaredField("name"), is(notNullValue()));
+        assertThat(type.getDeclaredField("age"), is(notNullValue()));
+        assertThat(type.getDeclaredField("email"), is(notNullValue()));
+    }
+
+    @Test
+    public void emptyAllOfGeneratesFromSiblingProperties() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/emptyAllOf.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.EmptyAllOf");
+
+        assertThat(type.getDeclaredField("directProperty"), is(notNullValue()));
+    }
+
+    @Test
+    public void singleElementAllOfUnwraps() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/singleElementAllOf.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.SingleElementAllOf");
+
+        assertThat(type.getDeclaredField("onlyProperty"), is(notNullValue()));
+    }
+
+    @Test
+    public void allOfWithOverlappingPropertiesUsesLastDefinition() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithOverlappingProperties.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithOverlappingProperties");
+
+        // All three unique properties present
+        assertThat(type.getDeclaredField("shared"), is(notNullValue()));
+        assertThat(type.getDeclaredField("firstOnly"), is(notNullValue()));
+        assertThat(type.getDeclaredField("secondOnly"), is(notNullValue()));
+    }
+
+    @Test
+    public void nestedAllOfIsFlattened() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/nestedAllOf.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.NestedAllOf");
+
+        assertThat(type.getDeclaredField("innerProperty"), is(notNullValue()));
+        assertThat(type.getDeclaredField("outerProperty"), is(notNullValue()));
+    }
+
+    @Test
+    public void allOfAllRefsMergesAllReferencedProperties() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfAllRefs.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfAllRefs");
+
+        assertThat(type.getDeclaredField("propA"), is(notNullValue()));
+        assertThat(type.getDeclaredField("propB"), is(notNullValue()));
+    }
+
+    @Test
+    public void allOfPropertyLevelGeneratesMergedType() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfPropertyLevel.json", "com.example");
+        Class<?> parentType = cl.loadClass("com.example.AllOfPropertyLevel");
+        Class<?> addressType = cl.loadClass("com.example.Address");
+
+        // The parent has an "address" property
+        Method getter = parentType.getMethod("getAddress");
+        assertThat(getter.getReturnType(), is(equalTo(addressType)));
+
+        // The address type has both merged properties
+        assertThat(addressType.getDeclaredField("street"), is(notNullValue()));
+        assertThat(addressType.getDeclaredField("city"), is(notNullValue()));
+    }
+
+    @Test
+    public void allOfWithEnumGeneratesEnumType() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithEnum.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithEnum");
+
+        assertThat(type.isEnum(), is(true));
+        assertThat(type.getEnumConstants().length, is(3));
+    }
+
+    @Test
+    public void allOfMergedTypeCanBeDeserialized() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/simpleAllOf.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.SimpleAllOf");
+
+        Object instance = mapper.readValue("{\"name\":\"Alice\",\"age\":30}", type);
+
+        assertThat(new PropertyDescriptor("name", type).getReadMethod().invoke(instance), is("Alice"));
+        assertThat(new PropertyDescriptor("age", type).getReadMethod().invoke(instance), is(30));
+    }
+
+    @Test
+    public void allOfMergedTypeCanBeSerializedAndDeserialized() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithThreeSchemas.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithThreeSchemas");
+
+        Object instance = mapper.readValue("{\"first\":\"hello\",\"second\":42,\"third\":true}", type);
+
+        // Round-trip: serialize back to JSON and deserialize again
+        String json = mapper.writeValueAsString(instance);
+        Object roundTripped = mapper.readValue(json, type);
+
+        assertThat(new PropertyDescriptor("first", type).getReadMethod().invoke(roundTripped), is("hello"));
+        assertThat(new PropertyDescriptor("second", type).getReadMethod().invoke(roundTripped), is(42));
+        assertThat(new PropertyDescriptor("third", type).getReadMethod().invoke(roundTripped), is(true));
+    }
+
+    @Test
+    public void allOfWithRefCanBeDeserialized() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithRef.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithRef");
+
+        Object instance = mapper.readValue("{\"baseProperty\":\"base\",\"extraProperty\":7}", type);
+
+        assertThat(new PropertyDescriptor("baseProperty", type).getReadMethod().invoke(instance), is("base"));
+        assertThat(new PropertyDescriptor("extraProperty", type).getReadMethod().invoke(instance), is(7));
+    }
+
+    @Test
+    public void allOfWithAnyOfPropertyComposesCorrectly() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/allOf/allOfWithAnyOfProperty.json", "com.example");
+        Class<?> type = cl.loadClass("com.example.AllOfWithAnyOfProperty");
+
+        // "name" from the first allOf sub-schema
+        assertThat(type.getDeclaredField("name"), is(notNullValue()));
+
+        // "variant" from the second allOf sub-schema should be an interface type
+        Method variantGetter = type.getMethod("getVariant");
+        Class<?> variantType = variantGetter.getReturnType();
+        assertThat(variantType.isInterface(), is(true));
+
+        // The anyOf children should implement the interface
+        Class<?> variantA = cl.loadClass("com.example.VariantA");
+        Class<?> variantB = cl.loadClass("com.example.VariantB");
+        assertThat(variantType.isAssignableFrom(variantA), is(true));
+        assertThat(variantType.isAssignableFrom(variantB), is(true));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AnyOfOneOfIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/AnyOfOneOfIT.java
@@ -1,0 +1,324 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AnyOfOneOfIT {
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void simpleAnyOfGeneratesMarkerInterfaceAndImplementations() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/simpleAnyOf.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.SimpleAnyOf");
+        Method shapeGetter = parentType.getMethod("getShape");
+        Class<?> shapeInterface = shapeGetter.getReturnType();
+
+        // The property type should be an interface
+        assertThat(shapeInterface.isInterface(), is(true));
+
+        // Child types should implement the interface
+        Class<?> circle = cl.loadClass("com.example.Circle");
+        Class<?> rectangle = cl.loadClass("com.example.Rectangle");
+        assertThat(shapeInterface.isAssignableFrom(circle), is(true));
+        assertThat(shapeInterface.isAssignableFrom(rectangle), is(true));
+
+        // Child types have their own properties
+        assertThat(circle.getDeclaredField("radius"), is(notNullValue()));
+        assertThat(rectangle.getDeclaredField("width"), is(notNullValue()));
+        assertThat(rectangle.getDeclaredField("height"), is(notNullValue()));
+    }
+
+    @Test
+    public void anyOfWithRefGeneratesInterfaceImplementedByReferencedTypes() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfWithRef.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.AnyOfWithRef");
+        Method choiceGetter = parentType.getMethod("getChoice");
+        Class<?> choiceInterface = choiceGetter.getReturnType();
+
+        assertThat(choiceInterface.isInterface(), is(true));
+
+        Class<?> target1 = cl.loadClass("com.example.AnyOfRefTarget1");
+        Class<?> target2 = cl.loadClass("com.example.AnyOfRefTarget2");
+        assertThat(choiceInterface.isAssignableFrom(target1), is(true));
+        assertThat(choiceInterface.isAssignableFrom(target2), is(true));
+    }
+
+    @Test
+    public void simpleOneOfBehavesLikeAnyOf() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/oneOf/simpleOneOf.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.SimpleOneOf");
+        Method paymentGetter = parentType.getMethod("getPayment");
+        Class<?> paymentInterface = paymentGetter.getReturnType();
+
+        assertThat(paymentInterface.isInterface(), is(true));
+
+        Class<?> creditCard = cl.loadClass("com.example.CreditCard");
+        Class<?> bankAccount = cl.loadClass("com.example.BankAccount");
+        assertThat(paymentInterface.isAssignableFrom(creditCard), is(true));
+        assertThat(paymentInterface.isAssignableFrom(bankAccount), is(true));
+
+        assertThat(creditCard.getDeclaredField("cardNumber"), is(notNullValue()));
+        assertThat(bankAccount.getDeclaredField("accountNumber"), is(notNullValue()));
+    }
+
+    @Test
+    public void anyOfWithPrimitiveFallsBackToObject() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfWithPrimitive.json", "com.example");
+
+        Class<?> type = cl.loadClass("com.example.AnyOfWithPrimitive");
+        Method getter = type.getMethod("getValue");
+
+        assertThat(getter.getReturnType(), is(equalTo(Object.class)));
+    }
+
+    @Test
+    public void anyOfAllPrimitivesFallsBackToObject() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfAllPrimitives.json", "com.example");
+
+        Class<?> type = cl.loadClass("com.example.AnyOfAllPrimitives");
+        Method getter = type.getMethod("getValue");
+
+        assertThat(getter.getReturnType(), is(equalTo(Object.class)));
+    }
+
+    @Test
+    public void emptyAnyOfFallsBackToObject() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/emptyAnyOf.json", "com.example");
+
+        Class<?> type = cl.loadClass("com.example.EmptyAnyOf");
+        Method getter = type.getMethod("getValue");
+
+        assertThat(getter.getReturnType(), is(equalTo(Object.class)));
+    }
+
+    @Test
+    public void singleChildAnyOfGeneratesInterfaceWithOneImplementation() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/singleChildAnyOf.json", "com.example");
+
+        Class<?> type = cl.loadClass("com.example.SingleChildAnyOf");
+        Method getter = type.getMethod("getItem");
+        Class<?> itemInterface = getter.getReturnType();
+
+        assertThat(itemInterface.isInterface(), is(true));
+
+        Class<?> onlyOption = cl.loadClass("com.example.OnlyOption");
+        assertThat(itemInterface.isAssignableFrom(onlyOption), is(true));
+        assertThat(onlyOption.getDeclaredField("name"), is(notNullValue()));
+    }
+
+    @Test
+    public void anyOfNoExplicitTypeTreatsChildrenAsObjects() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfNoExplicitType.json", "com.example");
+
+        Class<?> type = cl.loadClass("com.example.AnyOfNoExplicitType");
+        Method getter = type.getMethod("getData");
+        Class<?> dataInterface = getter.getReturnType();
+
+        assertThat(dataInterface.isInterface(), is(true));
+
+        Class<?> alpha = cl.loadClass("com.example.Alpha");
+        Class<?> beta = cl.loadClass("com.example.Beta");
+        assertThat(dataInterface.isAssignableFrom(alpha), is(true));
+        assertThat(dataInterface.isAssignableFrom(beta), is(true));
+    }
+
+    @Test
+    public void anyOfTopLevelGeneratesInterface() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfTopLevel.json", "com.example");
+
+        Class<?> topLevelInterface = cl.loadClass("com.example.AnyOfTopLevel");
+        assertThat(topLevelInterface.isInterface(), is(true));
+
+        Class<?> foo = cl.loadClass("com.example.Foo");
+        Class<?> bar = cl.loadClass("com.example.Bar");
+        assertThat(topLevelInterface.isAssignableFrom(foo), is(true));
+        assertThat(topLevelInterface.isAssignableFrom(bar), is(true));
+    }
+
+    @Test
+    public void anyOfWithDiscriminatorAddsJsonTypeInfoAnnotation() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfWithDiscriminator.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.AnyOfWithDiscriminator");
+        Method petGetter = parentType.getMethod("getPet");
+        Class<?> petInterface = petGetter.getReturnType();
+
+        assertThat(petInterface.isInterface(), is(true));
+
+        // Marker interface should have @JsonTypeInfo
+        JsonTypeInfo typeInfo = petInterface.getAnnotation(JsonTypeInfo.class);
+        assertThat(typeInfo, is(notNullValue()));
+        assertThat(typeInfo.use(), is(JsonTypeInfo.Id.NAME));
+        assertThat(typeInfo.include(), is(JsonTypeInfo.As.EXISTING_PROPERTY));
+        assertThat(typeInfo.property(), is("petType"));
+
+        // Marker interface should have @JsonSubTypes
+        JsonSubTypes subTypes = petInterface.getAnnotation(JsonSubTypes.class);
+        assertThat(subTypes, is(notNullValue()));
+        assertThat(subTypes.value().length, is(2));
+
+        // Child types should have @JsonTypeName
+        Class<?> cat = cl.loadClass("com.example.Cat");
+        Class<?> dog = cl.loadClass("com.example.Dog");
+        assertThat(petInterface.isAssignableFrom(cat), is(true));
+        assertThat(petInterface.isAssignableFrom(dog), is(true));
+
+        JsonTypeName catTypeName = cat.getAnnotation(JsonTypeName.class);
+        assertThat(catTypeName, is(notNullValue()));
+        assertThat(catTypeName.value(), is("Cat"));
+
+        JsonTypeName dogTypeName = dog.getAnnotation(JsonTypeName.class);
+        assertThat(dogTypeName, is(notNullValue()));
+        assertThat(dogTypeName.value(), is("Dog"));
+    }
+
+    @Test
+    public void oneOfWithDiscriminatorAddsJsonTypeInfoAnnotation() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/oneOf/oneOfWithDiscriminator.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.OneOfWithDiscriminator");
+        Method vehicleGetter = parentType.getMethod("getVehicle");
+        Class<?> vehicleInterface = vehicleGetter.getReturnType();
+
+        assertThat(vehicleInterface.isInterface(), is(true));
+
+        // Marker interface should have @JsonTypeInfo
+        JsonTypeInfo typeInfo = vehicleInterface.getAnnotation(JsonTypeInfo.class);
+        assertThat(typeInfo, is(notNullValue()));
+        assertThat(typeInfo.use(), is(JsonTypeInfo.Id.NAME));
+        assertThat(typeInfo.include(), is(JsonTypeInfo.As.EXISTING_PROPERTY));
+        assertThat(typeInfo.property(), is("vehicleType"));
+
+        // Marker interface should have @JsonSubTypes
+        JsonSubTypes subTypes = vehicleInterface.getAnnotation(JsonSubTypes.class);
+        assertThat(subTypes, is(notNullValue()));
+        assertThat(subTypes.value().length, is(2));
+
+        // Child types should have @JsonTypeName
+        Class<?> car = cl.loadClass("com.example.Car");
+        Class<?> bicycle = cl.loadClass("com.example.Bicycle");
+        assertThat(vehicleInterface.isAssignableFrom(car), is(true));
+        assertThat(vehicleInterface.isAssignableFrom(bicycle), is(true));
+
+        JsonTypeName carTypeName = car.getAnnotation(JsonTypeName.class);
+        assertThat(carTypeName, is(notNullValue()));
+        assertThat(carTypeName.value(), is("Car"));
+
+        JsonTypeName bicycleTypeName = bicycle.getAnnotation(JsonTypeName.class);
+        assertThat(bicycleTypeName, is(notNullValue()));
+        assertThat(bicycleTypeName.value(), is("Bicycle"));
+    }
+
+    @Test
+    public void anyOfWithoutDiscriminatorHasNoTypeInfoAnnotations() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/simpleAnyOf.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.SimpleAnyOf");
+        Method shapeGetter = parentType.getMethod("getShape");
+        Class<?> shapeInterface = shapeGetter.getReturnType();
+
+        // No discriminator, so no @JsonTypeInfo
+        assertThat(shapeInterface.getAnnotation(JsonTypeInfo.class), is(nullValue()));
+        assertThat(shapeInterface.getAnnotation(JsonSubTypes.class), is(nullValue()));
+    }
+
+    @Test
+    public void anyOfWithDiscriminatorDeserializesToCorrectSubtype() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfWithDiscriminator.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.AnyOfWithDiscriminator");
+        Class<?> cat = cl.loadClass("com.example.Cat");
+        Class<?> dog = cl.loadClass("com.example.Dog");
+
+        // Deserialize a Cat
+        Object catOwner = mapper.readValue(
+                "{\"pet\":{\"petType\":\"Cat\",\"huntingSkill\":\"lazy\"}}", parentType);
+        Object catPet = new PropertyDescriptor("pet", parentType).getReadMethod().invoke(catOwner);
+        assertThat(cat.isInstance(catPet), is(true));
+        assertThat(new PropertyDescriptor("huntingSkill", cat).getReadMethod().invoke(catPet), is("lazy"));
+
+        // Deserialize a Dog
+        Object dogOwner = mapper.readValue(
+                "{\"pet\":{\"petType\":\"Dog\",\"breed\":\"labrador\"}}", parentType);
+        Object dogPet = new PropertyDescriptor("pet", parentType).getReadMethod().invoke(dogOwner);
+        assertThat(dog.isInstance(dogPet), is(true));
+        assertThat(new PropertyDescriptor("breed", dog).getReadMethod().invoke(dogPet), is("labrador"));
+    }
+
+    @Test
+    public void oneOfWithDiscriminatorDeserializesToCorrectSubtype() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/oneOf/oneOfWithDiscriminator.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.OneOfWithDiscriminator");
+        Class<?> car = cl.loadClass("com.example.Car");
+        Class<?> bicycle = cl.loadClass("com.example.Bicycle");
+
+        // Deserialize a Car
+        Object carOwner = mapper.readValue(
+                "{\"vehicle\":{\"vehicleType\":\"Car\",\"doors\":4}}", parentType);
+        Object carVehicle = new PropertyDescriptor("vehicle", parentType).getReadMethod().invoke(carOwner);
+        assertThat(car.isInstance(carVehicle), is(true));
+        assertThat(new PropertyDescriptor("doors", car).getReadMethod().invoke(carVehicle), is(4));
+
+        // Deserialize a Bicycle
+        Object bicycleOwner = mapper.readValue(
+                "{\"vehicle\":{\"vehicleType\":\"Bicycle\",\"gears\":21}}", parentType);
+        Object bicycleVehicle = new PropertyDescriptor("vehicle", parentType).getReadMethod().invoke(bicycleOwner);
+        assertThat(bicycle.isInstance(bicycleVehicle), is(true));
+        assertThat(new PropertyDescriptor("gears", bicycle).getReadMethod().invoke(bicycleVehicle), is(21));
+    }
+
+    @Test
+    public void anyOfWithDiscriminatorRoundTrips() throws Exception {
+        ClassLoader cl = schemaRule.generateAndCompile("/schema/anyOf/anyOfWithDiscriminator.json", "com.example");
+
+        Class<?> parentType = cl.loadClass("com.example.AnyOfWithDiscriminator");
+        Class<?> cat = cl.loadClass("com.example.Cat");
+
+        // Deserialize, serialize, deserialize again
+        Object original = mapper.readValue(
+                "{\"pet\":{\"petType\":\"Cat\",\"huntingSkill\":\"expert\"}}", parentType);
+        String json = mapper.writeValueAsString(original);
+        Object roundTripped = mapper.readValue(json, parentType);
+
+        Object pet = new PropertyDescriptor("pet", parentType).getReadMethod().invoke(roundTripped);
+        assertThat(cat.isInstance(pet), is(true));
+        assertThat(new PropertyDescriptor("huntingSkill", cat).getReadMethod().invoke(pet), is("expert"));
+        assertThat(new PropertyDescriptor("petType", cat).getReadMethod().invoke(pet), is("Cat"));
+    }
+
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfAllRefs.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfAllRefs.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "allOfRefA.json"
+        },
+        {
+            "$ref": "allOfRefB.json"
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfPropertyLevel.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfPropertyLevel.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "properties": {
+        "address": {
+            "allOf": [
+                {
+                    "properties": {
+                        "street": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "city": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfRefA.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfRefA.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "propA": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfRefB.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfRefB.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "propB": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithAnyOfProperty.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithAnyOfProperty.json
@@ -1,0 +1,38 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "variant": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "title": "VariantA",
+                            "properties": {
+                                "aField": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "title": "VariantB",
+                            "properties": {
+                                "bField": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithEnum.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithEnum.json
@@ -1,0 +1,14 @@
+{
+    "allOf": [
+        {
+            "type": "string"
+        },
+        {
+            "enum": [
+                "RED",
+                "GREEN",
+                "BLUE"
+            ]
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithOverlappingProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithOverlappingProperties.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "shared": {
+                    "type": "string"
+                },
+                "firstOnly": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "shared": {
+                    "type": "string",
+                    "description": "overridden"
+                },
+                "secondOnly": {
+                    "type": "integer"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithOverlappingRequired.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithOverlappingRequired.json
@@ -1,0 +1,30 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "name",
+                "age"
+            ]
+        },
+        {
+            "properties": {
+                "email": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "age",
+                "email"
+            ]
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithRef.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithRef.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "base.json"
+        },
+        {
+            "properties": {
+                "extraProperty": {
+                    "type": "integer"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithSiblingProperties.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithSiblingProperties.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "properties": {
+        "directProperty": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "directProperty"
+    ],
+    "allOf": [
+        {
+            "properties": {
+                "mergedProperty": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "mergedProperty"
+            ]
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithThreeSchemas.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/allOfWithThreeSchemas.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "first": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "second": {
+                    "type": "integer"
+                }
+            }
+        },
+        {
+            "properties": {
+                "third": {
+                    "type": "boolean"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/base.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/base.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "properties": {
+        "baseProperty": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "baseProperty"
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/emptyAllOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/emptyAllOf.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "properties": {
+        "directProperty": {
+            "type": "string"
+        }
+    },
+    "allOf": []
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/nestedAllOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/nestedAllOf.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "allOf": [
+                {
+                    "properties": {
+                        "innerProperty": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "properties": {
+                "outerProperty": {
+                    "type": "integer"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/simpleAllOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/simpleAllOf.json
@@ -1,0 +1,22 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        {
+            "properties": {
+                "age": {
+                    "type": "integer"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/singleElementAllOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/allOf/singleElementAllOf.json
@@ -1,0 +1,12 @@
+{
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "onlyProperty": {
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfAllPrimitives.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfAllPrimitives.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "value": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfNoExplicitType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfNoExplicitType.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "properties": {
+        "data": {
+            "anyOf": [
+                {
+                    "title": "Alpha",
+                    "properties": {
+                        "alphaField": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "title": "Beta",
+                    "properties": {
+                        "betaField": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfRefTarget1.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfRefTarget1.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "refField1": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfRefTarget2.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfRefTarget2.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "refField2": {
+            "type": "integer"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfTopLevel.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfTopLevel.json
@@ -1,0 +1,22 @@
+{
+    "anyOf": [
+        {
+            "type": "object",
+            "title": "Foo",
+            "properties": {
+                "fooField": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "type": "object",
+            "title": "Bar",
+            "properties": {
+                "barField": {
+                    "type": "integer"
+                }
+            }
+        }
+    ]
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfWithDiscriminator.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfWithDiscriminator.json
@@ -1,0 +1,36 @@
+{
+    "type": "object",
+    "properties": {
+        "pet": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "title": "Cat",
+                    "properties": {
+                        "petType": {
+                            "type": "string"
+                        },
+                        "huntingSkill": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "title": "Dog",
+                    "properties": {
+                        "petType": {
+                            "type": "string"
+                        },
+                        "breed": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "discriminator": {
+                "propertyName": "petType"
+            }
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfWithPrimitive.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfWithPrimitive.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "value": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfWithRef.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/anyOfWithRef.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "choice": {
+            "anyOf": [
+                {
+                    "$ref": "anyOfRefTarget1.json"
+                },
+                {
+                    "$ref": "anyOfRefTarget2.json"
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/emptyAnyOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/emptyAnyOf.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+        "value": {
+            "anyOf": []
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/simpleAnyOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/simpleAnyOf.json
@@ -1,0 +1,30 @@
+{
+    "type": "object",
+    "properties": {
+        "shape": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "title": "Circle",
+                    "properties": {
+                        "radius": {
+                            "type": "number"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "title": "Rectangle",
+                    "properties": {
+                        "width": {
+                            "type": "number"
+                        },
+                        "height": {
+                            "type": "number"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/singleChildAnyOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/anyOf/singleChildAnyOf.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "properties": {
+        "item": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "title": "OnlyOption",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/oneOf/oneOfWithDiscriminator.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/oneOf/oneOfWithDiscriminator.json
@@ -1,0 +1,36 @@
+{
+    "type": "object",
+    "properties": {
+        "vehicle": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "Car",
+                    "properties": {
+                        "vehicleType": {
+                            "type": "string"
+                        },
+                        "doors": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "title": "Bicycle",
+                    "properties": {
+                        "vehicleType": {
+                            "type": "string"
+                        },
+                        "gears": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            ],
+            "discriminator": {
+                "propertyName": "vehicleType"
+            }
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/oneOf/simpleOneOf.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/oneOf/simpleOneOf.json
@@ -1,0 +1,27 @@
+{
+    "type": "object",
+    "properties": {
+        "payment": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "CreditCard",
+                    "properties": {
+                        "cardNumber": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "title": "BankAccount",
+                    "properties": {
+                        "accountNumber": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This is a vision for allOf/anyOf/oneOf that I've been thinking about for many years. The approach is simple but will hopefully support a very large percentage of use-cases for these keywords.

* **allOf:** All schemas are merged together to create a superset of schema rules.
* **anyOf / oneOf:** We generate each individual subtype, then create a 'marker' interface which all types implement. When working with types, users may have to rely on type checks and casts, but since Java has no union type (and adding intervening types is ugly) I think this is reasonable.

To achieve polymorphic deserialisation, there's a new 'discriminator' keyword, similar to OpenAPI's discriminator keyword, to specify the JSON property that will indicate the type name.

This PR is not complete, but it shows where I think we'll go. 