### PR TITLE
Handle $ref sibling descriptions

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -16,11 +16,16 @@
 
 package org.jsonschema2pojo.rules;
 
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.JsonPointerUtils;
 import org.jsonschema2pojo.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JDocCommentable;
@@ -30,7 +35,6 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Applies the schema rules that represent a property definition.
@@ -209,11 +213,29 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
     private JsonNode resolveRefs(JsonNode node, Schema parent) {
         if (node.has("$ref")) {
             Schema refSchema = ruleFactory.getSchemaStore().create(parent, node.get("$ref").asText(), ruleFactory.getGenerationConfig().getRefFragmentPathDelimiters());
-            JsonNode refNode = refSchema.getContent();
-            return resolveRefs(refNode, refSchema);
+            JsonNode refNode = resolveRefs(refSchema.getContent(), refSchema);
+            return mergeRefSiblings(refNode, node);
         } else {
             return node;
         }
+    }
+
+    private JsonNode mergeRefSiblings(JsonNode refNode, JsonNode node) {
+        if (!node.isObject() || !refNode.isObject()) {
+            return refNode;
+        }
+
+        ObjectNode mergedNode = ((ObjectNode) refNode).deepCopy();
+        Iterator<Entry<String, JsonNode>> fields = node.properties().iterator();
+
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> field = fields.next();
+            if (!"$ref".equals(field.getKey())) {
+                mergedNode.set(field.getKey(), field.getValue());
+            }
+        }
+
+        return mergedNode;
     }
 
     private JType getReturnType(final JDefinedClass c, final JFieldVar field, final boolean required, final boolean usesOptional) {

--- a/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RefSiblingIT.java
+++ b/jsonschema2pojo-integration-tests/src/test/java/org/jsonschema2pojo/integration/ref/RefSiblingIT.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2010-2020 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jsonschema2pojo.integration.ref;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.jsonschema2pojo.integration.util.CodeGenerationHelper.config;
+
+import java.lang.reflect.Field;
+
+import org.jsonschema2pojo.integration.util.Jsonschema2PojoRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public class RefSiblingIT {
+
+    @RegisterExtension public Jsonschema2PojoRule schemaRule = new Jsonschema2PojoRule();
+
+    @Test
+    public void refSiblingDescriptionIsUsedForPropertyDescription() throws ReflectiveOperationException {
+
+        ClassLoader resultsClassLoader = schemaRule.generateAndCompile("/schema/ref/refWithSiblingDescription.json",
+                "com.example", config("annotationStyle", "jackson2"));
+        Class<?> generatedType = resultsClassLoader.loadClass("com.example.RefWithSiblingDescription");
+
+        Field field = generatedType.getDeclaredField("address");
+
+        assertThat(field.getType().getName(), is("com.example.Address"));
+        assertThat(field.getAnnotation(JsonPropertyDescription.class).value(), is("The preferred contact address."));
+    }
+}

--- a/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/refWithSiblingDescription.json
+++ b/jsonschema2pojo-integration-tests/src/test/resources/schema/ref/refWithSiblingDescription.json
@@ -1,0 +1,10 @@
+{
+    "$schema" : "https://json-schema.org/draft/2020-12/schema",
+    "type" : "object",
+    "properties" : {
+        "address" : {
+            "description" : "The preferred contact address.",
+            "$ref" : "address.json"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix property-level annotation handling for schemas that define sibling keywords alongside `$ref`.

In Draft 2020-12, `$ref` is an applicator and sibling keywords in the same schema object are evaluated independently. Previously, jsonschema2pojo resolved `$ref` by replacing the property schema with the referenced schema, so a sibling `description` on the property was ignored and the referenced schema description was used instead.

This change preserves the referenced schema for type generation while merging sibling keywords back into the resolved property schema for property annotations. Local sibling keywords override the referenced schema keyword of the same name.

## Changes

- Merge `$ref` sibling keywords into the resolved property schema in `PropertyRule`
- Keep `$ref` itself excluded from the merged annotation schema
- Add an integration test using the existing `schema/ref/address.json` fixture
- Verify that a property-level sibling `description` becomes the generated `@JsonPropertyDescription`

## Verification

- `./mvnw clean verify`
- `git diff --check`
