### PR TITLE
Fix JLS 9.7.4 type-use annotation placement when using validation annotations

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AdditionalPropertiesRule.java
@@ -115,6 +115,7 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
             additionalPropertiesSchema.setJavaTypeIfEmpty(propertyType);
         } else {
             propertyType = jclass.owner().ref(Object.class);
+            propertyType = ruleFactory.getValidRule().apply(nodeName, node, parent, propertyType, schema);
         }
 
         JFieldVar field = addAdditionalPropertiesField(jclass, propertyType);
@@ -122,10 +123,6 @@ public class AdditionalPropertiesRule implements Rule<JDefinedClass, JDefinedCla
         addGetter(jclass, field);
 
         addSetter(jclass, propertyType, field);
-
-        if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
-            ruleFactory.getValidRule().apply(nodeName, node, parent, field, schema);
-        }
 
         if (ruleFactory.getGenerationConfig().isGenerateBuilders()) {
             addBuilder(jclass, propertyType, field);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -98,7 +98,8 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         jclass._extends((JClass) superType);
 
-        schema.setJavaTypeIfEmpty(jclass);
+        // storing this type for future self refs
+        schema.setJavaTypeIfEmpty(ruleFactory.getValidRule().apply(nodeName, node, parent, jclass, schema));
 
         if (node.has("title")) {
             ruleFactory.getTitleRule().apply(nodeName, node.get("title"), node, jclass, schema);

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -129,10 +129,6 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
 
         ruleFactory.getDigitsRule().apply(nodeName, node, parent, field, schema);
 
-        if (isObject(node) || isArray(node)) {
-            ruleFactory.getValidRule().apply(nodeName, node, parent, field, schema);
-        }
-
         return jclass;
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -307,13 +307,13 @@ public class RuleFactory {
     }
 
     /**
-     * Provides a rule instance that should be applied when a property
-     * declaration is found in the schema which itself contains properties, to
-     * assign validation of the properties within that property
+     * Provides a rule instance that should be applied when a new type is
+     * created, to add the {@code @Valid} annotation for cascading validation
+     * of non-container types.
      *
-     * @return a schema rule that can handle the "default" declaration.
+     * @return a schema rule that applies the {@code @Valid} annotation to types requiring cascading validation.
      */
-    public Rule<JFieldVar, JFieldVar> getValidRule() {
+    public Rule<JType, JType> getValidRule() {
         return new ValidRule(this);
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/TypeRule.java
@@ -118,6 +118,8 @@ public class TypeRule implements Rule<JClassContainer, JType> {
       type = ruleFactory.getMediaRule().apply(nodeName, node.get("media"), node, type, schema);
     }
 
+    type = ruleFactory.getValidRule().apply(nodeName, node, parent, type, schema);
+
     return type;
   }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ValidRule.java
@@ -17,25 +17,26 @@
 package org.jsonschema2pojo.rules;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
 
 import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.model.JAnnotatedClass;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JClass;
-import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JType;
 
 import jakarta.validation.Valid;
 
 /**
- * Applies the {@code @Valid} annotation to fields that require cascading validation.
+ * Applies the {@code @Valid} annotation to non-container types that require cascading validation.
  * <p>
- * For object fields, the annotation is placed on the field declaration.
- * For array/collection fields, the annotation is placed on the item type parameter
- * (e.g., {@code List<@Valid Item>}) to ensure proper cascading validation of elements.
+ * Container types (Collections, Maps) are not annotated — only their element/value types are,
+ * via the recursive rule pipeline.
  */
-public class ValidRule implements Rule<JFieldVar, JFieldVar> {
+public class ValidRule implements Rule<JType, JType> {
 
     private final RuleFactory ruleFactory;
 
@@ -43,58 +44,39 @@ public class ValidRule implements Rule<JFieldVar, JFieldVar> {
         this.ruleFactory = ruleFactory;
     }
 
-    /**
-     * Applies the {@code @Valid} annotation to the given field if JSR-303 annotations are enabled.
-     *
-     * @param nodeName the name of the JSON property
-     * @param node the JSON schema node
-     * @param parent the parent JSON schema node
-     * @param field the field to annotate
-     * @param currentSchema the current schema being processed
-     * @return the field, potentially with {@code @Valid} annotation added
-     */
     @Override
-    public JFieldVar apply(String nodeName, JsonNode node, JsonNode parent, JFieldVar field, Schema currentSchema) {
+    public JType apply(String nodeName, JsonNode node, JsonNode parent, JType type, Schema currentSchema) {
 
-        if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()) {
-            if (isArray(node)) {
-                // For arrays, the @Valid annotation is placed on the item type (e.g., List<@Valid Item>)
-                // We need to rebuild the type but the type param should become an annotated type param
-                JClass existingFieldType = (JClass) field.type();
-                JClass existingItemType = existingFieldType.getTypeParameters().get(0);
-                JClass annotatedItemType = JAnnotatedClass.of(existingItemType).annotated(getValidClass());
-                JClass newFieldType = existingFieldType.erasure().narrow(annotatedItemType);
-                field.type(newFieldType);
-            } else if (isMap(field.type())) {
-                // For maps (including additionalProperties), the @Valid annotation is placed on the value type
-                // (e.g. Map<String, @Valid Item>)
-                // We need to rebuild the type but the value type param should become an annotated type param
-                JClass existingFieldType = (JClass) field.type();
-                JClass existingKeyType = existingFieldType.getTypeParameters().get(0);
-                JClass existingValueType = existingFieldType.getTypeParameters().get(1);
-                JClass annotatedValueType = JAnnotatedClass.of(existingValueType).annotated(getValidClass());
-                JClass newFieldType = existingFieldType.erasure().narrow(existingKeyType).narrow(annotatedValueType);
-                field.type(newFieldType);
-            } else {
-                field.annotate(getValidClass());
-            }
+        if (ruleFactory.getGenerationConfig().isIncludeJsr303Annotations()
+            && type instanceof JClass jclass
+            && !isContainer(jclass)
+            && !isScalar(jclass)) {
+            return JAnnotatedClass.of(jclass).annotated(getValidClass());
+        } else {
+            return type;
         }
+    }
 
-        return field;
+    private boolean isContainer(JClass jclass) {
+        JClass e = jclass.erasure();
+        return jclass.owner().ref(Collection.class).isAssignableFrom(e)
+            || jclass.owner().ref(Map.class).isAssignableFrom(e)
+            || jclass.owner().ref(Optional.class).isAssignableFrom(e);
+    }
+
+    // Scalar types that never benefit from cascading @Valid validation.
+    // java.lang.Object is intentionally excluded — at runtime it may hold
+    // a complex type (e.g. additionalProperties values) that should be validated.
+    protected boolean isScalar(JClass jclass) {
+        String name = jclass.erasure().fullName();
+        return (name.startsWith("java.lang.") && !name.equals("java.lang.Object"))
+            || name.startsWith("java.math.");
     }
 
     private Class<? extends Annotation> getValidClass() {
         return ruleFactory.getGenerationConfig().isUseJakartaValidation()
                 ? Valid.class
                 : javax.validation.Valid.class;
-    }
-
-    private boolean isArray(JsonNode node) {
-        return node != null && node.path("type").asText().equals("array");
-    }
-
-    private boolean isMap(JType jtype) {
-        return jtype instanceof JClass jClass && jClass.owner().ref(java.util.Map.class).isAssignableFrom(jClass.erasure());
     }
 
 }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/TypeRuleTest.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import org.jsonschema2pojo.GenerationConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,6 +40,7 @@ import com.sun.codemodel.JType;
 
 public class TypeRuleTest {
 
+    private final ValidRule validRule = mock(ValidRule.class);
     private final GenerationConfig config = mock(GenerationConfig.class);
     private final RuleFactory ruleFactory = mock(RuleFactory.class);
 
@@ -47,6 +49,8 @@ public class TypeRuleTest {
     @BeforeEach
     public void wireUpConfig() {
         when(ruleFactory.getGenerationConfig()).thenReturn(config);
+        when(ruleFactory.getValidRule()).thenReturn(validRule);
+        when(validRule.apply(any(),any(),any(),any(),any())).then(AdditionalAnswers.returnsArgAt(3));
     }
 
     @Test

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validAdditionalPropertiesTrue.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validAdditionalPropertiesTrue.json
@@ -1,0 +1,4 @@
+{
+    "type" : "object",
+    "additionalProperties" : true
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validAdditionalPropertiesWithItemTypeArray.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validAdditionalPropertiesWithItemTypeArray.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "additionalProperties": {
+        "type": "array",
+        "items": {
+            "type": "string"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validAdditionalPropertiesWithNestedArrays.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validAdditionalPropertiesWithNestedArrays.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "type": "array",
+      "items" : {
+        "type": "array",
+        "items" : {
+          "type": "array",
+          "items" : {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "maxLength": 5
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validArray.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validArray.json
@@ -4,7 +4,10 @@
         "primitivearray" : {
             "type": "array",
             "items": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                }
             }
         },
         "objectarray" : {

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validArrayWithCollision.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validArrayWithCollision.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "things": {
+            "type": "array",
+            "items": {}
+        },
+        "object": {
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" }
+            }
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validExistingJavaType.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validExistingJavaType.json
@@ -1,0 +1,34 @@
+{
+    "type": "object",
+    "properties": {
+        "typedMap": {
+            "type": "object",
+            "existingJavaType": "java.util.Map<String,String>"
+        },
+        "rawMap": {
+            "type": "object",
+            "existingJavaType": "java.util.Map"
+        },
+        "typedList": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "existingJavaType": "java.util.LinkedList<String>"
+        },
+        "rawList": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "existingJavaType": "java.util.LinkedList"
+        },
+        "standardType": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "existingJavaType": "java.lang.Object"
+        }
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validScalarTypes.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validScalarTypes.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "stringProp": { "type": "string" },
+        "integerProp": { "type": "integer" },
+        "numberProp": { "type": "number" },
+        "booleanProp": { "type": "boolean" }
+    },
+    "additionalProperties": false
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validWithBuilders/animal.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validWithBuilders/animal.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "javaType": "com.example.Animal",
+  "properties": {
+    "tag": {
+      "$ref": "tag.json"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validWithBuilders/dog.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validWithBuilders/dog.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "javaType": "com.example.Dog",
+  "extendsJavaClass": "com.example.Animal",
+  "properties": {
+    "tag": {
+      "$ref": "tag.json"
+    }
+  }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validWithBuilders/tag.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/jsr303/validWithBuilders/tag.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "properties": {
+    "label": { "type": "string" }
+  }
+}


### PR DESCRIPTION
Place type-use annotations directly before the simple type name rather than before the fully-qualified name. This produces correct code like `com.example.@Valid MyItem` instead of `@Valid com.example.MyItem` when the type cannot be imported due to a name collision.

When the type is imported, simple names are used: `@Valid String`.

From the language spec:

> For example, assume an annotation type TA which is meta-annotated with
> just https://github.com/target(ElementType.TYPE_USE). The terms
> `@TA java.lang.Object` and `java.@TA lang.Object` are illegal because
> the simple name to which `@TA` is closest is classified as a package name.
> On the other hand, `java.lang.@TA Object` is legal.

Simplify JAnnotatedClass by removing 2 of 3 reflection points:
- Store annotation JClass refs directly instead of reflectively constructing JAnnotationUse instances
- Return this from substituteParams (only concrete types are wrapped)
- Keep importedClasses reflection (unavoidable with codemodel 2.6)

Closes #1776