### PR TITLE
Fix ValidRule::isMap causing IndexOutOfBoundsException when field type is java.lang.Object

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
@@ -94,7 +94,7 @@ public class ValidRule implements Rule<JFieldVar, JFieldVar> {
     }
 
     private boolean isMap(JType jtype) {
-        return (jtype instanceof JClass) && ((JClass) jtype).erasure().isAssignableFrom(jtype.owner().ref(java.util.Map.class));
+        return jtype instanceof JClass jClass && jClass.owner().ref(java.util.Map.class).isAssignableFrom(jClass.erasure());
     }
 
 }

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validObject.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validObject.json
@@ -12,6 +12,10 @@
                     "maxLength" : 5
                 }
             }
+        },
+        "objectTypeField" : {
+            "type": "object",
+            "existingJavaType": "java.lang.Object"
         }
     }
 }


### PR DESCRIPTION
Unfortunately it looks like that `ValidRule::isMap` is checking whether a class is assignable from `Map` in a wrong "direction", as a result a simplified schema like:
```json
{
  "type": "object",
  "properties": {
    "value": {
      "type": "object",
      "existingJavaType": "java.lang.Object"
    }
  }
}
```

would fail with `IndexOutOfBoundsException`:
```java
Caused by: java.lang.IndexOutOfBoundsException: Index: 0
	at java.base/java.util.Collections$EmptyList.get(Collections.java:4916)
	at org.jsonschema2pojo.rules.ValidRule.apply(ValidRule.java:73)
	at org.jsonschema2pojo.rules.ValidRule.apply(ValidRule.java:38)
	at org.jsonschema2pojo.rules.PropertyRule.apply(PropertyRule.java:133)
	at org.jsonschema2pojo.rules.PropertyRule.apply(PropertyRule.java:42)
	at org.jsonschema2pojo.rules.PropertiesRule.apply(PropertiesRule.java:70)
	at org.jsonschema2pojo.rules.PropertiesRule.apply(PropertiesRule.java:38)
	at org.jsonschema2pojo.rules.ObjectRule.apply(ObjectRule.java:120)
```