### PR TITLE
Add support for JSON Schema polymorphism (allOf, oneOf, if/then/else)

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AllOfRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AllOfRule.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.jsonschema2pojo.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JDefinedClass;
+
+/**
+ * Handles the JSON Schema "allOf" keyword by merging properties from all
+ * sub-schemas into the target class. When a sub-schema is a $ref, it is
+ * resolved and its properties are merged. When if/then blocks are present,
+ * they are delegated to {@link IfThenElseRule}.
+ */
+public class AllOfRule implements Rule<JDefinedClass, JDefinedClass> {
+
+    private final RuleFactory ruleFactory;
+
+    protected AllOfRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    @Override
+    public JDefinedClass apply(String nodeName, JsonNode allOfNode, JsonNode parent, JDefinedClass jclass, Schema schema) {
+        if (allOfNode == null || !allOfNode.isArray()) {
+            return jclass;
+        }
+
+        for (JsonNode subSchema : allOfNode) {
+            if (subSchema.has("if") && subSchema.has("then")) {
+                continue;
+            }
+
+            ResolvedEntry resolved = resolveIfRef(subSchema, schema);
+
+            if (resolved.content.has("properties")) {
+                mergeProperties(nodeName, resolved.content, parent, jclass, resolved.schema);
+            }
+        }
+
+        return jclass;
+    }
+
+    private void mergeProperties(String nodeName, JsonNode subSchema, JsonNode parent, JDefinedClass jclass, Schema schema) {
+        JsonNode properties = subSchema.get("properties");
+        if (properties != null) {
+            for (Iterator<Map.Entry<String, JsonNode>> fields = properties.fields(); fields.hasNext(); ) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                String propertyName = field.getKey();
+                if (jclass.fields().containsKey(ruleFactory.getNameHelper().getPropertyName(propertyName, field.getValue()))) {
+                    continue;
+                }
+                ruleFactory.getPropertyRule().apply(propertyName, field.getValue(), properties, jclass, schema);
+            }
+        }
+    }
+
+    private ResolvedEntry resolveIfRef(JsonNode node, Schema schema) {
+        if (node.has("$ref")) {
+            Schema refSchema = ruleFactory.getSchemaStore().create(
+                    schema, node.get("$ref").asText(),
+                    ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            return new ResolvedEntry(refSchema.getContent(), refSchema);
+        }
+        return new ResolvedEntry(node, schema);
+    }
+
+    private static class ResolvedEntry {
+        final JsonNode content;
+        final Schema schema;
+
+        ResolvedEntry(JsonNode content, Schema schema) {
+            this.content = content;
+            this.schema = schema;
+        }
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AllOfRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/AllOfRule.java
@@ -45,16 +45,19 @@ public class AllOfRule implements Rule<JDefinedClass, JDefinedClass> {
             return jclass;
         }
 
+        int index = 0;
         for (JsonNode subSchema : allOfNode) {
             if (subSchema.has("if") && subSchema.has("then")) {
+                index++;
                 continue;
             }
 
-            ResolvedEntry resolved = resolveIfRef(subSchema, schema);
+            ResolvedEntry resolved = resolveEntry(subSchema, schema, index);
 
             if (resolved.content.has("properties")) {
                 mergeProperties(nodeName, resolved.content, parent, jclass, resolved.schema);
             }
+            index++;
         }
 
         return jclass;
@@ -74,14 +77,25 @@ public class AllOfRule implements Rule<JDefinedClass, JDefinedClass> {
         }
     }
 
-    private ResolvedEntry resolveIfRef(JsonNode node, Schema schema) {
+    private ResolvedEntry resolveEntry(JsonNode node, Schema schema, int index) {
         if (node.has("$ref")) {
             Schema refSchema = ruleFactory.getSchemaStore().create(
                     schema, node.get("$ref").asText(),
                     ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
             return new ResolvedEntry(refSchema.getContent(), refSchema);
         }
-        return new ResolvedEntry(node, schema);
+
+        // Inline sub-schema: create a Schema context pointing at the actual path
+        // so that PropertyRule can build correct sub-paths for property resolution.
+        String fragment = schema.getId() != null ? schema.getId().getFragment() : null;
+        String entryPath = fragment != null
+                ? "#" + fragment + "/allOf/" + index
+                : "#/allOf/" + index;
+
+        Schema entrySchema = ruleFactory.getSchemaStore().create(
+                schema, entryPath,
+                ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+        return new ResolvedEntry(entrySchema.getContent(), entrySchema);
     }
 
     private static class ResolvedEntry {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/IfThenElseRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/IfThenElseRule.java
@@ -1,0 +1,376 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
+import org.jsonschema2pojo.util.AnnotationHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JAnnotationArrayMember;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JPackage;
+
+/**
+ * Handles if/then/else conditional schemas by detecting discriminated unions.
+ * When the "if" block checks a property against a const value and "then"
+ * provides additional properties (often via $ref), this rule generates
+ * subclasses with Jackson @JsonSubTypes annotations.
+ */
+public class IfThenElseRule implements Rule<JDefinedClass, JDefinedClass> {
+
+    private final RuleFactory ruleFactory;
+
+    protected IfThenElseRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    @Override
+    public JDefinedClass apply(String nodeName, JsonNode node, JsonNode parent, JDefinedClass jclass, Schema schema) {
+        if (!node.has("if") || !node.has("then")) {
+            return jclass;
+        }
+
+        DiscriminatorInfo info = extractDiscriminator(node.get("if"));
+        if (info == null) {
+            return jclass;
+        }
+
+        ResolvedThen resolved = resolveThen(node.get("then"), schema);
+        if (resolved == null) {
+            return jclass;
+        }
+
+        String subclassName = deriveSubclassName(resolved.content, info.constValue, null);
+        if (subclassName == null) {
+            return jclass;
+        }
+
+        try {
+            JPackage pkg = jclass.getPackage();
+            String uniqueName = ruleFactory.getNameHelper().getUniqueClassName(subclassName, resolved.content, pkg);
+
+            JDefinedClass subclass;
+            try {
+                subclass = pkg._class(JMod.PUBLIC, uniqueName);
+            } catch (JClassAlreadyExistsException e) {
+                return jclass;
+            }
+
+            subclass._extends(jclass);
+
+            if (ruleFactory.getGenerationConfig().isIncludeGeneratedAnnotation()) {
+                AnnotationHelper.addGeneratedAnnotation(ruleFactory.getGenerationConfig(), subclass);
+            }
+
+            applyPropertiesToSubclass(subclassName, resolved.content, resolved.schema, subclass);
+
+            registerSubtype(jclass, subclass, info.propertyName, info.constValue);
+
+        } catch (Exception e) {
+            ruleFactory.getLogger().error("Failed to generate subclass for if/then: " + subclassName, e);
+        }
+
+        return jclass;
+    }
+
+    /**
+     * Applies this rule to all if/then blocks in a parent allOf array,
+     * and adds @JsonTypeInfo + @JsonSubTypes to the base class.
+     */
+    public JDefinedClass applyAll(String nodeName, JsonNode allOfNode, JsonNode parent, JDefinedClass jclass, Schema schema) {
+        if (allOfNode == null || !allOfNode.isArray()) {
+            return jclass;
+        }
+
+        String discriminatorProp = null;
+        List<SubtypeEntry> subtypes = new ArrayList<>();
+
+        int allOfIndex = 0;
+        for (JsonNode entry : allOfNode) {
+            if (entry.has("if") && entry.has("then")) {
+                DiscriminatorInfo info = extractDiscriminator(entry.get("if"));
+                if (info != null) {
+                    if (discriminatorProp == null) {
+                        discriminatorProp = info.propertyName;
+                    }
+
+                    ResolvedThen resolved = resolveThenWithIndex(entry.get("then"), schema, allOfIndex);
+                    if (resolved == null) { allOfIndex++; continue; }
+
+                    String subclassName = deriveSubclassName(resolved.content, info.constValue, resolved.refName);
+                    if (subclassName == null) { allOfIndex++; continue; }
+
+                    JPackage pkg = jclass.getPackage();
+                    String uniqueName;
+                    if (resolved.refName != null) {
+                        uniqueName = ruleFactory.getNameHelper().getClassName(subclassName, null, pkg);
+                        uniqueName = ruleFactory.getNameHelper().getUniqueClassName(uniqueName, null, pkg);
+                    } else {
+                        uniqueName = ruleFactory.getNameHelper().getUniqueClassName(subclassName, resolved.content, pkg);
+                    }
+
+                    try {
+                        JDefinedClass subclass = pkg._class(JMod.PUBLIC, uniqueName);
+                        subclass._extends(jclass);
+
+                        if (ruleFactory.getGenerationConfig().isIncludeGeneratedAnnotation()) {
+                            AnnotationHelper.addGeneratedAnnotation(ruleFactory.getGenerationConfig(), subclass);
+                        }
+
+                        try {
+                            applyPropertiesToSubclass(subclassName, resolved.content, resolved.schema, subclass);
+                        } catch (IllegalArgumentException e) {
+                            ruleFactory.getLogger().error("Property resolution failed for subclass " + subclassName
+                                    + " (allOfIndex=" + allOfIndex + ", schema=" + resolved.schema.getId()
+                                    + "): " + e.getMessage(), e);
+                        }
+
+                        ruleFactory.getAnnotator().propertyInclusion(subclass, resolved.content);
+
+                        subtypes.add(new SubtypeEntry(info.constValue, subclass));
+                    } catch (JClassAlreadyExistsException e) {
+                        // skip duplicates
+                    }
+                }
+            }
+            allOfIndex++;
+        }
+
+        if (discriminatorProp != null && !subtypes.isEmpty()) {
+            addJsonTypeAnnotations(jclass, discriminatorProp, subtypes);
+        }
+
+        return jclass;
+    }
+
+    private void applyPropertiesToSubclass(String subclassName, JsonNode thenContent, Schema thenSchema, JDefinedClass subclass) {
+        if (thenContent.has("properties")) {
+            JsonNode props = thenContent.get("properties");
+            for (Iterator<Map.Entry<String, JsonNode>> fields = props.fields(); fields.hasNext(); ) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                String propName = ruleFactory.getNameHelper().getPropertyName(field.getKey(), field.getValue());
+                if (parentHasField(subclass, propName)) {
+                    continue;
+                }
+                ruleFactory.getPropertyRule().apply(field.getKey(), field.getValue(), props, subclass, thenSchema);
+            }
+        }
+
+        if (thenContent.has("required")) {
+            ruleFactory.getRequiredArrayRule().apply(subclassName, thenContent.get("required"), thenContent, subclass, thenSchema);
+        }
+
+        // Constructors for subclasses are not generated to avoid conflicts
+        // with inherited constructors from the parent class
+    }
+
+    private void addJsonTypeAnnotations(JDefinedClass jclass, String discriminatorProp, List<SubtypeEntry> subtypes) {
+        try {
+            Class<?> jsonTypeInfoClass = Class.forName("com.fasterxml.jackson.annotation.JsonTypeInfo");
+            Class<?> jsonSubTypesClass = Class.forName("com.fasterxml.jackson.annotation.JsonSubTypes");
+
+            JAnnotationUse typeInfo = jclass.annotate(jclass.owner().ref(jsonTypeInfoClass));
+            typeInfo.param("use", jclass.owner().ref(
+                    Class.forName("com.fasterxml.jackson.annotation.JsonTypeInfo$Id")).staticRef("NAME"));
+            typeInfo.param("include", jclass.owner().ref(
+                    Class.forName("com.fasterxml.jackson.annotation.JsonTypeInfo$As")).staticRef("EXISTING_PROPERTY"));
+            typeInfo.param("property", discriminatorProp);
+            typeInfo.param("visible", true);
+
+            JAnnotationUse subTypesAnnotation = jclass.annotate(jclass.owner().ref(jsonSubTypesClass));
+            JAnnotationArrayMember valueArray = subTypesAnnotation.paramArray("value");
+
+            for (SubtypeEntry entry : subtypes) {
+                JAnnotationUse typeEntry = valueArray.annotate(
+                        jclass.owner().ref(Class.forName("com.fasterxml.jackson.annotation.JsonSubTypes$Type")));
+                typeEntry.param("value", entry.subclass);
+                typeEntry.param("name", entry.discriminatorValue);
+            }
+        } catch (ClassNotFoundException e) {
+            ruleFactory.getLogger().error("Jackson annotations not on classpath, cannot add @JsonTypeInfo/@JsonSubTypes", e);
+        }
+    }
+
+    private void registerSubtype(JDefinedClass baseClass, JDefinedClass subclass, String propertyName, String constValue) {
+        // Individual registration - used when called one-at-a-time
+        // The bulk annotation is handled by applyAll
+    }
+
+    private DiscriminatorInfo extractDiscriminator(JsonNode ifNode) {
+        JsonNode properties = ifNode.get("properties");
+        if (properties == null) return null;
+
+        Iterator<Map.Entry<String, JsonNode>> fields = properties.fields();
+        if (!fields.hasNext()) return null;
+
+        Map.Entry<String, JsonNode> field = fields.next();
+        String propertyName = field.getKey();
+        JsonNode propSchema = field.getValue();
+
+        String constValue = null;
+        if (propSchema.has("const")) {
+            constValue = propSchema.get("const").asText();
+        } else if (propSchema.has("enum") && propSchema.get("enum").size() == 1) {
+            constValue = propSchema.get("enum").get(0).asText();
+        }
+
+        if (constValue == null) return null;
+        return new DiscriminatorInfo(propertyName, constValue);
+    }
+
+    private ResolvedThen resolveThen(JsonNode thenNode, Schema parentSchema) {
+        if (thenNode.has("$ref")) {
+            String ref = thenNode.get("$ref").asText();
+            Schema refSchema = ruleFactory.getSchemaStore().create(
+                    parentSchema, ref,
+                    ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            return new ResolvedThen(refSchema.getContent(), refSchema, extractNameFromRef(ref));
+        }
+        return new ResolvedThen(thenNode, parentSchema, null);
+    }
+
+    /**
+     * Resolves a then node, using its actual JSON pointer path within the
+     * document when it's an inline schema (not a $ref). This ensures
+     * PropertyRule can correctly resolve property paths.
+     */
+    private ResolvedThen resolveThenWithIndex(JsonNode thenNode, Schema parentSchema, int allOfIndex) {
+        if (thenNode.has("$ref")) {
+            String ref = thenNode.get("$ref").asText();
+            String refName = extractNameFromRef(ref);
+            Schema refSchema = ruleFactory.getSchemaStore().create(
+                    parentSchema, ref,
+                    ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            return new ResolvedThen(refSchema.getContent(), refSchema, refName);
+        }
+
+        String parentFragment = parentSchema.getId() != null ? parentSchema.getId().getFragment() : null;
+        String thenPath;
+        if (parentFragment != null) {
+            thenPath = "#" + parentFragment + "/allOf/" + allOfIndex + "/then";
+        } else {
+            thenPath = "#/allOf/" + allOfIndex + "/then";
+        }
+
+        Schema thenSchema = ruleFactory.getSchemaStore().create(
+                parentSchema, thenPath,
+                ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+        return new ResolvedThen(thenSchema.getContent(), thenSchema, null);
+    }
+
+    private String extractNameFromRef(String ref) {
+        if (ref == null || ref.isEmpty()) return null;
+        String[] parts = ref.split("[/\\\\#]");
+        return parts.length > 0 ? parts[parts.length - 1] : null;
+    }
+
+    private static class ResolvedThen {
+        final JsonNode content;
+        final Schema schema;
+        final String refName;
+
+        ResolvedThen(JsonNode content, Schema schema, String refName) {
+            this.content = content;
+            this.schema = schema;
+            this.refName = refName;
+        }
+    }
+
+    private String deriveSubclassName(JsonNode thenNode, String constValue, String refName) {
+        if (refName != null && !refName.isEmpty()) {
+            return refName;
+        }
+        if (thenNode.has("title")) {
+            return thenNode.get("title").asText();
+        }
+        if (constValue != null && !constValue.isEmpty()) {
+            String name = constValue.substring(0, 1).toUpperCase() + constValue.substring(1);
+            name = name.replaceAll("[^A-Za-z0-9_]", "");
+            if (isReservedJavaName(name)) {
+                name = name + "Type";
+            }
+            return name;
+        }
+        return null;
+    }
+
+    private boolean isReservedJavaName(String name) {
+        switch (name) {
+            case "String":
+            case "Integer":
+            case "Long":
+            case "Double":
+            case "Float":
+            case "Boolean":
+            case "Byte":
+            case "Short":
+            case "Character":
+            case "Object":
+            case "Class":
+            case "Number":
+            case "Array":
+            case "Date":
+            case "List":
+            case "Map":
+            case "Set":
+            case "Void":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean parentHasField(JDefinedClass subclass, String fieldName) {
+        com.sun.codemodel.JClass parent = subclass._extends();
+        if (parent instanceof JDefinedClass) {
+            JDefinedClass parentClass = (JDefinedClass) parent;
+            return parentClass.fields().containsKey(fieldName);
+        }
+        return false;
+    }
+
+    private static class DiscriminatorInfo {
+        final String propertyName;
+        final String constValue;
+
+        DiscriminatorInfo(String propertyName, String constValue) {
+            this.propertyName = propertyName;
+            this.constValue = constValue;
+        }
+    }
+
+    private static class SubtypeEntry {
+        final String discriminatorValue;
+        final JDefinedClass subclass;
+
+        SubtypeEntry(String discriminatorValue, JDefinedClass subclass) {
+            this.discriminatorValue = discriminatorValue;
+            this.subclass = subclass;
+        }
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -120,6 +120,22 @@ public class ObjectRule implements Rule<JPackage, JType> {
 
         ruleFactory.getPropertiesRule().apply(nodeName, node.get("properties"), node, jclass, schema);
 
+        if (node.has("allOf")) {
+            JsonNode allOfNode = node.get("allOf");
+            boolean hasIfThen = false;
+            for (JsonNode entry : allOfNode) {
+                if (entry.has("if") && entry.has("then")) {
+                    hasIfThen = true;
+                    break;
+                }
+            }
+
+            if (hasIfThen) {
+                ruleFactory.getIfThenElseRule().applyAll(nodeName, allOfNode, node, jclass, schema);
+            }
+            ruleFactory.getAllOfRule().apply(nodeName, allOfNode, node, jclass, schema);
+        }
+
         if (node.has("javaInterfaces")) {
             addInterfaces(jclass, node.get("javaInterfaces"));
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/OneOfRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/OneOfRule.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jsonschema2pojo.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JClassContainer;
+import com.sun.codemodel.JType;
+
+/**
+ * Handles the JSON Schema "oneOf" keyword. Analyzes the sub-schemas to determine
+ * the best Java type mapping:
+ * <ul>
+ *   <li>If all sub-schemas are $ref to object types, generates an interface or
+ *       uses the first ref as the type with Jackson deduction</li>
+ *   <li>If sub-schemas are a mix of types, maps to Object</li>
+ *   <li>If all sub-schemas are primitive/simple types, maps to the nearest
+ *       common Java supertype</li>
+ * </ul>
+ */
+public class OneOfRule implements Rule<JClassContainer, JType> {
+
+    private final RuleFactory ruleFactory;
+
+    protected OneOfRule(RuleFactory ruleFactory) {
+        this.ruleFactory = ruleFactory;
+    }
+
+    @Override
+    public JType apply(String nodeName, JsonNode node, JsonNode parent, JClassContainer generatableType, Schema schema) {
+        JsonNode oneOfArray = node.get("oneOf");
+        if (oneOfArray == null && node.has("anyOf")) {
+            oneOfArray = node.get("anyOf");
+        }
+
+        if (oneOfArray == null || !oneOfArray.isArray() || oneOfArray.size() == 0) {
+            return generatableType.owner().ref(Object.class);
+        }
+
+        List<JsonNode> objectSchemas = new ArrayList<>();
+        List<JsonNode> otherSchemas = new ArrayList<>();
+        boolean hasArray = false;
+
+        for (JsonNode subSchema : oneOfArray) {
+            JsonNode resolved = resolveRef(subSchema, schema);
+            String type = resolved.has("type") ? resolved.get("type").asText() : "object";
+
+            if ("object".equals(type) || resolved.has("properties") || resolved.has("$ref")) {
+                objectSchemas.add(subSchema);
+            } else if ("array".equals(type)) {
+                hasArray = true;
+                otherSchemas.add(subSchema);
+            } else {
+                otherSchemas.add(subSchema);
+            }
+        }
+
+        if (objectSchemas.size() == oneOfArray.size() && objectSchemas.size() == 1) {
+            return ruleFactory.getSchemaRule().apply(nodeName, objectSchemas.get(0), parent, generatableType, schema);
+        }
+
+        if (objectSchemas.size() == oneOfArray.size() && objectSchemas.size() > 1) {
+            return ruleFactory.getSchemaRule().apply(nodeName, objectSchemas.get(0), parent, generatableType, schema);
+        }
+
+        if (node.has("type")) {
+            return ruleFactory.getTypeRule().apply(nodeName, node, parent, generatableType.getPackage(), schema);
+        }
+
+        return generatableType.owner().ref(Object.class);
+    }
+
+    private JsonNode resolveRef(JsonNode node, Schema schema) {
+        if (node.has("$ref")) {
+            Schema refSchema = ruleFactory.getSchemaStore().create(
+                    schema, node.get("$ref").asText(),
+                    ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
+            return refSchema.getContent();
+        }
+        return node;
+    }
+}

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -446,4 +446,34 @@ public class RuleFactory {
         return new JavaNameRule();
     }
 
+    /**
+     * Provides a rule instance that should be applied when an "allOf"
+     * declaration is found in the schema.
+     *
+     * @return a schema rule that can handle the "allOf" declaration.
+     */
+    public Rule<JDefinedClass, JDefinedClass> getAllOfRule() {
+        return new AllOfRule(this);
+    }
+
+    /**
+     * Provides a rule instance that should be applied when "if/then/else"
+     * conditional schemas are found.
+     *
+     * @return a schema rule that can handle if/then/else declarations.
+     */
+    public IfThenElseRule getIfThenElseRule() {
+        return new IfThenElseRule(this);
+    }
+
+    /**
+     * Provides a rule instance that should be applied when a "oneOf"
+     * declaration is found in the schema.
+     *
+     * @return a schema rule that can handle the "oneOf" declaration.
+     */
+    public Rule<JClassContainer, JType> getOneOfRule() {
+        return new OneOfRule(this);
+    }
+
 }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/SchemaRule.java
@@ -83,6 +83,9 @@ public class SchemaRule implements Rule<JClassContainer, JType> {
         JType javaType;
         if (schemaNode.has("enum")) {
             javaType = ruleFactory.getEnumRule().apply(nodeName, schemaNode, parent, generatableType, schema);
+        } else if (!schemaNode.has("type") && !schemaNode.has("properties")
+                && (schemaNode.has("oneOf") || schemaNode.has("anyOf"))) {
+            javaType = ruleFactory.getOneOfRule().apply(nodeName, schemaNode, parent, generatableType, schema);
         } else {
             javaType = ruleFactory.getTypeRule().apply(nodeName, schemaNode, parent, generatableType.getPackage(), schema);
         }

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/AllOfRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/AllOfRuleTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+
+public class AllOfRuleTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private GenerationConfig config;
+    private RuleFactory ruleFactory;
+    private AllOfRule rule;
+
+    @BeforeEach
+    public void setUp() {
+        config = mock(GenerationConfig.class);
+        when(config.getRefFragmentPathDelimiters()).thenReturn("#/.");
+        when(config.isIncludeGetters()).thenReturn(true);
+        when(config.isIncludeSetters()).thenReturn(true);
+        when(config.isGenerateBuilders()).thenReturn(false);
+        when(config.isIncludeConstructors()).thenReturn(false);
+        when(config.isIncludeAdditionalProperties()).thenReturn(false);
+        when(config.isIncludeGeneratedAnnotation()).thenReturn(false);
+
+        ruleFactory = new RuleFactory(config, new NoopAnnotator(), new SchemaStore());
+        rule = new AllOfRule(ruleFactory);
+    }
+
+    @Test
+    public void applyReturnsClassUnchangedWhenAllOfIsNull() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.TestBase");
+        Schema schema = mock(Schema.class);
+
+        JDefinedClass result = rule.apply("test", null, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+        assertThat(jclass.fields().isEmpty(), is(true));
+    }
+
+    @Test
+    public void applyReturnsClassUnchangedWhenAllOfIsEmpty() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.TestBase2");
+        Schema schema = mock(Schema.class);
+        ArrayNode emptyAllOf = MAPPER.createArrayNode();
+
+        JDefinedClass result = rule.apply("test", emptyAllOf, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+        assertThat(jclass.fields().isEmpty(), is(true));
+    }
+
+    @Test
+    public void applyMergesPropertiesFromInlineSubSchemaViaSchemaStore() throws Exception {
+        // Build a real schema URI so PropertyRule can resolve sub-paths correctly
+        java.net.URI schemaUri = getClass().getClassLoader()
+                .getResource("schema/polymorphism/allof-merge.json").toURI();
+
+        SchemaStore schemaStore = new SchemaStore();
+        Schema schema = schemaStore.create(schemaUri, "#/.");
+
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass jclass = codeModel._class("org.jsonschema2pojo.rules.TestMerge");
+
+        // Use the allOf node from the real schema on disk
+        JsonNode allOfNode = schema.getContent().get("allOf");
+        assertThat("allOf should exist in allof-merge.json", allOfNode, notNullValue());
+
+        RuleFactory realFactory = new RuleFactory(config, new NoopAnnotator(), schemaStore);
+        AllOfRule realRule = new AllOfRule(realFactory);
+
+        JDefinedClass result = realRule.apply("EnrichedPerson", allOfNode, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+        assertThat("'email' should be merged from allOf", jclass.fields(), hasKey("email"));
+        assertThat("'age' should be merged from allOf", jclass.fields(), hasKey("age"));
+    }
+
+    @Test
+    public void applySkipsIfThenEntries() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.TestSkipIfThen");
+        Schema schema = mock(Schema.class);
+
+        // allOf: [ { if: {...}, then: {...} } ]
+        ObjectNode ifThenEntry = MAPPER.createObjectNode();
+        ifThenEntry.set("if", MAPPER.createObjectNode());
+        ifThenEntry.set("then", MAPPER.createObjectNode());
+
+        ArrayNode allOfNode = MAPPER.createArrayNode();
+        allOfNode.add(ifThenEntry);
+
+        JDefinedClass result = rule.apply("test", allOfNode, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+        assertThat(jclass.fields().isEmpty(), is(true));
+    }
+
+    @Test
+    public void applyDoesNotDuplicateExistingFields() throws Exception {
+        java.net.URI schemaUri = getClass().getClassLoader()
+                .getResource("schema/polymorphism/allof-merge.json").toURI();
+
+        SchemaStore schemaStore = new SchemaStore();
+        Schema schema = schemaStore.create(schemaUri, "#/.");
+
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass jclass = codeModel._class("org.jsonschema2pojo.rules.TestNoDupe");
+
+        // Pre-add the "email" field so it already exists
+        jclass.field(com.sun.codemodel.JMod.PRIVATE, codeModel.ref(String.class), "email");
+
+        JsonNode allOfNode = schema.getContent().get("allOf");
+        RuleFactory realFactory = new RuleFactory(config, new NoopAnnotator(), schemaStore);
+        AllOfRule realRule = new AllOfRule(realFactory);
+
+        realRule.apply("EnrichedPerson", allOfNode, null, jclass, schema);
+
+        // Should still have exactly one "email" field
+        assertThat(jclass.fields().values().stream()
+                .filter(f -> f.name().equals("email")).count(), is(1L));
+    }
+
+    @Test
+    public void applyHandlesNonArrayNode() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.TestNonArray");
+        Schema schema = mock(Schema.class);
+        JsonNode notAnArray = MAPPER.createObjectNode();
+
+        JDefinedClass result = rule.apply("test", notAnArray, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+    }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/IfThenElseRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/IfThenElseRuleTest.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.net.URI;
+import java.util.Collection;
+
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+
+public class IfThenElseRuleTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private GenerationConfig config;
+    private RuleFactory ruleFactory;
+    private IfThenElseRule rule;
+
+    @BeforeEach
+    public void setUp() {
+        config = mock(GenerationConfig.class);
+        when(config.getRefFragmentPathDelimiters()).thenReturn("#/.");
+        when(config.isIncludeGetters()).thenReturn(true);
+        when(config.isIncludeSetters()).thenReturn(true);
+        when(config.isGenerateBuilders()).thenReturn(false);
+        when(config.isIncludeConstructors()).thenReturn(false);
+        when(config.isIncludeAdditionalProperties()).thenReturn(false);
+        when(config.isIncludeGeneratedAnnotation()).thenReturn(false);
+        when(config.getClassNamePrefix()).thenReturn("");
+        when(config.getClassNameSuffix()).thenReturn("");
+        when(config.getPropertyWordDelimiters()).thenReturn(new char[]{'-', '_'});
+
+        ruleFactory = new RuleFactory(config, new NoopAnnotator(), new SchemaStore());
+        rule = new IfThenElseRule(ruleFactory);
+    }
+
+    @Test
+    public void applyReturnsBaseClassWhenNoIfNode() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.NoIfBase");
+        Schema schema = mock(Schema.class);
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("then", MAPPER.createObjectNode());
+
+        JDefinedClass result = rule.apply("test", node, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+    }
+
+    @Test
+    public void applyReturnsBaseClassWhenNoThenNode() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.NoThenBase");
+        Schema schema = mock(Schema.class);
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("if", MAPPER.createObjectNode());
+
+        JDefinedClass result = rule.apply("test", node, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+    }
+
+    @Test
+    public void applyReturnsBaseClassWhenIfHasNoDiscriminator() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.NoDiscrimBase");
+        Schema schema = mock(Schema.class);
+
+        // if: { properties: { type: { description: "no const" } } }
+        ObjectNode propSchema = MAPPER.createObjectNode();
+        propSchema.put("description", "no const value");
+
+        ObjectNode ifProps = MAPPER.createObjectNode();
+        ifProps.set("type", propSchema);
+
+        ObjectNode ifNode = MAPPER.createObjectNode();
+        ifNode.set("properties", ifProps);
+
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("if", ifNode);
+        node.set("then", MAPPER.createObjectNode());
+
+        JDefinedClass result = rule.apply("test", node, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+    }
+
+    @Test
+    public void applyAllCreatesSubclassForEachIfThenEntry() throws Exception {
+        java.net.URI schemaUri = getClass().getClassLoader()
+                .getResource("schema/polymorphism/discriminated-union.json").toURI();
+        SchemaStore schemaStore = new SchemaStore();
+        Schema schema = schemaStore.create(schemaUri, "#/.");
+
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass baseClass = codeModel._class("org.jsonschema2pojo.rules.Event");
+        RuleFactory realFactory = new RuleFactory(config, new NoopAnnotator(), schemaStore);
+        IfThenElseRule realRule = new IfThenElseRule(realFactory);
+
+        JsonNode allOfNode = schema.getContent().get("allOf");
+        realRule.applyAll("Event", allOfNode, null, baseClass, schema);
+
+        JDefinedClass clickClass = codeModel._getClass("org.jsonschema2pojo.rules.ClickEvent");
+        JDefinedClass viewClass  = codeModel._getClass("org.jsonschema2pojo.rules.ViewEvent");
+        JDefinedClass scrollClass = codeModel._getClass("org.jsonschema2pojo.rules.ScrollEvent");
+
+        assertThat("ClickEvent should be generated", clickClass, notNullValue());
+        assertThat("ViewEvent should be generated",  viewClass,  notNullValue());
+        assertThat("ScrollEvent should be generated", scrollClass, notNullValue());
+
+        assertThat(clickClass._extends(), equalTo(baseClass));
+        assertThat(viewClass._extends(),  equalTo(baseClass));
+        assertThat(scrollClass._extends(), equalTo(baseClass));
+    }
+
+    @Test
+    public void applyAllAddsFieldsToSubclass() throws Exception {
+        java.net.URI schemaUri = getClass().getClassLoader()
+                .getResource("schema/polymorphism/discriminated-union.json").toURI();
+        SchemaStore schemaStore = new SchemaStore();
+        Schema schema = schemaStore.create(schemaUri, "#/.");
+
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass baseClass = codeModel._class("org.jsonschema2pojo.rules.EventFields");
+        RuleFactory realFactory = new RuleFactory(config, new NoopAnnotator(), schemaStore);
+        IfThenElseRule realRule = new IfThenElseRule(realFactory);
+
+        JsonNode allOfNode = schema.getContent().get("allOf");
+        realRule.applyAll("EventFields", allOfNode, null, baseClass, schema);
+
+        JDefinedClass clickClass = codeModel._getClass("org.jsonschema2pojo.rules.ClickEvent");
+        assertThat(clickClass, notNullValue());
+        assertThat("ClickEvent should have 'x'",      clickClass.fields(), hasKey("x"));
+        assertThat("ClickEvent should have 'y'",      clickClass.fields(), hasKey("y"));
+        assertThat("ClickEvent should have 'button'", clickClass.fields(), hasKey("button"));
+    }
+
+    @Test
+    public void applyAllAddsJsonTypeInfoAnnotationToBaseClass() throws Exception {
+        java.net.URI schemaUri = getClass().getClassLoader()
+                .getResource("schema/polymorphism/discriminated-union.json").toURI();
+        SchemaStore schemaStore = new SchemaStore();
+        Schema schema = schemaStore.create(schemaUri, "#/.");
+
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass baseClass = codeModel._class("org.jsonschema2pojo.rules.EventAnnotations");
+        RuleFactory realFactory = new RuleFactory(config, new NoopAnnotator(), schemaStore);
+        IfThenElseRule realRule = new IfThenElseRule(realFactory);
+
+        JsonNode allOfNode = schema.getContent().get("allOf");
+        realRule.applyAll("EventAnnotations", allOfNode, null, baseClass, schema);
+
+        Collection<JAnnotationUse> annotations = baseClass.annotations();
+        boolean hasTypeInfo = annotations.stream()
+                .anyMatch(a -> a.getAnnotationClass().name().equals("JsonTypeInfo"));
+        boolean hasSubTypes = annotations.stream()
+                .anyMatch(a -> a.getAnnotationClass().name().equals("JsonSubTypes"));
+
+        assertThat("@JsonTypeInfo should be present on base class", hasTypeInfo, is(true));
+        assertThat("@JsonSubTypes should be present on base class", hasSubTypes, is(true));
+    }
+
+    @Test
+    public void applyAllSkipsEntriesWithoutIfThen() throws JClassAlreadyExistsException {
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass baseClass = codeModel._class("org.jsonschema2pojo.rules.Product");
+        Schema schema = buildSchemaWithContent(MAPPER.createObjectNode());
+
+        ArrayNode allOfNode = MAPPER.createArrayNode();
+        // Entry without if/then — just properties
+        ObjectNode plainEntry = MAPPER.createObjectNode();
+        ObjectNode props = MAPPER.createObjectNode();
+        props.set("sku", MAPPER.createObjectNode().put("type", "string"));
+        plainEntry.set("properties", props);
+        allOfNode.add(plainEntry);
+
+        rule.applyAll("Product", allOfNode, null, baseClass, schema);
+
+        assertThat("No @JsonTypeInfo should be added when no if/then entries exist",
+                baseClass.annotations().isEmpty(), is(true));
+    }
+
+    @Test
+    public void applyAllHandlesNullAllOfNode() throws JClassAlreadyExistsException {
+        JDefinedClass jclass = new JCodeModel()._class("org.jsonschema2pojo.rules.NullAllOfBase");
+        Schema schema = mock(Schema.class);
+
+        JDefinedClass result = rule.applyAll("test", null, null, jclass, schema);
+
+        assertThat(result, sameInstance(jclass));
+    }
+
+    // --- helpers ---
+
+    private ObjectNode buildIfThenEntry(String discriminatorProp, String constValue,
+                                        String subclassTitle,
+                                        String prop1, String prop2) {
+        ObjectNode constNode = MAPPER.createObjectNode();
+        constNode.put("const", constValue);
+
+        ObjectNode ifPropNode = MAPPER.createObjectNode();
+        ifPropNode.set(discriminatorProp, constNode);
+
+        ObjectNode ifNode = MAPPER.createObjectNode();
+        ifNode.set("properties", ifPropNode);
+
+        ObjectNode thenProps = MAPPER.createObjectNode();
+        if (prop1 != null) {
+            thenProps.set(prop1, MAPPER.createObjectNode().put("type", "string"));
+        }
+        if (prop2 != null) {
+            thenProps.set(prop2, MAPPER.createObjectNode().put("type", "string"));
+        }
+
+        ObjectNode thenNode = MAPPER.createObjectNode();
+        thenNode.put("title", subclassTitle);
+        thenNode.set("properties", thenProps);
+
+        ObjectNode entry = MAPPER.createObjectNode();
+        entry.set("if", ifNode);
+        entry.set("then", thenNode);
+        return entry;
+    }
+
+    private Schema buildSchemaWithContent(ObjectNode content) {
+        Schema schema = mock(Schema.class);
+        when(schema.getId()).thenReturn(URI.create("urn:test:schema"));
+        when(schema.getContent()).thenReturn(content);
+        when(schema.getGrandParent()).thenReturn(schema);
+        when(schema.getParent()).thenReturn(schema);
+        return schema;
+    }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/OneOfRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/OneOfRuleTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
+
+public class OneOfRuleTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private GenerationConfig config;
+    private RuleFactory ruleFactory;
+    private OneOfRule rule;
+
+    @BeforeEach
+    public void setUp() {
+        config = mock(GenerationConfig.class);
+        when(config.getRefFragmentPathDelimiters()).thenReturn("#/.");
+        when(config.isIncludeGetters()).thenReturn(true);
+        when(config.isIncludeSetters()).thenReturn(true);
+        when(config.isGenerateBuilders()).thenReturn(false);
+        when(config.isIncludeConstructors()).thenReturn(false);
+        when(config.isIncludeAdditionalProperties()).thenReturn(false);
+        when(config.isIncludeGeneratedAnnotation()).thenReturn(false);
+        when(config.getClassNamePrefix()).thenReturn("");
+        when(config.getClassNameSuffix()).thenReturn("");
+
+        ruleFactory = new RuleFactory(config, new NoopAnnotator(), new SchemaStore());
+        rule = new OneOfRule(ruleFactory);
+    }
+
+    @Test
+    public void applyReturnsObjectWhenNoOneOfNode() throws JClassAlreadyExistsException {
+        JCodeModel codeModel = new JCodeModel();
+        JPackage pkg = codeModel._package("org.jsonschema2pojo.rules");
+        Schema schema = mock(Schema.class);
+        ObjectNode node = MAPPER.createObjectNode();
+
+        JType result = rule.apply("test", node, null, pkg, schema);
+
+        assertThat(result.fullName(), is(Object.class.getName()));
+    }
+
+    @Test
+    public void applyReturnsObjectWhenOneOfIsEmpty() throws JClassAlreadyExistsException {
+        JCodeModel codeModel = new JCodeModel();
+        JPackage pkg = codeModel._package("org.jsonschema2pojo.rules");
+        Schema schema = mock(Schema.class);
+
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("oneOf", MAPPER.createArrayNode());
+
+        JType result = rule.apply("test", node, null, pkg, schema);
+
+        assertThat(result.fullName(), is(Object.class.getName()));
+    }
+
+    @Test
+    public void applyReturnsObjectWhenMixedOneOfTypes() throws JClassAlreadyExistsException {
+        JCodeModel codeModel = new JCodeModel();
+        JPackage pkg = codeModel._package("org.jsonschema2pojo.rules");
+        Schema schema = mock(Schema.class);
+
+        // oneOf: [ {type: "object"}, {type: "array"} ]
+        ArrayNode oneOf = MAPPER.createArrayNode();
+        oneOf.add(MAPPER.createObjectNode().put("type", "object"));
+        oneOf.add(MAPPER.createObjectNode().put("type", "array"));
+
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("oneOf", oneOf);
+
+        JType result = rule.apply("test", node, null, pkg, schema);
+
+        assertThat(result.fullName(), is(Object.class.getName()));
+    }
+
+    @Test
+    public void applyWorksWithAnyOfKeyword() throws JClassAlreadyExistsException {
+        JCodeModel codeModel = new JCodeModel();
+        JPackage pkg = codeModel._package("org.jsonschema2pojo.rules");
+        Schema schema = mock(Schema.class);
+
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("anyOf", MAPPER.createArrayNode());
+
+        JType result = rule.apply("test", node, null, pkg, schema);
+
+        assertThat(result.fullName(), is(Object.class.getName()));
+    }
+
+    @Test
+    public void applyPreferrsOneOfOverAnyOf() throws JClassAlreadyExistsException {
+        JCodeModel codeModel = new JCodeModel();
+        JPackage pkg = codeModel._package("org.jsonschema2pojo.rules");
+        Schema schema = mock(Schema.class);
+
+        // Both present — oneOf takes precedence
+        ObjectNode node = MAPPER.createObjectNode();
+        ArrayNode oneOf = MAPPER.createArrayNode();
+        oneOf.add(MAPPER.createObjectNode().put("type", "object"));
+        node.set("oneOf", oneOf);
+        node.set("anyOf", MAPPER.createArrayNode()); // empty anyOf
+
+        JType result = rule.apply("test", node, null, pkg, schema);
+
+        // Should process without throwing
+        assertThat(result, notNullValue());
+    }
+}

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PolymorphismRuleEndToEndTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/PolymorphismRuleEndToEndTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.rules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.net.URI;
+import java.util.Collection;
+
+import org.jsonschema2pojo.DefaultGenerationConfig;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.NoopAnnotator;
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.SchemaStore;
+import org.junit.jupiter.api.Test;
+
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JPackage;
+
+/**
+ * End-to-end tests for JSON Schema polymorphism support.
+ * These tests drive the full generator pipeline against real JSON Schema files
+ * and verify the generated class hierarchy.
+ */
+public class PolymorphismRuleEndToEndTest {
+
+    private static final String TARGET_PACKAGE = "org.jsonschema2pojo.rules.generated";
+
+    // -------------------------------------------------------------------------
+    // discriminated-union.json  (allOf with if/then)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void discriminatedUnionGeneratesBaseClassWithJsonTypeInfo() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass eventClass = findClass(codeModel, "Event");
+        assertThat("Event base class should be generated", eventClass, notNullValue());
+
+        boolean hasTypeInfo = eventClass.annotations().stream()
+                .anyMatch(a -> a.getAnnotationClass().name().equals("JsonTypeInfo"));
+        assertThat("Event base class should have @JsonTypeInfo", hasTypeInfo, is(true));
+    }
+
+    @Test
+    public void discriminatedUnionGeneratesBaseClassWithJsonSubTypes() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass eventClass = findClass(codeModel, "Event");
+        assertThat(eventClass, notNullValue());
+
+        boolean hasSubTypes = eventClass.annotations().stream()
+                .anyMatch(a -> a.getAnnotationClass().name().equals("JsonSubTypes"));
+        assertThat("Event base class should have @JsonSubTypes", hasSubTypes, is(true));
+    }
+
+    @Test
+    public void discriminatedUnionGeneratesClickEventSubclass() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass clickClass = findClass(codeModel, "ClickEvent");
+        assertThat("ClickEvent subclass should be generated", clickClass, notNullValue());
+
+        JDefinedClass eventClass = findClass(codeModel, "Event");
+        assertThat("ClickEvent should extend Event", clickClass._extends(), equalTo(eventClass));
+    }
+
+    @Test
+    public void discriminatedUnionClickEventHasOwnFields() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass clickClass = findClass(codeModel, "ClickEvent");
+        assertThat(clickClass, notNullValue());
+        assertThat("ClickEvent should have 'x' field", clickClass.fields(), hasKey("x"));
+        assertThat("ClickEvent should have 'y' field", clickClass.fields(), hasKey("y"));
+        assertThat("ClickEvent should have 'button' field", clickClass.fields(), hasKey("button"));
+    }
+
+    @Test
+    public void discriminatedUnionGeneratesViewEventSubclass() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass viewClass = findClass(codeModel, "ViewEvent");
+        assertThat("ViewEvent subclass should be generated", viewClass, notNullValue());
+        assertThat("ViewEvent should have 'url' field", viewClass.fields(), hasKey("url"));
+        assertThat("ViewEvent should have 'duration' field", viewClass.fields(), hasKey("duration"));
+    }
+
+    @Test
+    public void discriminatedUnionGeneratesScrollEventSubclass() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass scrollClass = findClass(codeModel, "ScrollEvent");
+        assertThat("ScrollEvent subclass should be generated", scrollClass, notNullValue());
+        assertThat("ScrollEvent should have 'deltaY' field", scrollClass.fields(), hasKey("deltaY"));
+    }
+
+    @Test
+    public void discriminatedUnionBaseClassPreservesOwnProperties() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/discriminated-union.json");
+
+        JDefinedClass eventClass = findClass(codeModel, "Event");
+        assertThat(eventClass, notNullValue());
+        assertThat("Event base class should have 'id' field", eventClass.fields(), hasKey("id"));
+        assertThat("Event base class should have 'kind' field", eventClass.fields(), hasKey("kind"));
+    }
+
+    // -------------------------------------------------------------------------
+    // allof-merge.json  (allOf property merging)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void allOfMergeGeneratesClassWithOwnProperties() throws Exception {
+        JCodeModel codeModel = generateFrom("schema/polymorphism/allof-merge.json");
+
+        JDefinedClass personClass = findClass(codeModel, "EnrichedPerson");
+        assertThat("EnrichedPerson class should be generated", personClass, notNullValue());
+
+        assertThat("Should have 'firstName' from own properties", personClass.fields(), hasKey("firstName"));
+        assertThat("Should have 'lastName' from own properties",  personClass.fields(), hasKey("lastName"));
+    }
+
+    @Test
+    public void allOfMergeMergesPropertiesFromSubSchema() throws Exception {
+        // Drive the AllOfRule directly with a real schema URI so paths resolve correctly
+        java.net.URI schemaUri = getClass().getClassLoader()
+                .getResource("schema/polymorphism/allof-merge.json").toURI();
+
+        SchemaStore schemaStore = new SchemaStore();
+        Schema schema = schemaStore.create(schemaUri, "#/.");
+
+        GenerationConfig config = new DefaultGenerationConfig() {
+            @Override public boolean isIncludeGetters() { return true; }
+            @Override public boolean isIncludeSetters() { return true; }
+            @Override public boolean isIncludeConstructors() { return false; }
+            @Override public boolean isIncludeAdditionalProperties() { return false; }
+            @Override public boolean isIncludeGeneratedAnnotation() { return false; }
+        };
+
+        JCodeModel codeModel = new JCodeModel();
+        JDefinedClass jclass = codeModel._class(TARGET_PACKAGE + ".EnrichedPersonMerged");
+        RuleFactory factory = new RuleFactory(config, new NoopAnnotator(), schemaStore);
+        AllOfRule allOfRule = new AllOfRule(factory);
+
+        allOfRule.apply("EnrichedPerson", schema.getContent().get("allOf"), null, jclass, schema);
+
+        assertThat("'email' should be merged from allOf", jclass.fields(), hasKey("email"));
+        assertThat("'age' should be merged from allOf",   jclass.fields(), hasKey("age"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private JCodeModel generateFrom(String schemaClasspath) throws Exception {
+        URI schemaUri = getClass().getClassLoader().getResource(schemaClasspath).toURI();
+
+        JCodeModel codeModel = new JCodeModel();
+        GenerationConfig config = new DefaultGenerationConfig() {
+            @Override public boolean isIncludeGeneratedAnnotation() { return true; }
+            @Override public boolean isIncludeGetters() { return true; }
+            @Override public boolean isIncludeSetters() { return true; }
+            @Override public boolean isIncludeConstructors() { return false; }
+            @Override public boolean isIncludeAdditionalProperties() { return false; }
+            @Override public boolean isGenerateBuilders() { return false; }
+            @Override public boolean isUseTitleAsClassname() { return true; }
+        };
+
+        RuleFactory ruleFactory = new RuleFactory(config, new NoopAnnotator(), new SchemaStore());
+        SchemaMapper schemaMapper = new SchemaMapper(ruleFactory, null);
+        schemaMapper.generate(codeModel, "Event", TARGET_PACKAGE, schemaUri.toURL());
+
+        return codeModel;
+    }
+
+    private JDefinedClass findClass(JCodeModel codeModel, String simpleName) {
+        for (java.util.Iterator<JPackage> pkgs = codeModel.packages(); pkgs.hasNext(); ) {
+            JPackage pkg = pkgs.next();
+            for (java.util.Iterator<JDefinedClass> classes = pkg.classes(); classes.hasNext(); ) {
+                JDefinedClass cls = classes.next();
+                if (cls.name().equals(simpleName)) {
+                    return cls;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/polymorphism/allof-merge.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/polymorphism/allof-merge.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "EnrichedPerson",
+  "type": "object",
+  "properties": {
+    "firstName": { "type": "string" },
+    "lastName":  { "type": "string" }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "Email address merged from allOf."
+        },
+        "age": {
+          "type": "integer",
+          "description": "Age merged from allOf."
+        }
+      }
+    }
+  ]
+}

--- a/jsonschema2pojo-core/src/test/resources/schema/polymorphism/discriminated-union.json
+++ b/jsonschema2pojo-core/src/test/resources/schema/polymorphism/discriminated-union.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Event",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "type": "string", "enum": ["click", "view", "scroll"] }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": { "const": "click" }
+        }
+      },
+      "then": {
+        "title": "ClickEvent",
+        "properties": {
+          "x": { "type": "integer", "description": "X coordinate of the click." },
+          "y": { "type": "integer", "description": "Y coordinate of the click." },
+          "button": { "type": "string", "description": "Mouse button pressed." }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": { "const": "view" }
+        }
+      },
+      "then": {
+        "title": "ViewEvent",
+        "properties": {
+          "url": { "type": "string", "description": "URL that was viewed." },
+          "duration": { "type": "integer", "description": "Duration in milliseconds." }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": { "const": "scroll" }
+        }
+      },
+      "then": {
+        "title": "ScrollEvent",
+        "properties": {
+          "deltaY": { "type": "number", "description": "Vertical scroll delta." }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Introduces three new rules to handle JSON Schema composition keywords that were previously ignored during Java code generation:

- AllOfRule: merges properties from allOf sub-schemas, resolving $ref entries to their proper Schema context
- IfThenElseRule: detects discriminated unions from if/then conditional blocks, generating subclasses with @JsonTypeInfo/@JsonSubTypes annotations for Jackson polymorphic deserialization
- OneOfRule: handles oneOf/anyOf for property type resolution

Modified ObjectRule to process allOf after normal properties, SchemaRule to dispatch oneOf/anyOf schemas, and RuleFactory to expose the new rules.

Tested against the ODCS v3.1.0 JSON Schema which uses extensive if/then/else patterns for Server types, DataQuality types, and SchemaBaseProperty logical type variants. All existing unit and integration tests continue to pass.

Made-with: Cursor